### PR TITLE
Add time_frame check to ohlcv market data source

### DIFF
--- a/investing_algorithm_framework/infrastructure/models/market_data_sources/ccxt.py
+++ b/investing_algorithm_framework/infrastructure/models/market_data_sources/ccxt.py
@@ -472,6 +472,15 @@ class CCXTOHLCVMarketDataSource(OHLCVMarketDataSource):
                 if end_date is None:
                     end_date = datetime.now(tz=timezone.utc)
 
+                if self.window_size is None:
+                    raise OperationalException(
+                        "Window_size should be defined before the " +
+                        "get_data method can be called. Make sure to set " +
+                        "the window_size attribute on your " +
+                        "CCXTOHLCVMarketDataSource or provide a start_date " +
+                        "and end_date to the get_data method."
+                    )
+
                 start_date = self.create_start_date(
                     end_date=end_date,
                     time_frame=self.time_frame,

--- a/investing_algorithm_framework/infrastructure/services/market_service/ccxt_market_service.py
+++ b/investing_algorithm_framework/infrastructure/services/market_service/ccxt_market_service.py
@@ -432,8 +432,7 @@ class CCXTMarketService(MarketService):
         col_names = ["Datetime", "Open", "High", "Low", "Close", "Volume"]
 
         # Combine the Series into a DataFrame with given column names
-        df = pl.DataFrame(data, schema=col_names)
-
+        df = pl.DataFrame(data, schema=col_names, orient="row")
         return df
 
     def get_ohlcvs(

--- a/tests/infrastructure/market_data_sources/test_ccxt_ohlcv_market_data_source.py
+++ b/tests/infrastructure/market_data_sources/test_ccxt_ohlcv_market_data_source.py
@@ -4,6 +4,7 @@ from unittest import TestCase, mock
 
 from investing_algorithm_framework.infrastructure import \
     CCXTOHLCVMarketDataSource
+from investing_algorithm_framework.domain import OperationalException
 
 
 class Test(TestCase):
@@ -78,6 +79,21 @@ class Test(TestCase):
         data = data_source.get_data()
         self.assertIsNotNone(data)
         self.assertEqual(data_source.window_size, 200)
+
+    def test_get_data_with_no_params_and_window_size(self):
+        """
+        This should raise an exception because the window size needs to be
+        defined if no start date or end date is provided.
+        """
+        data_source = CCXTOHLCVMarketDataSource(
+            identifier="BTC/EUR",
+            time_frame="15m",
+            market="BITVAVO",
+            symbol="BTC/EUR",
+        )
+
+        with self.assertRaises(OperationalException) as context:
+            data_source.get_data()
 
     @mock.patch('investing_algorithm_framework.infrastructure.services.market_service.ccxt_market_service.CCXTMarketService.get_ohlcv')
     def test_get_data_with_only_start_date(self, mock):


### PR DESCRIPTION
# Fix: Include window size check when calling get_data method

## Description

When no start and end date have been provided a check is done if the window size  attribute has been set on the 
data source

 

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/optimization

## Checklist
- [x] Code is formatted with `black` or a similar linter.
- [x] Tests have been added or updated.
- [x] Documentation has been updated (if needed).

## Additional Notes
Include any additional notes or context here.
