### PR TITLE
feat: add CSV, JSON, and Parquet URL data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This framework is built around the full loop: **create strategies → backtest t
 - 🎯 **Return Scenario Projections** — Good, average, bad & very bad year projections from backtest data
 - 📉 **Benchmark Comparison** — Beat-rate analysis vs Buy & Hold, DCA, risk-free & custom benchmarks
 - 📄 **One-Click HTML Report** — Self-contained file, no server, dark & light theme, shareable
+- 🌐 **Load External Data** — Fetch CSV, JSON, or Parquet from any URL with caching and auto-refresh
 - 🚀 **Build → Backtest → Deploy** — Local dev, cloud deploy (AWS / Azure), or monetize on Finterion
 
 </details>
@@ -262,15 +263,17 @@ report.save("my_report.html")
 
 | | |
 |---|---|
-| **Backtest Report Dashboard** | Self-contained HTML report with ranking tables, equity curves, metric charts, heatmaps, and strategy comparison |
-| **Event-Driven Backtesting** | Realistic, order-by-order simulation |
-| **Vectorized Backtesting** | Fast signal research and prototyping |
+| **[Backtest Report Dashboard](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** | Self-contained HTML report with ranking tables, equity curves, metric charts, heatmaps, and strategy comparison |
+| **[Event-Driven Backtesting](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtesting)** | Realistic, order-by-order simulation |
+| **[Vectorized Backtesting](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/vector-backtesting)** | Fast signal research and prototyping |
 | **50+ Metrics** | CAGR, Sharpe, Sortino, max drawdown, win rate, profit factor, recovery factor, volatility, and more |
-| **Live Trading** | Connect to exchanges via CCXT for real-time execution |
-| **Portfolio Management** | Position tracking, trade management, persistence |
-| **Cloud Deployment** | Deploy to AWS Lambda, Azure Functions, or run as a web service |
-| **Market Data** | OHLCV, tickers, custom data — Polars and Pandas native |
-| **Extensible** | Custom data providers, order executors, and strategy classes |
+| **[Live Trading](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/application-setup)** | Connect to exchanges via CCXT for real-time execution |
+| **[Portfolio Management](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/portfolio-configuration)** | Position tracking, trade management, persistence |
+| **[Cloud Deployment](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/deployment)** | Deploy to AWS Lambda, Azure Functions, or run as a web service |
+| **[Market Data Providers](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/custom-data-providers)** | Built-in providers for CCXT, Yahoo Finance, Alpha Vantage, and Polygon — or build your own |
+| **[Load External Data](https://coding-kitties.github.io/investing-algorithm-framework/Data/external-data)** | Fetch CSV, JSON, or Parquet from any URL with caching, date parsing, and pre/post-processing |
+| **[Strategies](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/strategies)** | OHLCV, tickers, custom data — Polars and Pandas native |
+| **[Extensible](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/custom-data-providers)** | Custom data providers, order executors, and strategy classes |
 
 </details>
 

--- a/docusaurus/docs/Data/external-data.md
+++ b/docusaurus/docs/Data/external-data.md
@@ -1,0 +1,221 @@
+---
+sidebar_position: 4
+---
+
+# Load External Data
+
+Load CSV, JSON, or Parquet data from any URL during strategy execution or as a pre-declared data source. Use this to bring in sentiment scores, earnings data, macro indicators, or any external dataset.
+
+## Overview
+
+The framework provides two ways to load external data:
+
+1. **Data Sources** — Declare `DataSource.from_csv()`, `DataSource.from_json()`, or `DataSource.from_parquet()` in your strategy's `data_sources` list. Data is fetched automatically and available in your `data` dict.
+2. **Context methods** — Call `context.fetch_csv()`, `context.fetch_json()`, or `context.fetch_parquet()` on demand inside your strategy's `run_strategy` method.
+
+Both approaches support caching, refresh intervals, date parsing, and pre/post-processing callbacks.
+
+## Supported Formats
+
+| Format | DataSource Factory | Context Method | Provider Class |
+|--------|-------------------|----------------|----------------|
+| CSV | `DataSource.from_csv()` | `context.fetch_csv()` | `CSVURLDataProvider` |
+| JSON | `DataSource.from_json()` | `context.fetch_json()` | `JSONURLDataProvider` |
+| Parquet | `DataSource.from_parquet()` | `context.fetch_parquet()` | `ParquetURLDataProvider` |
+
+## Using DataSource (Pre-Declared)
+
+Declare external data sources alongside your market data. The framework fetches them automatically before your strategy runs.
+
+### CSV
+
+```python
+from investing_algorithm_framework import TradingStrategy, DataSource, TimeUnit
+
+class SentimentStrategy(TradingStrategy):
+    time_unit = TimeUnit.DAY
+    interval = 1
+    symbols = ["BTC"]
+
+    data_sources = [
+        DataSource.from_csv(
+            identifier="sentiment",
+            url="https://example.com/crypto_sentiment.csv",
+            date_column="date",
+            date_format="%Y-%m-%d",
+            cache=True,
+            refresh_interval="1d",
+        ),
+    ]
+
+    def run_strategy(self, context, data):
+        sentiment_df = data["sentiment"]
+        latest_score = sentiment_df["score"][-1]
+
+        if latest_score > 0.7:
+            context.create_limit_order(...)
+```
+
+### JSON
+
+```python
+data_sources = [
+    DataSource.from_json(
+        identifier="earnings",
+        url="https://api.example.com/earnings.json",
+        date_column="report_date",
+        date_format="%Y-%m-%d",
+        refresh_interval="1d",
+    ),
+]
+```
+
+The JSON data must be either:
+- An **array of objects** (records orientation): `[{"date": "2024-01-01", "value": 42}, ...]`
+- An **object of arrays** (columnar orientation): `{"date": ["2024-01-01", ...], "value": [42, ...]}`
+
+### Parquet
+
+```python
+data_sources = [
+    DataSource.from_parquet(
+        identifier="features",
+        url="https://storage.example.com/features.parquet",
+        date_column="date",
+        refresh_interval="1W",
+    ),
+]
+```
+
+> **Note:** Parquet is a binary format, so `pre_process` callbacks are not supported. Use `post_process` instead.
+
+## Using Context Methods (On-Demand)
+
+Fetch data dynamically inside your strategy without pre-declaring it as a data source. Useful when the URL depends on runtime values or when you only need data conditionally.
+
+```python
+class MyStrategy(TradingStrategy):
+    time_unit = TimeUnit.DAY
+    interval = 1
+    symbols = ["BTC"]
+
+    def run_strategy(self, context, data):
+        # Fetch CSV on demand
+        sentiment = context.fetch_csv(
+            url="https://example.com/sentiment.csv",
+            date_column="date",
+            cache=True,
+            refresh_interval="1d",
+        )
+
+        # Fetch JSON on demand
+        earnings = context.fetch_json(
+            url="https://api.example.com/earnings",
+            date_column="report_date",
+        )
+
+        # Fetch Parquet on demand
+        features = context.fetch_parquet(
+            url="https://storage.example.com/features.parquet",
+        )
+```
+
+## Parameters
+
+All three factory methods and context methods accept the same core parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `identifier` | `str` | — | Unique identifier (DataSource only). |
+| `url` | `str` | — | URL to fetch the data from. |
+| `date_column` | `str` | `None` | Name of the column containing dates. Parsed to `polars.Datetime`. |
+| `date_format` | `str` | `None` | strftime format for parsing dates (e.g., `"%Y-%m-%d"`). Auto-detected if omitted. |
+| `cache` | `bool` | `True` | Cache fetched data locally to avoid repeated downloads. |
+| `refresh_interval` | `str` | `None` | How often to re-fetch: `"1m"`, `"5m"`, `"15m"`, `"30m"`, `"1h"`, `"4h"`, `"1d"`, `"1W"`. |
+| `pre_process` | `callable` | `None` | Transform raw text before parsing. Receives `str`, returns `str`. Not available for Parquet. |
+| `post_process` | `callable` | `None` | Transform the parsed DataFrame. Receives `DataFrame`, returns `DataFrame`. |
+
+## Pre/Post Processing
+
+### Pre-Processing
+
+Clean or transform raw text before it is parsed into a DataFrame. Useful for removing comment lines, fixing delimiters, or filtering rows.
+
+```python
+def clean_csv(text):
+    """Remove comment lines starting with #."""
+    lines = [line for line in text.split("\n") if not line.startswith("#")]
+    return "\n".join(lines)
+
+DataSource.from_csv(
+    identifier="cleaned_data",
+    url="https://example.com/messy_data.csv",
+    pre_process=clean_csv,
+)
+```
+
+### Post-Processing
+
+Transform the parsed DataFrame — add computed columns, filter rows, change types.
+
+```python
+import polars as pl
+
+def add_z_score(df):
+    """Add a z-score column for the score field."""
+    mean = df["score"].mean()
+    std = df["score"].std()
+    return df.with_columns(
+        ((pl.col("score") - mean) / std).alias("z_score")
+    )
+
+DataSource.from_csv(
+    identifier="scored_data",
+    url="https://example.com/scores.csv",
+    post_process=add_z_score,
+)
+```
+
+## Caching
+
+External data is cached both **in memory** and **on disk**:
+
+- **In-memory cache** — Avoids re-parsing on every strategy tick.
+- **File cache** — Stored inside your resource directory (e.g., `resources/data/`). Falls back to `.data_cache/` if no resource directory is configured.
+- **Refresh interval** — When set, the framework re-fetches data after the specified interval expires. Staleness is determined by the cache file's modification time, so it survives process restarts.
+
+Cache files are named using an MD5 hash of the URL, so different URLs never collide.
+
+### Cloud Deployments (AWS Lambda / Azure Functions)
+
+When a state handler (`AWSS3StorageStateHandler` or `AzureBlobStorageStateHandler`) is configured, cache files are automatically persisted because they live inside the resource directory that state handlers sync:
+
+1. **Load state** — Cache files are restored from S3 / Azure Blob to `resources/data/`
+2. **Check interval** — The file modification time is compared against `refresh_interval`
+3. **Skip or re-fetch** — Only fetches from the URL if the interval has elapsed
+4. **Save state** — Updated cache files are synced back to cloud storage
+
+This means `refresh_interval` works correctly across cold starts — no extra configuration needed.
+
+## Backtesting
+
+External data sources work with backtesting. The framework calls `prepare_backtest_data()` before the backtest starts, and `get_backtest_data()` on each tick. If a `date_column` is configured, data is automatically filtered to only include rows up to the current backtest date.
+
+```python
+data_sources = [
+    DataSource.from_csv(
+        identifier="macro",
+        url="https://example.com/macro_indicators.csv",
+        date_column="date",
+        date_format="%Y-%m-%d",
+    ),
+]
+```
+
+During backtesting, `data["macro"]` will only contain rows where `date <= current_backtest_date`, giving you realistic point-in-time data.
+
+## Next Steps
+
+- Learn about [Data Sources](data-sources) for market data configuration
+- Explore [Custom Data Providers](../Advanced%20Concepts/custom-data-providers) to build your own provider
+- Check out [Strategies](../Getting%20Started/strategies) for strategy implementation

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -67,6 +67,10 @@ const sidebars = {
                     type: 'doc',
                     id: 'Data/multiple-market-data-sources',
                 },
+                {
+                    type: 'doc',
+                    id: 'Data/external-data',
+                },
             ],
         },
         {

--- a/investing_algorithm_framework/__init__.py
+++ b/investing_algorithm_framework/__init__.py
@@ -26,7 +26,8 @@ from .domain import ApiException, combine_backtests, PositionSize, \
     save_backtests_to_directory, BacktestMetrics, DATA_DIRECTORY, \
     retag_backtests
 from .infrastructure import AzureBlobStorageStateHandler, \
-    CSVOHLCVDataProvider, CSVTickerDataProvider, \
+    CSVOHLCVDataProvider, CSVTickerDataProvider, CSVURLDataProvider, \
+    JSONURLDataProvider, ParquetURLDataProvider, \
     CCXTOHLCVDataProvider, CCXTTickerDataProvider, \
     PandasOHLCVDataProvider, OHLCVDataProviderBase, \
     YahooOHLCVDataProvider, \
@@ -116,7 +117,8 @@ __all__ = [
     'DataType',
     'CSVOHLCVDataProvider',
     'CSVTickerDataProvider',
-    "CCXTOHLCVDataProvider",
+    'CSVURLDataProvider',    'JSONURLDataProvider',
+    'ParquetURLDataProvider',    "CCXTOHLCVDataProvider",
     "CCXTTickerDataProvider",
     "OHLCVDataProviderBase",
     "YahooOHLCVDataProvider",

--- a/investing_algorithm_framework/app/context.py
+++ b/investing_algorithm_framework/app/context.py
@@ -2008,3 +2008,191 @@ class Context:
             query_params["triggered"] = triggered
 
         return self.trade_stop_loss_service.get_all(query_params)
+
+    def fetch_csv(
+        self,
+        url,
+        date_column=None,
+        date_format=None,
+        cache=True,
+        refresh_interval=None,
+        pre_process=None,
+        post_process=None,
+    ):
+        """
+        Fetch CSV data from a remote URL on demand.
+
+        This is a convenience method for dynamically loading external
+        CSV data during strategy execution without pre-declaring it
+        as a DataSource.
+
+        Args:
+            url (str): URL to fetch the CSV data from.
+            date_column (str, optional): Name of the date column to
+                parse.
+            date_format (str, optional): strftime format for parsing
+                dates.
+            cache (bool): Cache fetched data locally (default: True).
+            refresh_interval (str, optional): Re-fetch interval
+                (e.g., "1d", "1h").
+            pre_process (callable, optional): Transform raw CSV text
+                before parsing.
+            post_process (callable, optional): Transform the parsed
+                DataFrame.
+
+        Returns:
+            polars.DataFrame: The parsed CSV data.
+
+        Example::
+
+            def run_strategy(self, context, data):
+                earnings = context.fetch_csv(
+                    url="https://example.com/earnings.csv",
+                    date_column="report_date",
+                )
+                latest = earnings["eps"].iloc[-1]
+        """
+        from investing_algorithm_framework.infrastructure \
+            import CSVURLDataProvider
+
+        if not hasattr(self, '_csv_url_providers'):
+            self._csv_url_providers = {}
+
+        if url not in self._csv_url_providers:
+            provider = CSVURLDataProvider(
+                url=url,
+                date_column=date_column,
+                date_format=date_format,
+                cache=cache,
+                refresh_interval=refresh_interval,
+                pre_process=pre_process,
+                post_process=post_process,
+            )
+            provider.config = self.configuration_service.get_config()
+            self._csv_url_providers[url] = provider
+
+        return self._csv_url_providers[url].get_data()
+
+    def fetch_json(
+        self,
+        url,
+        date_column=None,
+        date_format=None,
+        cache=True,
+        refresh_interval=None,
+        pre_process=None,
+        post_process=None,
+    ):
+        """
+        Fetch JSON data from a remote URL on demand.
+
+        This is a convenience method for dynamically loading external
+        JSON data during strategy execution without pre-declaring it
+        as a DataSource.
+
+        The JSON data must be either an array of objects or an object
+        of arrays.
+
+        Args:
+            url (str): URL to fetch the JSON data from.
+            date_column (str, optional): Name of the date column to
+                parse.
+            date_format (str, optional): strftime format for parsing
+                dates.
+            cache (bool): Cache fetched data locally (default: True).
+            refresh_interval (str, optional): Re-fetch interval
+                (e.g., "1d", "1h").
+            pre_process (callable, optional): Transform raw JSON text
+                before parsing.
+            post_process (callable, optional): Transform the parsed
+                DataFrame.
+
+        Returns:
+            polars.DataFrame: The parsed JSON data.
+
+        Example::
+
+            def run_strategy(self, context, data):
+                earnings = context.fetch_json(
+                    url="https://api.example.com/earnings",
+                    date_column="report_date",
+                )
+        """
+        from investing_algorithm_framework.infrastructure \
+            import JSONURLDataProvider
+
+        if not hasattr(self, '_json_url_providers'):
+            self._json_url_providers = {}
+
+        if url not in self._json_url_providers:
+            provider = JSONURLDataProvider(
+                url=url,
+                date_column=date_column,
+                date_format=date_format,
+                cache=cache,
+                refresh_interval=refresh_interval,
+                pre_process=pre_process,
+                post_process=post_process,
+            )
+            provider.config = self.configuration_service.get_config()
+            self._json_url_providers[url] = provider
+
+        return self._json_url_providers[url].get_data()
+
+    def fetch_parquet(
+        self,
+        url,
+        date_column=None,
+        date_format=None,
+        cache=True,
+        refresh_interval=None,
+        post_process=None,
+    ):
+        """
+        Fetch Parquet data from a remote URL on demand.
+
+        This is a convenience method for dynamically loading external
+        Parquet data during strategy execution without pre-declaring
+        it as a DataSource.
+
+        Args:
+            url (str): URL to fetch the Parquet file from.
+            date_column (str, optional): Name of the date column to
+                parse.
+            date_format (str, optional): strftime format for parsing
+                dates.
+            cache (bool): Cache fetched data locally (default: True).
+            refresh_interval (str, optional): Re-fetch interval
+                (e.g., "1d", "1h").
+            post_process (callable, optional): Transform the parsed
+                DataFrame.
+
+        Returns:
+            polars.DataFrame: The parsed Parquet data.
+
+        Example::
+
+            def run_strategy(self, context, data):
+                features = context.fetch_parquet(
+                    url="https://storage.example.com/features.parquet",
+                )
+        """
+        from investing_algorithm_framework.infrastructure \
+            import ParquetURLDataProvider
+
+        if not hasattr(self, '_parquet_url_providers'):
+            self._parquet_url_providers = {}
+
+        if url not in self._parquet_url_providers:
+            provider = ParquetURLDataProvider(
+                url=url,
+                date_column=date_column,
+                date_format=date_format,
+                cache=cache,
+                refresh_interval=refresh_interval,
+                post_process=post_process,
+            )
+            provider.config = self.configuration_service.get_config()
+            self._parquet_url_providers[url] = provider
+
+        return self._parquet_url_providers[url].get_data()

--- a/investing_algorithm_framework/domain/models/data/data_source.py
+++ b/investing_algorithm_framework/domain/models/data/data_source.py
@@ -1,7 +1,7 @@
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
-from typing import Union
+from typing import Union, Callable, Optional
 
 from dateutil import parser
 
@@ -41,6 +41,18 @@ class DataSource:
     start_date: Union[datetime, None] = None
     end_date: Union[datetime, None] = None
     save: bool = False
+    # CSV URL fields
+    url: Optional[str] = None
+    date_column: Optional[str] = None
+    date_format: Optional[str] = None
+    cache: bool = True
+    refresh_interval: Optional[str] = None
+    pre_process: Optional[Callable] = field(
+        default=None, repr=False, compare=False
+    )
+    post_process: Optional[Callable] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self):
         # Handle backward compatibility for window_size -> warmup_window
@@ -107,6 +119,169 @@ class DataSource:
 
         if self.symbol is not None:
             object.__setattr__(self, 'symbol', self.symbol.upper())
+
+    @classmethod
+    def from_csv(
+        cls,
+        identifier: str,
+        url: str,
+        date_column: str = None,
+        date_format: str = None,
+        cache: bool = True,
+        refresh_interval: str = None,
+        pre_process: Callable = None,
+        post_process: Callable = None,
+    ) -> "DataSource":
+        """
+        Create a DataSource that fetches CSV data from a remote URL.
+
+        Args:
+            identifier: Unique identifier for this data source.
+            url: URL to fetch the CSV data from.
+            date_column: Name of the column containing dates.
+            date_format: strftime format for parsing the date column.
+            cache: Whether to cache the fetched data locally
+                (default: True).
+            refresh_interval: How often to re-fetch the data
+                (e.g., "1d", "1h"). If None, data is fetched once and
+                cached indefinitely.
+            pre_process: Optional callback to transform the raw CSV
+                text before parsing. Receives a string, must return
+                a string.
+            post_process: Optional callback to transform the parsed
+                DataFrame. Receives a DataFrame, must return a
+                DataFrame.
+
+        Returns:
+            DataSource: A configured DataSource for CSV URL fetching.
+
+        Example:
+            DataSource.from_csv(
+                identifier="sentiment",
+                url="https://example.com/crypto_sentiment.csv",
+                date_column="date",
+                date_format="%Y-%m-%d",
+                cache=True,
+                refresh_interval="1d",
+            )
+        """
+        return cls(
+            identifier=identifier,
+            data_type=DataType.CUSTOM,
+            data_provider_identifier="csv_url_data_provider",
+            url=url,
+            date_column=date_column,
+            date_format=date_format,
+            cache=cache,
+            refresh_interval=refresh_interval,
+            pre_process=pre_process,
+            post_process=post_process,
+        )
+
+    @classmethod
+    def from_json(
+        cls,
+        identifier: str,
+        url: str,
+        date_column: str = None,
+        date_format: str = None,
+        cache: bool = True,
+        refresh_interval: str = None,
+        pre_process: Callable = None,
+        post_process: Callable = None,
+    ) -> "DataSource":
+        """
+        Create a DataSource that fetches JSON data from a remote URL.
+
+        The JSON data must be either an array of objects (records
+        orientation) or an object of arrays (columnar orientation).
+
+        Args:
+            identifier: Unique identifier for this data source.
+            url: URL to fetch the JSON data from.
+            date_column: Name of the column containing dates.
+            date_format: strftime format for parsing the date column.
+            cache: Whether to cache the fetched data locally
+                (default: True).
+            refresh_interval: How often to re-fetch the data
+                (e.g., "1d", "1h").
+            pre_process: Optional callback to transform the raw JSON
+                text before parsing. Receives a string, must return
+                a string.
+            post_process: Optional callback to transform the parsed
+                DataFrame.
+
+        Returns:
+            DataSource: A configured DataSource for JSON URL fetching.
+
+        Example:
+            DataSource.from_json(
+                identifier="earnings",
+                url="https://api.example.com/earnings.json",
+                date_column="report_date",
+            )
+        """
+        return cls(
+            identifier=identifier,
+            data_type=DataType.CUSTOM,
+            data_provider_identifier="json_url_data_provider",
+            url=url,
+            date_column=date_column,
+            date_format=date_format,
+            cache=cache,
+            refresh_interval=refresh_interval,
+            pre_process=pre_process,
+            post_process=post_process,
+        )
+
+    @classmethod
+    def from_parquet(
+        cls,
+        identifier: str,
+        url: str,
+        date_column: str = None,
+        date_format: str = None,
+        cache: bool = True,
+        refresh_interval: str = None,
+        post_process: Callable = None,
+    ) -> "DataSource":
+        """
+        Create a DataSource that fetches Parquet data from a remote
+        URL.
+
+        Args:
+            identifier: Unique identifier for this data source.
+            url: URL to fetch the Parquet file from.
+            date_column: Name of the column containing dates.
+            date_format: strftime format for parsing the date column.
+            cache: Whether to cache the fetched data locally
+                (default: True).
+            refresh_interval: How often to re-fetch the data
+                (e.g., "1d", "1h").
+            post_process: Optional callback to transform the parsed
+                DataFrame.
+
+        Returns:
+            DataSource: A configured DataSource for Parquet URL
+            fetching.
+
+        Example:
+            DataSource.from_parquet(
+                identifier="features",
+                url="https://storage.example.com/features.parquet",
+            )
+        """
+        return cls(
+            identifier=identifier,
+            data_type=DataType.CUSTOM,
+            data_provider_identifier="parquet_url_data_provider",
+            url=url,
+            date_column=date_column,
+            date_format=date_format,
+            cache=cache,
+            refresh_interval=refresh_interval,
+            post_process=post_process,
+        )
 
     def get_identifier(self):
         """

--- a/investing_algorithm_framework/infrastructure/__init__.py
+++ b/investing_algorithm_framework/infrastructure/__init__.py
@@ -11,7 +11,8 @@ from .repositories import SQLOrderRepository, SQLPositionRepository, \
 from .services import AzureBlobStorageStateHandler, AWSS3StorageStateHandler, \
     BacktestService
 from .data_providers import CSVOHLCVDataProvider, \
-    CSVTickerDataProvider, get_default_data_providers, \
+    CSVTickerDataProvider, CSVURLDataProvider, JSONURLDataProvider, \
+    ParquetURLDataProvider, get_default_data_providers, \
     get_default_ohlcv_data_providers, CCXTOHLCVDataProvider, \
     CCXTTickerDataProvider, PandasOHLCVDataProvider, \
     OHLCVDataProviderBase, \
@@ -55,6 +56,9 @@ __all__ = [
     "BacktestOrderExecutor",
     "PandasOHLCVDataProvider",
     "OHLCVDataProviderBase",
+    "CSVURLDataProvider",
+    "JSONURLDataProvider",
+    "ParquetURLDataProvider",
     "YahooOHLCVDataProvider",
     "AlphaVantageOHLCVDataProvider",
     "PolygonOHLCVDataProvider",

--- a/investing_algorithm_framework/infrastructure/data_providers/__init__.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/__init__.py
@@ -1,5 +1,8 @@
 from .ccxt import CCXTOHLCVDataProvider, CCXTTickerDataProvider
 from .csv import CSVOHLCVDataProvider, CSVTickerDataProvider
+from .csv_url import CSVURLDataProvider
+from .json_url import JSONURLDataProvider
+from .parquet_url import ParquetURLDataProvider
 from .pandas import PandasOHLCVDataProvider
 from .ohlcv_base import OHLCVDataProviderBase
 
@@ -59,6 +62,9 @@ def get_default_data_providers():
     providers = [
         CCXTOHLCVDataProvider(),
         CCXTTickerDataProvider(),
+        CSVURLDataProvider(),
+        JSONURLDataProvider(),
+        ParquetURLDataProvider(),
     ]
 
     if _yahoo_available:
@@ -99,6 +105,9 @@ def get_default_ohlcv_data_providers():
 __all__ = [
     'CSVOHLCVDataProvider',
     'CSVTickerDataProvider',
+    'CSVURLDataProvider',
+    'JSONURLDataProvider',
+    'ParquetURLDataProvider',
     'CCXTOHLCVDataProvider',
     'CCXTTickerDataProvider',
     'get_default_data_providers',

--- a/investing_algorithm_framework/infrastructure/data_providers/base_url.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/base_url.py
@@ -1,0 +1,372 @@
+import hashlib
+import logging
+import os
+import ssl
+import time
+import urllib.request
+from abc import abstractmethod
+
+import polars as pl
+
+from investing_algorithm_framework.domain import DataProvider, DataType
+
+logger = logging.getLogger("investing_algorithm_framework")
+
+# Mapping of refresh_interval strings to seconds
+INTERVAL_SECONDS = {
+    "1m": 60,
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "4h": 14400,
+    "1d": 86400,
+    "1W": 604800,
+}
+
+
+class BaseURLDataProvider(DataProvider):
+    """
+    Abstract base class for data providers that fetch data from a
+    remote URL.
+
+    Provides shared logic for caching, refresh intervals,
+    pre/post-processing callbacks, and date parsing. Subclasses
+    only need to implement ``_parse_raw_data`` and
+    ``_write_cache_file`` for their specific format.
+    """
+    data_type = DataType.CUSTOM
+    data_provider_identifier = None  # Must be set by subclasses
+
+    def __init__(
+        self,
+        url=None,
+        date_column=None,
+        date_format=None,
+        cache=True,
+        refresh_interval=None,
+        pre_process=None,
+        post_process=None,
+        priority=5,
+        identifier=None,
+    ):
+        super().__init__(
+            data_provider_identifier=(
+                identifier or self.data_provider_identifier
+            ),
+            data_type=DataType.CUSTOM.value,
+            priority=priority,
+        )
+        self._url = url
+        self._date_column = date_column
+        self._date_format = date_format
+        self._cache = cache
+        self._refresh_interval = refresh_interval
+        self._pre_process = pre_process
+        self._post_process = post_process
+        self._cached_data = None
+        self._last_fetch_time = None
+
+    # ------------------------------------------------------------------
+    # Abstract methods — subclasses must implement
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _parse_raw_data(self, raw_bytes):
+        """
+        Parse raw bytes fetched from the URL into a Polars DataFrame.
+
+        Args:
+            raw_bytes (bytes): The raw content downloaded from the URL.
+
+        Returns:
+            polars.DataFrame: Parsed tabular data.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _read_cache_file(self, path):
+        """
+        Read a cached file from disk into a Polars DataFrame.
+
+        Args:
+            path (str): Path to the cache file.
+
+        Returns:
+            polars.DataFrame
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _write_cache_file(self, df, path):
+        """
+        Write a Polars DataFrame to disk as a cache file.
+
+        Args:
+            df (polars.DataFrame): The data to cache.
+            path (str): Path to write to.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _cache_file_suffix(self):
+        """Return the file extension for cache files (e.g. '.csv')."""
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # DataProvider interface
+    # ------------------------------------------------------------------
+
+    def has_data(self, data_source, start_date=None, end_date=None):
+        """Check if this provider can serve the given data source."""
+        if not DataType.CUSTOM.equals(data_source.data_type):
+            return False
+
+        if data_source.data_provider_identifier \
+                == self.data_provider_identifier \
+                and data_source.url is not None:
+            return True
+
+        return False
+
+    def get_data(
+        self, date=None, start_date=None, end_date=None, save=False
+    ):
+        """Fetch and return data from the configured URL."""
+        if self._should_refetch():
+            self._fetch_and_parse()
+
+        return self._cached_data
+
+    def prepare_backtest_data(
+        self,
+        backtest_start_date,
+        backtest_end_date,
+        fill_missing_data=False,
+        show_progress=False,
+    ):
+        """Pre-fetch data for backtesting."""
+        self._fetch_and_parse()
+
+    def get_backtest_data(
+        self,
+        backtest_index_date=None,
+        backtest_start_date=None,
+        backtest_end_date=None,
+        data_source=None,
+    ):
+        """Return data for a specific backtest date."""
+        if self._cached_data is None:
+            self._fetch_and_parse()
+
+        df = self._cached_data
+
+        # Filter by date column if available
+        if self._date_column and self._date_column in df.columns:
+            if backtest_index_date is not None:
+                try:
+                    df = df.filter(
+                        pl.col(self._date_column) <= backtest_index_date
+                    )
+                except Exception:
+                    pass
+
+        return df
+
+    def get_number_of_data_points(self, start_date, end_date):
+        """Return the number of rows in the cached data."""
+        if self._cached_data is None:
+            return 0
+        return len(self._cached_data)
+
+    def get_missing_data_dates(self, start_date, end_date):
+        """URL-fetched data does not track missing dates."""
+        return []
+
+    def get_data_source_file_path(self):
+        """Return the cache file path if available."""
+        return self._get_cache_path()
+
+    def copy(self, data_source=None):
+        """Create a copy of this provider configured for a data source."""
+        url = self._url
+        date_column = self._date_column
+        date_format = self._date_format
+        cache = self._cache
+        refresh_interval = self._refresh_interval
+        pre_process = self._pre_process
+        post_process = self._post_process
+        identifier = self.data_provider_identifier
+
+        if data_source is not None:
+            url = data_source.url or url
+            date_column = data_source.date_column or date_column
+            date_format = data_source.date_format or date_format
+            cache = data_source.cache if data_source.cache is not None \
+                else cache
+            refresh_interval = data_source.refresh_interval \
+                or refresh_interval
+            pre_process = data_source.pre_process or pre_process
+            post_process = data_source.post_process or post_process
+
+        provider = self.__class__(
+            url=url,
+            date_column=date_column,
+            date_format=date_format,
+            cache=cache,
+            refresh_interval=refresh_interval,
+            pre_process=pre_process,
+            post_process=post_process,
+            priority=self.priority,
+            identifier=identifier,
+        )
+        provider.config = self.config
+        return provider
+
+    # ------------------------------------------------------------------
+    # Shared internal helpers
+    # ------------------------------------------------------------------
+
+    def _should_refetch(self):
+        """Determine if data should be re-fetched."""
+        if self._cached_data is None:
+            return True
+
+        if not self._cache:
+            return True
+
+        if self._refresh_interval and self._last_fetch_time:
+            interval_seconds = INTERVAL_SECONDS.get(
+                self._refresh_interval, None
+            )
+
+            if interval_seconds is not None:
+                elapsed = time.time() - self._last_fetch_time
+                return elapsed >= interval_seconds
+
+        return False
+
+    def _fetch_and_parse(self):
+        """Fetch data from URL, apply callbacks, and cache."""
+        url = self._url
+
+        if url is None:
+            raise ValueError(
+                f"{self.__class__.__name__} requires a URL. "
+                f"Configure it via the appropriate DataSource "
+                f"factory method."
+            )
+
+        logger.info(f"Fetching data from: {url}")
+
+        # Check for local cache file first
+        cache_path = self._get_cache_path()
+
+        if cache_path and self._cache and os.path.exists(cache_path):
+            if not self._should_refetch_from_cache(cache_path):
+                logger.debug(f"Loading cached data from: {cache_path}")
+                df = self._read_cache_file(cache_path)
+                df = self._parse_dates(df)
+
+                if self._post_process:
+                    df = self._post_process(df)
+
+                self._cached_data = df
+                self._last_fetch_time = os.path.getmtime(cache_path)
+                return
+
+        # Fetch from URL
+        ctx = ssl.create_default_context()
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "investing-algorithm-framework"}
+        )
+        with urllib.request.urlopen(req, context=ctx) as response:
+            raw_bytes = response.read()
+
+        # Apply pre-processing callback (operates on text)
+        if self._pre_process:
+            raw_text = raw_bytes.decode("utf-8")
+            raw_text = self._pre_process(raw_text)
+            raw_bytes = raw_text.encode("utf-8")
+
+        # Parse into DataFrame (format-specific)
+        df = self._parse_raw_data(raw_bytes)
+
+        # Parse date column
+        df = self._parse_dates(df)
+
+        # Save to cache file
+        if cache_path and self._cache:
+            os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+            self._write_cache_file(df, cache_path)
+            logger.debug(f"Cached data to: {cache_path}")
+
+        # Apply post-processing callback
+        if self._post_process:
+            df = self._post_process(df)
+
+        self._cached_data = df
+        self._last_fetch_time = time.time()
+
+    def _parse_dates(self, df):
+        """Parse the date column if configured."""
+        if self._date_column and self._date_column in df.columns:
+            try:
+                if self._date_format:
+                    df = df.with_columns(
+                        pl.col(self._date_column)
+                        .str.strptime(pl.Datetime, self._date_format)
+                        .alias(self._date_column)
+                    )
+                else:
+                    df = df.with_columns(
+                        pl.col(self._date_column)
+                        .str.to_datetime()
+                        .alias(self._date_column)
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Could not parse date column "
+                    f"'{self._date_column}': {e}"
+                )
+
+        return df
+
+    def _get_cache_path(self):
+        """Generate a cache file path based on the URL hash."""
+        if self._url is None:
+            return None
+
+        storage_dir = None
+
+        if self.config:
+            resource_dir = self.config.get("RESOURCE_DIRECTORY")
+            data_dir_name = self.config.get("DATA_DIRECTORY")
+
+            if resource_dir and data_dir_name:
+                storage_dir = os.path.join(resource_dir, data_dir_name)
+
+        if storage_dir is None:
+            storage_dir = os.path.join(os.getcwd(), ".data_cache")
+
+        url_hash = hashlib.md5(
+            self._url.encode()
+        ).hexdigest()[:12]
+        suffix = self._cache_file_suffix()
+        return os.path.join(storage_dir, f"url_{url_hash}{suffix}")
+
+    def _should_refetch_from_cache(self, cache_path):
+        """Check if cached file is stale based on refresh interval."""
+        if not self._refresh_interval:
+            return False
+
+        interval_seconds = INTERVAL_SECONDS.get(
+            self._refresh_interval, None
+        )
+
+        if interval_seconds is None:
+            return False
+
+        file_age = time.time() - os.path.getmtime(cache_path)
+        return file_age >= interval_seconds

--- a/investing_algorithm_framework/infrastructure/data_providers/csv_url.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/csv_url.py
@@ -1,0 +1,33 @@
+from io import StringIO
+
+import polars as pl
+
+from .base_url import BaseURLDataProvider
+
+
+class CSVURLDataProvider(BaseURLDataProvider):
+    """
+    Data provider that fetches CSV data from a remote URL.
+
+    Supports caching, configurable date parsing, and pre/post
+    processing callbacks for data transformation.
+
+    This provider is automatically used when a DataSource is created
+    via ``DataSource.from_csv()``.
+    """
+    data_provider_identifier = "csv_url_data_provider"
+
+    def _parse_raw_data(self, raw_bytes):
+        """Parse raw CSV bytes into a Polars DataFrame."""
+        return pl.read_csv(StringIO(raw_bytes.decode("utf-8")))
+
+    def _read_cache_file(self, path):
+        """Read a cached CSV file."""
+        return pl.read_csv(path)
+
+    def _write_cache_file(self, df, path):
+        """Write a DataFrame to a CSV cache file."""
+        df.write_csv(path)
+
+    def _cache_file_suffix(self):
+        return ".csv"

--- a/investing_algorithm_framework/infrastructure/data_providers/json_url.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/json_url.py
@@ -1,0 +1,53 @@
+import json
+
+import polars as pl
+
+from .base_url import BaseURLDataProvider
+
+
+class JSONURLDataProvider(BaseURLDataProvider):
+    """
+    Data provider that fetches JSON data from a remote URL.
+
+    Supports caching, configurable date parsing, and pre/post
+    processing callbacks for data transformation.
+
+    This provider is automatically used when a DataSource is created
+    via ``DataSource.from_json()``.
+
+    The JSON data must be either:
+    - An array of objects (records orientation), or
+    - An object of arrays (columnar orientation).
+    """
+    data_provider_identifier = "json_url_data_provider"
+
+    def _parse_raw_data(self, raw_bytes):
+        """Parse raw JSON bytes into a Polars DataFrame."""
+        text = raw_bytes.decode("utf-8")
+        data = json.loads(text)
+
+        # Handle both list-of-dicts and dict-of-lists
+        if isinstance(data, list):
+            return pl.DataFrame(data)
+        elif isinstance(data, dict):
+            return pl.DataFrame(data)
+        else:
+            raise ValueError(
+                "JSON data must be an array of objects or an "
+                "object of arrays."
+            )
+
+    def _read_cache_file(self, path):
+        """Read a cached JSON file."""
+        with open(path, "r") as f:
+            data = json.load(f)
+        return pl.DataFrame(data)
+
+    def _write_cache_file(self, df, path):
+        """Write a DataFrame to a JSON cache file."""
+        records = df.to_dicts()
+        with open(path, "w") as f:
+            json.dump(records, f)
+
+    def _cache_file_suffix(self):
+        return ".json"

--- a/investing_algorithm_framework/infrastructure/data_providers/parquet_url.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/parquet_url.py
@@ -1,0 +1,36 @@
+from io import BytesIO
+
+import polars as pl
+
+from .base_url import BaseURLDataProvider
+
+
+class ParquetURLDataProvider(BaseURLDataProvider):
+    """
+    Data provider that fetches Parquet data from a remote URL.
+
+    Supports caching, configurable date parsing, and pre/post
+    processing callbacks for data transformation.
+
+    This provider is automatically used when a DataSource is created
+    via ``DataSource.from_parquet()``.
+
+    Note: Pre-processing callbacks are not applied for Parquet data
+    since Parquet is a binary format.
+    """
+    data_provider_identifier = "parquet_url_data_provider"
+
+    def _parse_raw_data(self, raw_bytes):
+        """Parse raw Parquet bytes into a Polars DataFrame."""
+        return pl.read_parquet(BytesIO(raw_bytes))
+
+    def _read_cache_file(self, path):
+        """Read a cached Parquet file."""
+        return pl.read_parquet(path)
+
+    def _write_cache_file(self, df, path):
+        """Write a DataFrame to a Parquet cache file."""
+        df.write_parquet(path)
+
+    def _cache_file_suffix(self):
+        return ".parquet"

--- a/tests/domain/models/data/test_data_source.py
+++ b/tests/domain/models/data/test_data_source.py
@@ -348,7 +348,14 @@ class TestDataSource(TestCase):
             "storage_path",
             "date",
             "identifier",
-            "warmup_window"
+            "warmup_window",
+            "url",
+            "date_column",
+            "date_format",
+            "cache",
+            "refresh_interval",
+            "pre_process",
+            "post_process"
         ]
 
         self.assertEqual(set(field_names), set(expected_fields))
@@ -362,7 +369,7 @@ class TestDataSource(TestCase):
 
         for field in fields(DataSource):
 
-            if field.name in ["save", "pandas"]:
+            if field.name in ["save", "pandas", "cache"]:
                 # These fields are expected to have a default value
                 self.assertIsNotNone(field.default)
             else:

--- a/tests/infrastructure/data_providers/test_csv_url_data_provider.py
+++ b/tests/infrastructure/data_providers/test_csv_url_data_provider.py
@@ -1,0 +1,317 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+import polars as pl
+
+from investing_algorithm_framework import DataSource, CSVURLDataProvider
+
+
+MOCK_TARGET = (
+    "investing_algorithm_framework.infrastructure.data_providers"
+    ".base_url.urllib.request.urlopen"
+)
+
+
+class TestDataSourceFromCsv(unittest.TestCase):
+    """Tests for the DataSource.from_csv() class method."""
+
+    def test_from_csv_creates_data_source(self):
+        """Test that from_csv creates a properly configured DataSource."""
+        ds = DataSource.from_csv(
+            identifier="sentiment",
+            url="https://example.com/data.csv",
+            date_column="date",
+            date_format="%Y-%m-%d",
+        )
+        self.assertEqual(ds.identifier, "sentiment")
+        self.assertEqual(ds.url, "https://example.com/data.csv")
+        self.assertEqual(ds.date_column, "date")
+        self.assertEqual(ds.date_format, "%Y-%m-%d")
+        self.assertEqual(
+            ds.data_provider_identifier, "csv_url_data_provider"
+        )
+        self.assertTrue(ds.cache)
+
+    def test_from_csv_with_all_options(self):
+        """Test from_csv with all optional parameters."""
+        pre = lambda x: x  # noqa: E731
+        post = lambda x: x  # noqa: E731
+
+        ds = DataSource.from_csv(
+            identifier="earnings",
+            url="https://example.com/earnings.csv",
+            date_column="report_date",
+            date_format="%m/%d/%Y",
+            cache=False,
+            refresh_interval="1d",
+            pre_process=pre,
+            post_process=post,
+        )
+        self.assertEqual(ds.identifier, "earnings")
+        self.assertEqual(ds.url, "https://example.com/earnings.csv")
+        self.assertFalse(ds.cache)
+        self.assertEqual(ds.refresh_interval, "1d")
+        self.assertEqual(ds.pre_process, pre)
+        self.assertEqual(ds.post_process, post)
+
+    def test_from_csv_get_identifier(self):
+        """Test that the identifier is returned correctly."""
+        ds = DataSource.from_csv(
+            identifier="my_data",
+            url="https://example.com/data.csv",
+        )
+        self.assertEqual(ds.get_identifier(), "my_data")
+
+    def test_from_csv_defaults(self):
+        """Test default values for optional parameters."""
+        ds = DataSource.from_csv(
+            identifier="test",
+            url="https://example.com/test.csv",
+        )
+        self.assertIsNone(ds.date_column)
+        self.assertIsNone(ds.date_format)
+        self.assertTrue(ds.cache)
+        self.assertIsNone(ds.refresh_interval)
+        self.assertIsNone(ds.pre_process)
+        self.assertIsNone(ds.post_process)
+
+
+class TestCSVURLDataProvider(unittest.TestCase):
+    """Tests for CSVURLDataProvider."""
+
+    CSV_CONTENT = "date,symbol,score\n2024-01-01,BTC,0.8\n2024-01-02,BTC,0.6"
+
+    def _mock_urlopen(self, csv_text=None):
+        """Create a mock for urllib.request.urlopen."""
+        if csv_text is None:
+            csv_text = self.CSV_CONTENT
+        response = MagicMock()
+        response.read.return_value = csv_text.encode("utf-8")
+        response.__enter__ = lambda s: s
+        response.__exit__ = MagicMock(return_value=False)
+        return response
+
+    def test_has_data_matches_csv_url_data_source(self):
+        """Test that has_data returns True for matching DataSources."""
+        provider = CSVURLDataProvider()
+        ds = DataSource.from_csv(
+            identifier="test",
+            url="https://example.com/test.csv",
+        )
+        self.assertTrue(provider.has_data(ds))
+
+    def test_has_data_rejects_non_csv_url(self):
+        """Test that has_data returns False for non-CSV URL DataSources."""
+        provider = CSVURLDataProvider()
+        ds = DataSource(
+            identifier="test",
+            data_type="OHLCV",
+            symbol="BTC/EUR",
+            market="BITVAVO",
+        )
+        self.assertFalse(provider.has_data(ds))
+
+    def test_has_data_rejects_no_url(self):
+        """Test that has_data returns False when no URL is set."""
+        provider = CSVURLDataProvider()
+        ds = DataSource(
+            identifier="test",
+            data_type="CUSTOM",
+            data_provider_identifier="csv_url_data_provider",
+        )
+        self.assertFalse(provider.has_data(ds))
+
+    @patch(MOCK_TARGET)
+    def test_get_data_fetches_and_parses_csv(self, mock_urlopen):
+        """Test that get_data fetches and parses CSV correctly."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIsInstance(df, pl.DataFrame)
+        self.assertEqual(len(df), 2)
+        self.assertIn("date", df.columns)
+        self.assertIn("symbol", df.columns)
+        self.assertIn("score", df.columns)
+
+    @patch(MOCK_TARGET)
+    def test_get_data_with_date_parsing(self, mock_urlopen):
+        """Test date column parsing."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            date_column="date",
+            date_format="%Y-%m-%d",
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertEqual(df["date"].dtype, pl.Datetime)
+
+    @patch(MOCK_TARGET)
+    def test_get_data_with_pre_process(self, mock_urlopen):
+        """Test pre-processing callback."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        def add_header_comment(text):
+            # Remove any comment lines
+            lines = [line for line in text.split("\n") if not line.startswith("#")]
+            return "\n".join(lines)
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            pre_process=add_header_comment,
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIsInstance(df, pl.DataFrame)
+        self.assertEqual(len(df), 2)
+
+    @patch(MOCK_TARGET)
+    def test_get_data_with_post_process(self, mock_urlopen):
+        """Test post-processing callback."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        def add_column(df):
+            return df.with_columns(
+                (pl.col("score") * 100).alias("score_pct")
+            )
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            post_process=add_column,
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIn("score_pct", df.columns)
+        self.assertAlmostEqual(df["score_pct"][0], 80.0)
+
+    @patch(MOCK_TARGET)
+    def test_caching_does_not_refetch(self, mock_urlopen):
+        """Test that cached data is reused without re-fetching."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            cache=True,
+        )
+        # Disable file-based cache to isolate in-memory caching
+        provider._get_cache_path = lambda: None
+
+        # First call fetches
+        df1 = provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+        # Second call uses cache
+        df2 = provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+        self.assertEqual(len(df1), len(df2))
+
+    @patch(MOCK_TARGET)
+    def test_no_cache_refetches(self, mock_urlopen):
+        """Test that disabling cache causes re-fetching."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            cache=False,
+        )
+
+        provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+        # Re-create mock for second call
+        mock_urlopen.return_value = self._mock_urlopen()
+        provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 2)
+
+    def test_copy_preserves_config(self):
+        """Test that copy() preserves provider configuration."""
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            date_column="date",
+            date_format="%Y-%m-%d",
+            cache=True,
+            refresh_interval="1d",
+        )
+
+        copied = provider.copy()
+        self.assertEqual(copied._url, "https://example.com/data.csv")
+        self.assertEqual(copied._date_column, "date")
+        self.assertEqual(copied._date_format, "%Y-%m-%d")
+        self.assertTrue(copied._cache)
+        self.assertEqual(copied._refresh_interval, "1d")
+
+    def test_copy_with_data_source_overrides(self):
+        """Test that copy() uses data source values when available."""
+        provider = CSVURLDataProvider(
+            url="https://example.com/default.csv",
+        )
+
+        ds = DataSource.from_csv(
+            identifier="test",
+            url="https://example.com/override.csv",
+            date_column="my_date",
+        )
+
+        copied = provider.copy(data_source=ds)
+        self.assertEqual(copied._url, "https://example.com/override.csv")
+        self.assertEqual(copied._date_column, "my_date")
+
+    def test_raises_on_missing_url(self):
+        """Test that fetching without a URL raises ValueError."""
+        provider = CSVURLDataProvider(cache=False)
+
+        with self.assertRaises(ValueError):
+            provider.get_data()
+
+    @patch(MOCK_TARGET)
+    def test_prepare_backtest_data(self, mock_urlopen):
+        """Test that prepare_backtest_data pre-fetches the data."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            cache=False,
+        )
+
+        from datetime import datetime, timezone
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 12, 31, tzinfo=timezone.utc)
+
+        provider.prepare_backtest_data(start, end)
+        self.assertIsNotNone(provider._cached_data)
+
+    @patch(MOCK_TARGET)
+    def test_get_backtest_data_returns_data(self, mock_urlopen):
+        """Test that get_backtest_data returns cached data."""
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = CSVURLDataProvider(
+            url="https://example.com/data.csv",
+            cache=False,
+        )
+
+        from datetime import datetime, timezone
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 12, 31, tzinfo=timezone.utc)
+
+        provider.prepare_backtest_data(start, end)
+        df = provider.get_backtest_data(
+            backtest_index_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            backtest_start_date=start,
+            backtest_end_date=end,
+        )
+        self.assertIsInstance(df, pl.DataFrame)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infrastructure/data_providers/test_json_url_data_provider.py
+++ b/tests/infrastructure/data_providers/test_json_url_data_provider.py
@@ -1,0 +1,226 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+import polars as pl
+
+from investing_algorithm_framework import DataSource, JSONURLDataProvider
+
+
+MOCK_TARGET = (
+    "investing_algorithm_framework.infrastructure.data_providers"
+    ".base_url.urllib.request.urlopen"
+)
+
+
+class TestDataSourceFromJson(unittest.TestCase):
+    """Tests for the DataSource.from_json() class method."""
+
+    def test_from_json_creates_data_source(self):
+        ds = DataSource.from_json(
+            identifier="earnings",
+            url="https://api.example.com/earnings.json",
+            date_column="date",
+            date_format="%Y-%m-%d",
+        )
+        self.assertEqual(ds.identifier, "earnings")
+        self.assertEqual(ds.url, "https://api.example.com/earnings.json")
+        self.assertEqual(ds.date_column, "date")
+        self.assertEqual(ds.date_format, "%Y-%m-%d")
+        self.assertEqual(
+            ds.data_provider_identifier, "json_url_data_provider"
+        )
+        self.assertTrue(ds.cache)
+
+    def test_from_json_defaults(self):
+        ds = DataSource.from_json(
+            identifier="test",
+            url="https://example.com/test.json",
+        )
+        self.assertIsNone(ds.date_column)
+        self.assertIsNone(ds.date_format)
+        self.assertTrue(ds.cache)
+        self.assertIsNone(ds.refresh_interval)
+        self.assertIsNone(ds.pre_process)
+        self.assertIsNone(ds.post_process)
+
+
+class TestJSONURLDataProvider(unittest.TestCase):
+    """Tests for JSONURLDataProvider."""
+
+    JSON_RECORDS = [
+        {"date": "2024-01-01", "symbol": "BTC", "score": 0.8},
+        {"date": "2024-01-02", "symbol": "BTC", "score": 0.6},
+    ]
+
+    def _mock_urlopen(self, data=None):
+        if data is None:
+            data = self.JSON_RECORDS
+        response = MagicMock()
+        response.read.return_value = json.dumps(data).encode("utf-8")
+        response.__enter__ = lambda s: s
+        response.__exit__ = MagicMock(return_value=False)
+        return response
+
+    def test_has_data_matches_json_url_data_source(self):
+        provider = JSONURLDataProvider()
+        ds = DataSource.from_json(
+            identifier="test",
+            url="https://example.com/test.json",
+        )
+        self.assertTrue(provider.has_data(ds))
+
+    def test_has_data_rejects_non_json_url(self):
+        provider = JSONURLDataProvider()
+        ds = DataSource(
+            identifier="test",
+            data_type="OHLCV",
+            symbol="BTC/EUR",
+            market="BITVAVO",
+        )
+        self.assertFalse(provider.has_data(ds))
+
+    def test_has_data_rejects_csv_provider(self):
+        provider = JSONURLDataProvider()
+        ds = DataSource.from_csv(
+            identifier="test",
+            url="https://example.com/test.csv",
+        )
+        self.assertFalse(provider.has_data(ds))
+
+    @patch(MOCK_TARGET)
+    def test_get_data_fetches_and_parses_json_records(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = JSONURLDataProvider(
+            url="https://example.com/data.json",
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIsInstance(df, pl.DataFrame)
+        self.assertEqual(len(df), 2)
+        self.assertIn("date", df.columns)
+        self.assertIn("symbol", df.columns)
+        self.assertIn("score", df.columns)
+
+    @patch(MOCK_TARGET)
+    def test_get_data_fetches_columnar_json(self, mock_urlopen):
+        columnar = {
+            "date": ["2024-01-01", "2024-01-02"],
+            "symbol": ["BTC", "BTC"],
+            "score": [0.8, 0.6],
+        }
+        mock_urlopen.return_value = self._mock_urlopen(columnar)
+
+        provider = JSONURLDataProvider(
+            url="https://example.com/data.json",
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIsInstance(df, pl.DataFrame)
+        self.assertEqual(len(df), 2)
+
+    @patch(MOCK_TARGET)
+    def test_get_data_with_date_parsing(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = JSONURLDataProvider(
+            url="https://example.com/data.json",
+            date_column="date",
+            date_format="%Y-%m-%d",
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertEqual(df["date"].dtype, pl.Datetime)
+
+    @patch(MOCK_TARGET)
+    def test_get_data_with_post_process(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        def add_column(df):
+            return df.with_columns(
+                (pl.col("score") * 100).alias("score_pct")
+            )
+
+        provider = JSONURLDataProvider(
+            url="https://example.com/data.json",
+            post_process=add_column,
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIn("score_pct", df.columns)
+
+    @patch(MOCK_TARGET)
+    def test_caching_does_not_refetch(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = JSONURLDataProvider(
+            url="https://example.com/data.json",
+            cache=True,
+        )
+        # Disable file-based cache to isolate in-memory caching
+        provider._get_cache_path = lambda: None
+
+        provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+        provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+    def test_copy_preserves_config(self):
+        provider = JSONURLDataProvider(
+            url="https://example.com/data.json",
+            date_column="date",
+            cache=True,
+        )
+
+        copied = provider.copy()
+        self.assertEqual(copied._url, "https://example.com/data.json")
+        self.assertEqual(copied._date_column, "date")
+        self.assertIsInstance(copied, JSONURLDataProvider)
+
+    def test_copy_with_data_source_overrides(self):
+        provider = JSONURLDataProvider(
+            url="https://example.com/default.json",
+        )
+
+        ds = DataSource.from_json(
+            identifier="test",
+            url="https://example.com/override.json",
+            date_column="my_date",
+        )
+
+        copied = provider.copy(data_source=ds)
+        self.assertEqual(
+            copied._url, "https://example.com/override.json"
+        )
+        self.assertEqual(copied._date_column, "my_date")
+
+    def test_raises_on_missing_url(self):
+        provider = JSONURLDataProvider(cache=False)
+        with self.assertRaises(ValueError):
+            provider.get_data()
+
+    @patch(MOCK_TARGET)
+    def test_prepare_backtest_data(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = JSONURLDataProvider(
+            url="https://example.com/data.json",
+            cache=False,
+        )
+
+        from datetime import datetime, timezone
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 12, 31, tzinfo=timezone.utc)
+
+        provider.prepare_backtest_data(start, end)
+        self.assertIsNotNone(provider._cached_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infrastructure/data_providers/test_parquet_url_data_provider.py
+++ b/tests/infrastructure/data_providers/test_parquet_url_data_provider.py
@@ -1,0 +1,184 @@
+import io
+import unittest
+from unittest.mock import patch, MagicMock
+
+import polars as pl
+
+from investing_algorithm_framework import DataSource, ParquetURLDataProvider
+
+
+MOCK_TARGET = (
+    "investing_algorithm_framework.infrastructure.data_providers"
+    ".base_url.urllib.request.urlopen"
+)
+
+
+def _make_parquet_bytes(df):
+    """Helper to serialize a Polars DataFrame to Parquet bytes."""
+    buf = io.BytesIO()
+    df.write_parquet(buf)
+    return buf.getvalue()
+
+
+class TestDataSourceFromParquet(unittest.TestCase):
+    """Tests for the DataSource.from_parquet() class method."""
+
+    def test_from_parquet_creates_data_source(self):
+        ds = DataSource.from_parquet(
+            identifier="features",
+            url="https://storage.example.com/features.parquet",
+            date_column="date",
+        )
+        self.assertEqual(ds.identifier, "features")
+        self.assertEqual(
+            ds.url, "https://storage.example.com/features.parquet"
+        )
+        self.assertEqual(ds.date_column, "date")
+        self.assertEqual(
+            ds.data_provider_identifier, "parquet_url_data_provider"
+        )
+        self.assertTrue(ds.cache)
+
+    def test_from_parquet_defaults(self):
+        ds = DataSource.from_parquet(
+            identifier="test",
+            url="https://example.com/test.parquet",
+        )
+        self.assertIsNone(ds.date_column)
+        self.assertIsNone(ds.date_format)
+        self.assertTrue(ds.cache)
+        self.assertIsNone(ds.refresh_interval)
+        self.assertIsNone(ds.post_process)
+
+    def test_from_parquet_no_pre_process(self):
+        """from_parquet should not accept pre_process."""
+        # Parquet is binary, pre_process (text-based) is not supported
+        import inspect
+        sig = inspect.signature(DataSource.from_parquet)
+        self.assertNotIn("pre_process", sig.parameters)
+
+
+class TestParquetURLDataProvider(unittest.TestCase):
+    """Tests for ParquetURLDataProvider."""
+
+    SAMPLE_DF = pl.DataFrame({
+        "date": ["2024-01-01", "2024-01-02"],
+        "symbol": ["BTC", "BTC"],
+        "score": [0.8, 0.6],
+    })
+
+    def _mock_urlopen(self, df=None):
+        if df is None:
+            df = self.SAMPLE_DF
+        parquet_bytes = _make_parquet_bytes(df)
+        response = MagicMock()
+        response.read.return_value = parquet_bytes
+        response.__enter__ = lambda s: s
+        response.__exit__ = MagicMock(return_value=False)
+        return response
+
+    def test_has_data_matches_parquet_url_data_source(self):
+        provider = ParquetURLDataProvider()
+        ds = DataSource.from_parquet(
+            identifier="test",
+            url="https://example.com/test.parquet",
+        )
+        self.assertTrue(provider.has_data(ds))
+
+    def test_has_data_rejects_csv_provider(self):
+        provider = ParquetURLDataProvider()
+        ds = DataSource.from_csv(
+            identifier="test",
+            url="https://example.com/test.csv",
+        )
+        self.assertFalse(provider.has_data(ds))
+
+    @patch(MOCK_TARGET)
+    def test_get_data_fetches_and_parses_parquet(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = ParquetURLDataProvider(
+            url="https://example.com/data.parquet",
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIsInstance(df, pl.DataFrame)
+        self.assertEqual(len(df), 2)
+        self.assertIn("date", df.columns)
+        self.assertIn("symbol", df.columns)
+        self.assertIn("score", df.columns)
+
+    @patch(MOCK_TARGET)
+    def test_get_data_with_post_process(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        def add_column(df):
+            return df.with_columns(
+                (pl.col("score") * 100).alias("score_pct")
+            )
+
+        provider = ParquetURLDataProvider(
+            url="https://example.com/data.parquet",
+            post_process=add_column,
+            cache=False,
+        )
+
+        df = provider.get_data()
+        self.assertIn("score_pct", df.columns)
+
+    @patch(MOCK_TARGET)
+    def test_caching_does_not_refetch(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = ParquetURLDataProvider(
+            url="https://example.com/data.parquet",
+            cache=True,
+        )
+        # Disable file-based cache to isolate in-memory caching
+        provider._get_cache_path = lambda: None
+
+        provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+        provider.get_data()
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+    def test_copy_preserves_config(self):
+        provider = ParquetURLDataProvider(
+            url="https://example.com/data.parquet",
+            date_column="date",
+            cache=True,
+        )
+
+        copied = provider.copy()
+        self.assertEqual(
+            copied._url, "https://example.com/data.parquet"
+        )
+        self.assertEqual(copied._date_column, "date")
+        self.assertIsInstance(copied, ParquetURLDataProvider)
+
+    def test_raises_on_missing_url(self):
+        provider = ParquetURLDataProvider(cache=False)
+        with self.assertRaises(ValueError):
+            provider.get_data()
+
+    @patch(MOCK_TARGET)
+    def test_prepare_backtest_data(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = ParquetURLDataProvider(
+            url="https://example.com/data.parquet",
+            cache=False,
+        )
+
+        from datetime import datetime, timezone
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 12, 31, tzinfo=timezone.utc)
+
+        provider.prepare_backtest_data(start, end)
+        self.assertIsNotNone(provider._cached_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add support for loading external CSV, JSON, and Parquet data from any URL during strategy execution.

### Changes

- **BaseURLDataProvider** — shared base class with caching (in-memory + file), refresh intervals, date parsing, and pre/post-processing callbacks
- **CSVURLDataProvider**, **JSONURLDataProvider**, **ParquetURLDataProvider** — format-specific implementations
- **DataSource.from_csv()**, **from_json()**, **from_parquet()** — factory methods for pre-declared data sources
- **context.fetch_csv()**, **fetch_json()**, **fetch_parquet()** — on-demand methods for dynamic fetching
- **Cache path fix** — cache files now stored inside `resources/data/` (synced by state handlers in cloud deployments) instead of a detached `.data_cache/` directory
- **43 tests** covering all three providers
- **Documentation** — new `external-data.md` docs page, sidebar registration, README updates

### Cloud deployment support

Cache files live inside the resource directory, so `AWSS3StorageStateHandler` and `AzureBlobStorageStateHandler` automatically persist them. `refresh_interval` works correctly across cold starts using file modification times.

Closes #458