### PR TITLE
feat: order metadata, consistency/stability metrics, dashboard & MCP improvements

### DIFF
--- a/investing_algorithm_framework/cli/mcp_server.py
+++ b/investing_algorithm_framework/cli/mcp_server.py
@@ -1907,7 +1907,8 @@ class BacktestMCPServer:
                                         "description": (
                                             "Metric name, e.g. sharpe_ratio, "
                                             "cagr, max_drawdown, win_rate, "
-                                            "consistency_score, stability_score"
+                                            "consistency_score, "  # noqa
+                                            "stability_score"
                                         ),
                                     },
                                     "operator": {

--- a/investing_algorithm_framework/infrastructure/services/backtesting/vector_backtest_service.py
+++ b/investing_algorithm_framework/infrastructure/services/backtesting/vector_backtest_service.py
@@ -332,8 +332,10 @@ class VectorBacktestService:
             sym_data['entry_count'] = 0
             sym_data['scale_out_count'] = 0
 
-        def _open_trade(sym, sym_data, price, date, capital,
-                       order_reason="buy_signal"):
+        def _open_trade(
+            sym, sym_data, price, date, capital,
+            order_reason="buy_signal"
+        ):
             """Helper to open a new trade for a symbol."""
             nonlocal current_unallocated, total_allocated
 


### PR DESCRIPTION
## Changes

### Order Metadata
- Add `metadata_json` column to Order model with reason tracking
- Tag orders with reasons: buy_signal, sell_signal, scale_out, stop_loss, take_profit
- 43 tests across 7 test files

### Consistency & Stability Metrics
- CV-based consistency (scale-invariant) and normalized-std stability metrics
- 8 new fields in BacktestSummaryMetrics
- Weights added to all 4 BacktestEvaluationFocus presets

### Dashboard Improvements
- Consistency/Stability KPI cards and ranking table columns
- Absolute-threshold color coding on metrics with best-value stars
- Reason column in orders table, Stop Loss/Take Profit in trades table
- Fixed empty timeline chart (custom canvas 2D rendering)
- Symbol dropdown for timeline filtering
- Fixed `report.show(browser=True)`

### MCP Server
- Consistency/Stability columns in list_strategies
- Added to compare_strategies and rank/filter tool hints
- 32 new MCP server tests

### Housekeeping
- Flake8 lint fixes (E501, E128)
- Tutorial notebook and strategy example updates