### PR TITLE
fix: Use existing OHLCV data files and make Windows path compatible in tests/domain (#371)

### DIFF
--- a/tests/domain/backtests/test_backtest_save.py
+++ b/tests/domain/backtests/test_backtest_save.py
@@ -86,7 +86,8 @@ class TestBacktestSave(TestCase):
         self.assertTrue(
             os.path.exists(os.path.join(backtest_run_dir, "run.json"))
         )
-        self.assertTrue(
+        # metrics.json is only created when backtest_metrics is provided
+        self.assertFalse(
             os.path.exists(os.path.join(backtest_run_dir, "metrics.json"))
         )
 
@@ -152,4 +153,3 @@ class TestBacktestSave(TestCase):
         self.assertTrue(
             os.path.exists(os.path.join(backtest_run_dir, "metrics.json"))
         )
-

--- a/tests/domain/models/backtesting/test_backtest.py
+++ b/tests/domain/models/backtesting/test_backtest.py
@@ -44,7 +44,9 @@ class TestBacktestSaveOpen(unittest.TestCase):
         )
         self.ohlcv_csv_path = os.path.join(
             self.resource_dir,
-            "backtest_data/OHLCV_BTC-EUR_BINANCE_2h_2020-12-15-06-00_2021-01-01-00-30.csv"
+            "test_data",
+            "ohlcv",
+            "OHLCV_BTC-EUR_BINANCE_2h_2023-08-07-07-08_2023-12-02-00-00.csv"
         )
 
         # Test models
@@ -1473,4 +1475,3 @@ class TestBacktestSaveOpen(unittest.TestCase):
         self.assertEqual(len(backtest_set2), 2)
         self.assertIn(backtest4, backtest_set2)
         self.assertIn(backtest5, backtest_set2)
-

--- a/tests/domain/utils/test_polars.py
+++ b/tests/domain/utils/test_polars.py
@@ -4,7 +4,7 @@ from pandas import Timestamp
 from investing_algorithm_framework import convert_polars_to_pandas
 
 class TestConvertPandasToPolars(TestCase):
-    
+
     def test_convert_pandas_to_polars(self):
         polars_df = DataFrame({
             "Datetime": ["2021-01-01", "2021-01-02", "2021-01-03"],
@@ -33,7 +33,7 @@ class TestConvertPandasToPolars(TestCase):
         self.assertEqual(set(column_names), {'Close'})
 
         # Check if the index is a datetime object
-        self.assertEqual(polars_df_converted.index.dtype, "datetime64[ns]")
+        self.assertEqual(polars_df_converted.index.dtype, "datetime64[us]")
         self.assertEqual(
             polars_df_converted.index[0], Timestamp('2021-01-01 00:00:00')
         )


### PR DESCRIPTION
## Summary

Fixes #371 for `tests/domain/` and `tests/cli/` directories.

### Changes

**tests/domain/models/backtesting/test_backtest.py**
- Replaced hardcoded forward-slash path to a non-existent CSV with `os.path.join()` pointing to existing `test_data/ohlcv/` file
- Fixes 5 test failures (FileNotFoundError)

**tests/domain/utils/test_polars.py**
- Updated `datetime64[ns]` assertion to `datetime64[us]` for newer pandas compatibility (pandas now uses microsecond resolution by default)
- Fixes 1 test failure

**tests/domain/backtests/test_backtest_save.py**
- Fixed `test_save_without_metrics` to assert `metrics.json` is NOT created when no pre-computed metrics are provided — this matches the actual `BacktestRun.save()` behavior which only writes `metrics.json` when `self.backtest_metrics` is set
- Fixes 1 test failure

**tests/cli/** — All 7 tests already passing (no changes needed)

### Test Results

- `tests/domain/`: **103 passed** (was 96 passed, 7 failed)
- `tests/cli/`: **7 passed** (no changes)
- flake8: clean
