### PR TITLE
fix: enforce utf-8 for backtest report template and html io

### DIFF
--- a/investing_algorithm_framework/app/reporting/backtest_report.py
+++ b/investing_algorithm_framework/app/reporting/backtest_report.py
@@ -34,7 +34,7 @@ _TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
 
 
 def _read_template(filename):
-    with open(os.path.join(_TEMPLATE_DIR, filename), 'r') as f:
+    with open(os.path.join(_TEMPLATE_DIR, filename), 'r', encoding='utf-8') as f:
         return f.read()
 
 
@@ -186,7 +186,7 @@ class BacktestReport:
             self.html_report = self._build_html()
 
         path = "/tmp/backtest_report.html"
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(self.html_report)
 
         if browser:
@@ -208,7 +208,7 @@ class BacktestReport:
     def save(self, path):
         if not self.html_report:
             self.html_report = self._build_html()
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(self.html_report)
 
     @staticmethod

--- a/tests/app/reporting/test_backtest_report_html.py
+++ b/tests/app/reporting/test_backtest_report_html.py
@@ -211,7 +211,7 @@ class TestBacktestReportSave(TestCase):
         report.save(path)
         self.assertTrue(os.path.isfile(path))
 
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             content = f.read()
         self.assertIn("<!DOCTYPE html>", content)
         self.assertIn("const STRATEGIES", content)


### PR DESCRIPTION
## Summary
- Use explicit `encoding=\"utf-8\"` when reading report templates in `backtest_report.py`.
- Use explicit UTF-8 when writing generated HTML in `BacktestReport.show()` and `BacktestReport.save()`.
- Update report HTML save test to read generated file with UTF-8 explicitly so the assertion is locale-independent on Windows.

## Verification
- `E:/AProject/TianX/Personal/investing-algorithm-framework/.venv/Scripts/python.exe -m pytest tests/app/reporting/test_backtest_report_html.py -v`
  - Result: `23 passed, 1 warning`

## Linked Issue
- #462