### PR TITLE
feat: Warn or prevent scheduling interval faster than data timeframe (#396)

### DIFF
--- a/investing_algorithm_framework/app/strategy.py
+++ b/investing_algorithm_framework/app/strategy.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from investing_algorithm_framework.domain import OperationalException, \
     Position, PositionSize, TimeUnit, StrategyProfile, Trade, \
-    DataSource, OrderSide, StopLossRule, TakeProfitRule, Order, \
+    DataSource, DataType, OrderSide, StopLossRule, TakeProfitRule, Order, \
     INDEX_DATETIME
 from .context import Context
 
@@ -155,6 +155,32 @@ class TradingStrategy:
             raise OperationalException(
                 f"Interval not set for strategy instance {self.strategy_id}"
             )
+
+        # Check if scheduling interval is faster than the smallest
+        # OHLCV data source timeframe
+        ohlcv_timeframes = [
+            ds.time_frame.amount_of_minutes
+            for ds in self.data_sources
+            if ds.time_frame is not None
+            and DataType.OHLCV.equals(ds.data_type)
+        ]
+
+        if ohlcv_timeframes:
+            scheduling_interval = \
+                self.time_unit.amount_of_minutes * self.interval
+            smallest_timeframe = min(ohlcv_timeframes)
+
+            if scheduling_interval < smallest_timeframe:
+                raise OperationalException(
+                    f"Strategy '{self.strategy_id}' scheduling interval "
+                    f"({self.interval} {self.time_unit.value.lower()}"
+                    f"{'s' if self.interval > 1 else ''}"
+                    f" = {scheduling_interval} min) is faster than "
+                    f"the smallest OHLCV data source timeframe "
+                    f"({smallest_timeframe} min). The strategy would "
+                    f"run without new data. Increase the scheduling "
+                    f"interval or use a smaller data timeframe."
+                )
 
         # Initialize stop_losses as a new list per instance
         if stop_losses is not None:

--- a/tests/app/test_data_completeness.py
+++ b/tests/app/test_data_completeness.py
@@ -10,7 +10,7 @@ from investing_algorithm_framework.domain.exceptions import DataError
 from tests.resources import TestBase
 
 class TestStrategy(TradingStrategy):
-    time_unit = "MINUTE"
+    time_unit = "DAY"
     interval = 1
     data_sources = [
         DataSource(
@@ -35,7 +35,7 @@ class TestStrategy(TradingStrategy):
 
 
 class TestStrategyIncompleteData(TradingStrategy):
-    time_unit = "MINUTE"
+    time_unit = "DAY"
     interval = 1
     data_sources = [
         DataSource(

--- a/tests/app/test_strategy_interval_validation.py
+++ b/tests/app/test_strategy_interval_validation.py
@@ -1,0 +1,170 @@
+"""
+Tests for the scheduling interval vs OHLCV data timeframe validation
+added in TradingStrategy.__init__ (issue #396).
+
+The validation raises OperationalException when the strategy's scheduling
+interval (time_unit.amount_of_minutes * interval) is strictly less than
+the smallest OHLCV data source timeframe.
+"""
+from unittest import TestCase
+
+from investing_algorithm_framework.app.strategy import TradingStrategy
+from investing_algorithm_framework.domain import (
+    OperationalException, TimeUnit, DataType, TimeFrame,
+)
+from investing_algorithm_framework.domain.models.data.data_source import (
+    DataSource,
+)
+
+
+class _ConcreteStrategy(TradingStrategy):
+    """Minimal concrete subclass for testing __init__ validation."""
+
+    def run_strategy(self, context, data):
+        pass
+
+
+class TestStrategyIntervalValidation(TestCase):
+
+    # ------------------------------------------------------------------
+    # 1. Should raise when interval is faster than the OHLCV timeframe
+    # ------------------------------------------------------------------
+    def test_raises_when_interval_faster_than_ohlcv_timeframe(self):
+        """1 minute interval < 60 minute (1h) OHLCV → must raise."""
+        with self.assertRaises(OperationalException):
+            _ConcreteStrategy(
+                time_unit=TimeUnit.MINUTE,
+                interval=1,
+                data_sources=[
+                    DataSource(
+                        symbol="BTC/EUR",
+                        data_type=DataType.OHLCV,
+                        time_frame=TimeFrame.ONE_HOUR,
+                        market="BITVAVO",
+                        warmup_window=100,
+                    )
+                ],
+            )
+
+    # ------------------------------------------------------------------
+    # 2. No error when interval exactly matches the OHLCV timeframe
+    # ------------------------------------------------------------------
+    def test_no_error_when_interval_matches_ohlcv_timeframe(self):
+        """1 hour interval == 60 min == 1h OHLCV → should NOT raise."""
+        strategy = _ConcreteStrategy(
+            time_unit=TimeUnit.HOUR,
+            interval=1,
+            data_sources=[
+                DataSource(
+                    symbol="BTC/EUR",
+                    data_type=DataType.OHLCV,
+                    time_frame=TimeFrame.ONE_HOUR,
+                    market="BITVAVO",
+                    warmup_window=100,
+                )
+            ],
+        )
+        self.assertIsNotNone(strategy)
+
+    # ------------------------------------------------------------------
+    # 3. No error when interval is slower than the OHLCV timeframe
+    # ------------------------------------------------------------------
+    def test_no_error_when_interval_slower_than_ohlcv_timeframe(self):
+        """1 day interval (1440 min) > 60 min (1h) OHLCV → should NOT raise."""
+        strategy = _ConcreteStrategy(
+            time_unit=TimeUnit.DAY,
+            interval=1,
+            data_sources=[
+                DataSource(
+                    symbol="BTC/EUR",
+                    data_type=DataType.OHLCV,
+                    time_frame=TimeFrame.ONE_HOUR,
+                    market="BITVAVO",
+                    warmup_window=100,
+                )
+            ],
+        )
+        self.assertIsNotNone(strategy)
+
+    # ------------------------------------------------------------------
+    # 4. Validation uses the *smallest* OHLCV timeframe among sources
+    # ------------------------------------------------------------------
+    def test_uses_smallest_ohlcv_timeframe_for_validation(self):
+        """5 min interval < 15 min (smallest OHLCV) → must raise."""
+        with self.assertRaises(OperationalException):
+            _ConcreteStrategy(
+                time_unit=TimeUnit.MINUTE,
+                interval=5,
+                data_sources=[
+                    DataSource(
+                        symbol="BTC/EUR",
+                        data_type=DataType.OHLCV,
+                        time_frame=TimeFrame.ONE_HOUR,
+                        market="BITVAVO",
+                        warmup_window=100,
+                    ),
+                    DataSource(
+                        symbol="ETH/EUR",
+                        data_type=DataType.OHLCV,
+                        time_frame=TimeFrame.FIFTEEN_MINUTE,
+                        market="BITVAVO",
+                        warmup_window=100,
+                    ),
+                ],
+            )
+
+    # ------------------------------------------------------------------
+    # 5. No validation when there are no OHLCV data sources at all
+    # ------------------------------------------------------------------
+    def test_no_validation_when_no_ohlcv_data_sources(self):
+        """No OHLCV sources → nothing to compare → should NOT raise."""
+        strategy = _ConcreteStrategy(
+            time_unit=TimeUnit.MINUTE,
+            interval=1,
+            data_sources=[],
+        )
+        self.assertIsNotNone(strategy)
+
+    # ------------------------------------------------------------------
+    # 6. Non-OHLCV sources (no time_frame) are skipped
+    # ------------------------------------------------------------------
+    def test_skips_data_sources_without_timeframe(self):
+        """Ticker source has no time_frame → should NOT raise."""
+        strategy = _ConcreteStrategy(
+            time_unit=TimeUnit.MINUTE,
+            interval=1,
+            data_sources=[
+                DataSource(
+                    symbol="BTC/EUR",
+                    data_type=DataType.TICKER,
+                    market="BITVAVO",
+                )
+            ],
+        )
+        self.assertIsNotNone(strategy)
+
+    # ------------------------------------------------------------------
+    # 7. Error message is descriptive
+    # ------------------------------------------------------------------
+    def test_raises_with_descriptive_error_message(self):
+        """Exception message should contain interval info AND timeframe info."""
+        with self.assertRaises(OperationalException) as cm:
+            _ConcreteStrategy(
+                time_unit=TimeUnit.MINUTE,
+                interval=1,
+                data_sources=[
+                    DataSource(
+                        symbol="BTC/EUR",
+                        data_type=DataType.OHLCV,
+                        time_frame=TimeFrame.ONE_HOUR,
+                        market="BITVAVO",
+                        warmup_window=100,
+                    )
+                ],
+            )
+
+        msg = str(cm.exception)
+        # Verify scheduling interval info is present
+        self.assertIn("1 min", msg)
+        # Verify OHLCV timeframe info is present
+        self.assertIn("60 min", msg)


### PR DESCRIPTION
## Summary

Closes #396

Raises `OperationalException` during `TradingStrategy.__init__` when the strategy's scheduling interval is faster than the smallest OHLCV data source timeframe.

## Changes

- **`investing_algorithm_framework/app/strategy.py`** — Added validation that computes the scheduling interval (`time_unit.amount_of_minutes * interval`) and compares it against the smallest OHLCV data source timeframe. Raises a descriptive `OperationalException` if the interval is too fast.

- **`tests/app/test_strategy_interval_validation.py`** (new) — 7 test cases covering: raises on too-fast interval, accepts matching/slower intervals, validates against smallest OHLCV source, skips when no OHLCV sources, skips non-OHLCV sources, and checks the error message.

- **`tests/app/test_data_completeness.py`** — Fixed test strategies that had invalid 1-minute intervals with 1-day OHLCV data (updated to DAY).

## Example error message

```
OperationalException: Strategy 'MyStrategy' scheduling interval (1 minute = 1 min)
is faster than the smallest OHLCV data source timeframe (60 min). The strategy would
run without new data. Increase the scheduling interval or use a smaller data timeframe.
```

## Tests

All 161 app tests pass (`poetry run pytest tests/app/ -v`).
