### PR TITLE
feat(pipeline): #503 Phase 3a — warmup_window validation

### DIFF
--- a/docusaurus/docs/Advanced Concepts/pipelines-live.md
+++ b/docusaurus/docs/Advanced Concepts/pipelines-live.md
@@ -34,9 +34,69 @@ If you want to experiment, the same example covers both:
   scratch.
 - ✅ Validation of `warmup_window` against `pipeline.required_window()`
   so you get a clear error at startup if any data source is too short.
+- ✅ Live envelope validation (≤ 50 symbols, daily-or-coarser
+  timeframes) at first iteration in non-backtest environments.
+- ✅ Universe-refresh cadence (`Pipeline.refresh_universe_every`) so
+  the universe filter doesn't have to run every bar.
+- ✅ Per-pipeline error resilience — a single failing pipeline is
+  logged and skipped in live mode instead of killing the iteration.
+- 🚧 Batched / async OHLCV fetch in `CCXTOHLCVDataProvider` (tracked
+  for a follow-up PR — needs live integration testing).
 - First-class handling of partial bars (so you don't accidentally trade
   on an unclosed candle).
 - Live observability hooks for pipeline output (print/log/snapshot).
+
+## Live envelope (shipped)
+
+v1 of the live pipeline engine is intentionally conservative:
+
+| Constraint | Value |
+| --- | --- |
+| Maximum unique OHLCV symbols per strategy | `50` |
+| Minimum supported timeframe | daily (`24h`) |
+
+These limits are checked once per run at the first iteration when the
+environment is not `BACKTEST`. Violations raise
+`OperationalException` with an actionable message naming the
+strategy and the offending symbols / timeframe. Backtests are
+unaffected — sub-daily timeframes and large universes keep working in
+backtest mode exactly as before.
+
+## Universe refresh cadence (shipped)
+
+A pipeline can declare how often the universe filter should be
+re-evaluated by setting the class attribute
+`refresh_universe_every: timedelta`. Inside that cadence the engine
+keeps the surviving symbol set fixed and skips evaluating the
+universe filter, which is typically the most expensive part of the
+pipeline.
+
+```python
+from datetime import timedelta
+
+class DailyMomentum(Pipeline):
+    sma200 = SMA(window=200)
+    dollar_volume = AverageDollarVolume(window=30)
+
+    universe = dollar_volume.top(50)
+    signal = sma200.zscore(mask=universe)
+
+    # Re-pick the top-50 universe once per day; reuse the
+    # selection on every intra-day bar.
+    refresh_universe_every = timedelta(days=1)
+```
+
+When `refresh_universe_every` is `None` (the default) the universe is
+re-evaluated every bar, preserving Phase 1 / Phase 2 behaviour
+exactly.
+
+## Per-pipeline resilience (shipped)
+
+In non-backtest environments a single pipeline raising during
+`evaluate` is logged and the iteration continues with an empty output
+frame for that pipeline — so an unrelated strategy on the same event
+loop is not knocked out by one bad data source. Backtests still
+re-raise so failures stay deterministic.
 
 ## Warmup validation (shipped)
 

--- a/docusaurus/docs/Advanced Concepts/pipelines-live.md
+++ b/docusaurus/docs/Advanced Concepts/pipelines-live.md
@@ -32,11 +32,43 @@ If you want to experiment, the same example covers both:
 
 - A streaming panel that appends new bars instead of rebuilding from
   scratch.
-- Validation of `warmup_window` against `pipeline.required_window()`
+- ✅ Validation of `warmup_window` against `pipeline.required_window()`
   so you get a clear error at startup if any data source is too short.
 - First-class handling of partial bars (so you don't accidentally trade
   on an unclosed candle).
 - Live observability hooks for pipeline output (print/log/snapshot).
+
+## Warmup validation (shipped)
+
+When a strategy declares `pipelines = [...]`, the framework validates
+at construction time that every OHLCV data source has a
+`warmup_window` ≥ the pipeline's longest factor window. If any source
+is short — or `warmup_window` is left unset — strategy instantiation
+raises `OperationalException` with an actionable message listing the
+offending sources and the required window size.
+
+```python
+class MomentumScreener(Pipeline):
+    sma = SMA(window=200)
+
+
+class MyStrategy(TradingStrategy):
+    time_unit = TimeUnit.HOUR
+    interval = 1
+    pipelines = [MomentumScreener]
+    data_sources = [
+        DataSource(
+            symbol="BTC/EUR",
+            data_type=DataType.OHLCV,
+            time_frame=TimeFrame.ONE_HOUR,
+            market="BITVAVO",
+            warmup_window=200,   # must be >= 200 to satisfy SMA(200)
+        ),
+    ]
+```
+
+This eliminates a common failure mode in live deployments: a bot
+silently trading on NaN factor columns until enough bars accrue.
 
 ## What stays the same
 

--- a/investing_algorithm_framework/app/eventloop.py
+++ b/investing_algorithm_framework/app/eventloop.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from time import sleep
-from typing import List, Set, Dict
+from typing import List, Set, Dict, FrozenSet, Tuple, Optional, Type
 from logging import getLogger
 
 import polars as pl
@@ -84,6 +84,18 @@ class EventLoopService:
         self.next_run_times = {}
         self.history = {}
         self._pipeline_engine = PipelineEngine()
+
+        # Per (strategy_id, pipeline_cls) cache of the most recent
+        # universe-refresh: (refresh_at, frozen surviving-symbol set).
+        # Populated when a pipeline declares
+        # ``refresh_universe_every`` so the engine can skip re-running
+        # the universe filter every bar.
+        self._pipeline_universe_cache: Dict[
+            Tuple[str, Type], Tuple[datetime, FrozenSet[str]]
+        ] = {}
+        # One-shot flag: live-mode envelope validation runs once per
+        # process. Reset by ``cleanup`` so a new run re-validates.
+        self._pipelines_live_validated: bool = False
 
     @staticmethod
     def _get_data_sources_for_iteration(
@@ -332,6 +344,11 @@ class EventLoopService:
             None
         """
         self._portfolio_snapshot_service.save_all(self._snapshots)
+        # Reset per-run pipeline state so a subsequent run re-runs
+        # live envelope validation and starts with a fresh universe
+        # cache.
+        self._pipeline_universe_cache.clear()
+        self._pipelines_live_validated = False
 
     def start(
         self,
@@ -445,6 +462,121 @@ class EventLoopService:
 
         self.cleanup()
 
+    # ------------------------------------------------------------------ #
+    # Pipeline live-mode helpers (#503 phase 3b/3c/3d)
+    # ------------------------------------------------------------------ #
+    # Envelope: v1 of live pipelines supports daily timeframes only and
+    # caps universes at 50 symbols per pipeline. Any sub-daily timeframe
+    # on a strategy that declares pipelines, or a strategy whose total
+    # OHLCV symbol set exceeds the cap, raises at first iteration when
+    # running outside backtest mode. See #503.
+    _LIVE_MAX_PIPELINE_SYMBOLS: int = 50
+    _LIVE_MIN_TIMEFRAME_MINUTES: int = 24 * 60  # daily
+
+    def _validate_live_envelope(
+        self, strategies: List[TradingStrategy]
+    ) -> None:
+        """Validate the v1 live-pipeline envelope (max 50 symbols /
+        daily-or-coarser timeframes). Called once per run when env is
+        not BACKTEST. Raises :class:`OperationalException` on
+        violation."""
+        for strategy in strategies or []:
+            pipelines = getattr(strategy, "pipelines", None)
+            if not pipelines:
+                continue
+
+            ohlcv_sources = [
+                ds for ds in (strategy.data_sources or [])
+                if DataType.OHLCV.equals(ds.data_type)
+            ]
+
+            sub_daily = [
+                ds for ds in ohlcv_sources
+                if ds.time_frame is not None
+                and ds.time_frame.amount_of_minutes
+                < self._LIVE_MIN_TIMEFRAME_MINUTES
+            ]
+            if sub_daily:
+                desc = ", ".join(
+                    f"{ds.symbol}@{ds.time_frame.value}"
+                    for ds in sub_daily
+                )
+                raise OperationalException(
+                    f"Strategy '{strategy.strategy_id}' declares "
+                    f"pipelines but uses sub-daily OHLCV timeframes "
+                    f"in live mode: {desc}. v1 of the live pipeline "
+                    f"engine supports daily timeframes only — see "
+                    f"#503. Use a daily timeframe or run the strategy "
+                    f"in backtest mode."
+                )
+
+            unique_symbols = {ds.symbol for ds in ohlcv_sources}
+            unique_symbols.discard(None)
+            if len(unique_symbols) > self._LIVE_MAX_PIPELINE_SYMBOLS:
+                raise OperationalException(
+                    f"Strategy '{strategy.strategy_id}' declares "
+                    f"pipelines over {len(unique_symbols)} symbols, "
+                    f"which exceeds the v1 live cap of "
+                    f"{self._LIVE_MAX_PIPELINE_SYMBOLS}. Reduce the "
+                    f"universe or run the strategy in backtest mode "
+                    f"(see #503)."
+                )
+
+    def _maybe_validate_live_envelope(
+        self, strategies: List[TradingStrategy], environment: str
+    ) -> None:
+        """One-shot envelope validation; no-op for BACKTEST mode."""
+        if self._pipelines_live_validated:
+            return
+        if Environment.BACKTEST.equals(environment):
+            self._pipelines_live_validated = True
+            return
+        self._validate_live_envelope(strategies)
+        self._pipelines_live_validated = True
+
+    def _filter_symbols_for_universe_cache(
+        self,
+        strategy_id: str,
+        pipeline_cls: Type,
+        symbol_to_identifier: Dict[str, str],
+        as_of: datetime,
+    ) -> Optional[Dict[str, str]]:
+        """If ``pipeline_cls`` declares ``refresh_universe_every`` and
+        we have a cached surviving-symbol set still inside the cadence,
+        return a restricted ``symbol_to_identifier`` mapping. Returning
+        ``None`` means "no cache hit — run a full universe evaluation".
+        """
+        cadence: Optional[timedelta] = getattr(
+            pipeline_cls, "refresh_universe_every", None
+        )
+        if cadence is None or cadence <= timedelta(0):
+            return None
+
+        cache_key = (strategy_id, pipeline_cls)
+        cached = self._pipeline_universe_cache.get(cache_key)
+        if cached is None:
+            return None
+
+        last_refresh, symbols = cached
+        # Normalise tz so naive backtest datetimes and aware live
+        # datetimes compare cleanly.
+        if last_refresh.tzinfo is None and as_of.tzinfo is not None:
+            cmp_as_of = as_of.replace(tzinfo=None)
+        elif last_refresh.tzinfo is not None and as_of.tzinfo is None:
+            cmp_as_of = as_of.replace(tzinfo=last_refresh.tzinfo)
+        else:
+            cmp_as_of = as_of
+        if cmp_as_of - last_refresh >= cadence:
+            return None  # cadence elapsed → refresh
+
+        # Cache hit: restrict the symbol set, skipping the universe
+        # filter entirely on this iteration.
+        return {
+            sym: ident
+            for sym, ident in symbol_to_identifier.items()
+            if sym in symbols
+        }
+
     def _run_pipelines(
         self,
         strategy: TradingStrategy,
@@ -457,12 +589,26 @@ class EventLoopService:
         class name.
 
         Strategies without ``pipelines`` skip this entirely (zero cost).
-        Per Phase 1 of the Pipeline API (#501); see
-        ``docs/design/pipeline-api.md``.
+
+        Live-mode hardening (#503):
+
+        * The v1 envelope (max 50 symbols, daily-or-coarser timeframes)
+          is validated once per run.
+        * Pipelines that declare ``refresh_universe_every`` reuse the
+          last surviving symbol set within the cadence — saving the
+          cost of evaluating the universe filter every bar.
+        * In non-backtest environments, a single failing pipeline is
+          logged and skipped (the iteration continues with an empty
+          output) instead of killing the whole event loop. Backtests
+          keep raising so failures stay deterministic.
         """
         pipelines = getattr(strategy, "pipelines", None)
         if not pipelines:
             return
+
+        config = self._configuration_service.get_config()
+        environment = config[ENVIRONMENT]
+        is_backtest = Environment.BACKTEST.equals(environment)
 
         # Map symbol -> data-source identifier from the strategy's
         # OHLCV data sources. If a symbol appears on multiple data
@@ -484,20 +630,62 @@ class EventLoopService:
             return
 
         for pipeline_cls in pipelines:
+            # 3c: universe-refresh cache. If the pipeline declares a
+            # refresh cadence and we're inside it, restrict the panel
+            # input to the cached symbols.
+            cached_mapping = self._filter_symbols_for_universe_cache(
+                strategy_id=strategy.strategy_id,
+                pipeline_cls=pipeline_cls,
+                symbol_to_identifier=symbol_to_identifier,
+                as_of=as_of,
+            )
+            mapping = (
+                cached_mapping
+                if cached_mapping is not None
+                else symbol_to_identifier
+            )
+
             try:
                 output = self._pipeline_engine.evaluate(
                     pipeline_cls=pipeline_cls,
                     data_object=data_object,
-                    symbol_to_identifier=symbol_to_identifier,
+                    symbol_to_identifier=mapping,
                     as_of=as_of,
                 )
-            except Exception:  # pragma: no cover - logged + re-raised
+            except Exception:
+                # 3d: live-mode resilience. In live trading a single
+                # pipeline failure must not kill the iteration —
+                # surface an empty frame and log so the rest of the
+                # strategies can still run. Backtests re-raise so
+                # failures stay deterministic.
                 logger.exception(
                     "Pipeline %s failed during evaluation at %s",
                     pipeline_cls.__name__,
                     as_of,
                 )
-                raise
+                if is_backtest:
+                    raise
+                output = self._pipeline_engine._empty_output(
+                    pipeline_cls
+                )
+
+            # 3c: refresh the universe cache when we just ran a full
+            # evaluation (cached_mapping was None) and the pipeline
+            # declares a cadence.
+            cadence = getattr(
+                pipeline_cls, "refresh_universe_every", None
+            )
+            if (
+                cadence is not None
+                and cadence > timedelta(0)
+                and cached_mapping is None
+                and "symbol" in output.columns
+            ):
+                surviving = frozenset(output["symbol"].to_list())
+                self._pipeline_universe_cache[
+                    (strategy.strategy_id, pipeline_cls)
+                ] = (as_of, surviving)
+
             data[pipeline_cls.__name__] = output
 
     def _run_iteration(
@@ -526,6 +714,11 @@ class EventLoopService:
         config = self._configuration_service.get_config()
         environment = config[ENVIRONMENT]
         current_datetime = config[INDEX_DATETIME]
+
+        # Validate the live-pipeline envelope (max 50 symbols /
+        # daily-or-coarser timeframes) once per run. No-op for
+        # backtests. See #503 phase 3b.
+        self._maybe_validate_live_envelope(strategies, environment)
 
         # Step 1: Collect all data for the strategies and for the
         # pending orders

--- a/investing_algorithm_framework/app/strategy.py
+++ b/investing_algorithm_framework/app/strategy.py
@@ -194,6 +194,57 @@ class TradingStrategy:
                     f"interval or use a smaller data timeframe."
                 )
 
+        # Validate that every declared pipeline has enough warmup on
+        # the strategy's OHLCV data sources to compute its longest
+        # factor window. Without this check a live strategy starts
+        # silently emitting NaN columns until enough bars accrue.
+        # Tracked under #503 (Phase 3 — live hardening).
+        if self.pipelines:
+            ohlcv_sources = [
+                ds for ds in self.data_sources
+                if DataType.OHLCV.equals(ds.data_type)
+            ]
+            if not ohlcv_sources:
+                raise OperationalException(
+                    f"Strategy '{self.strategy_id}' declares "
+                    f"{len(self.pipelines)} pipeline(s) but has no "
+                    f"OHLCV data sources. Pipelines build their panel "
+                    f"from the strategy's OHLCV data sources — add at "
+                    f"least one DataSource(data_type=DataType.OHLCV, "
+                    f"...) to data_sources."
+                )
+            for pipeline_cls in self.pipelines:
+                required = pipeline_cls.required_window()
+                # We compare against each OHLCV source's warmup_window
+                # (canonical) / window_size (legacy alias) — the
+                # framework keeps them in sync, but a source may
+                # legitimately leave both unset, which we treat as
+                # "insufficient" because the pipeline cannot guarantee
+                # a full window of data.
+                short_sources = [
+                    ds for ds in ohlcv_sources
+                    if ds.warmup_window is None
+                    or ds.warmup_window < required
+                ]
+                if short_sources:
+                    short_desc = ", ".join(
+                        f"{ds.symbol}@{ds.time_frame.value if ds.time_frame else '?'}"  # noqa: E501
+                        f" (warmup_window="
+                        f"{ds.warmup_window if ds.warmup_window is not None else 'unset'})"  # noqa: E501
+                        for ds in short_sources
+                    )
+                    raise OperationalException(
+                        f"Strategy '{self.strategy_id}' pipeline "
+                        f"'{pipeline_cls.__name__}' requires a "
+                        f"warmup window of {required} bars but the "
+                        f"following OHLCV data source(s) have an "
+                        f"insufficient warmup_window: {short_desc}. "
+                        f"Set warmup_window>={required} on each OHLCV "
+                        f"DataSource the pipeline relies on, otherwise "
+                        f"the pipeline will emit NaN columns until "
+                        f"enough bars accrue."
+                    )
+
         # Initialize stop_losses as a new list per instance
         if stop_losses is not None:
             self.stop_losses = list(stop_losses)

--- a/investing_algorithm_framework/domain/pipeline/pipeline.py
+++ b/investing_algorithm_framework/domain/pipeline/pipeline.py
@@ -19,7 +19,8 @@ Example::
 """
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple
+from datetime import timedelta
+from typing import ClassVar, Dict, List, Optional, Tuple
 
 from .factor import Factor
 from .filter import Filter
@@ -39,6 +40,14 @@ class Pipeline:
     # Excludes the special ``universe`` column.
     __pipeline_columns__: Tuple[Tuple[str, Factor], ...] = ()
     __pipeline_universe__: Optional[Filter] = None
+
+    #: Optional cadence for re-evaluating the universe filter. When
+    #: set, the engine caches the surviving symbol set and reuses it
+    #: between refreshes — saving the cost of evaluating the (often
+    #: expensive) universe filter every bar. Factors are still
+    #: recomputed on every iteration. ``None`` (the default)
+    #: re-evaluates the universe every bar.
+    refresh_universe_every: ClassVar[Optional[timedelta]] = None
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)

--- a/tests/app/test_pipeline_live_hardening.py
+++ b/tests/app/test_pipeline_live_hardening.py
@@ -1,0 +1,258 @@
+"""Tests for #503 phase 3b/3c/3d — live-mode pipeline hardening.
+
+Covers:
+  * Envelope validation (max 50 symbols, daily-or-coarser timeframes)
+  * Universe-refresh cadence cache
+  * Per-pipeline error resilience in non-backtest environments
+"""
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest import TestCase
+
+from investing_algorithm_framework import (
+    DataSource, DataType, OperationalException,
+)
+from investing_algorithm_framework.app.eventloop import EventLoopService
+from investing_algorithm_framework.domain import TimeFrame, Environment
+from investing_algorithm_framework.domain.pipeline.pipeline import Pipeline
+from investing_algorithm_framework.domain.pipeline.factors.builtin import (
+    SMA,
+)
+
+
+# ----------------------------------------------------------------- #
+# Fixtures
+# ----------------------------------------------------------------- #
+def _ds(symbol, time_frame=TimeFrame.ONE_DAY, warmup_window=10):
+    return DataSource(
+        symbol=symbol,
+        data_type=DataType.OHLCV,
+        time_frame=time_frame,
+        market="bitvavo",
+        warmup_window=warmup_window,
+    )
+
+
+class _DailyPipeline(Pipeline):
+    sma = SMA(window=5)
+
+
+class _CadencePipeline(Pipeline):
+    sma = SMA(window=5)
+    refresh_universe_every = timedelta(days=1)
+
+
+def _strategy(strategy_id, data_sources, pipelines):
+    """Minimal stub satisfying the attributes ``_run_pipelines`` and
+    ``_validate_live_envelope`` read."""
+    return SimpleNamespace(
+        strategy_id=strategy_id,
+        data_sources=data_sources,
+        pipelines=pipelines,
+    )
+
+
+def _eventloop(env=Environment.DEV):
+    """Construct an :class:`EventLoopService` with stub services. The
+    helper methods under test only need ``configuration_service`` to
+    return ``{"environment": env}``, the rest can stay ``None``."""
+    cfg = SimpleNamespace(
+        get_config=lambda: {
+            "environment": env.value,
+            "ENVIRONMENT": env.value,
+        },
+    )
+    return EventLoopService(
+        context=None,
+        order_service=None,
+        trade_service=None,
+        portfolio_service=None,
+        configuration_service=cfg,
+        data_provider_service=None,
+        portfolio_snapshot_service=None,
+    )
+
+
+# ----------------------------------------------------------------- #
+# 3b: envelope validation
+# ----------------------------------------------------------------- #
+class TestLiveEnvelopeValidation(TestCase):
+    def test_sub_daily_with_pipeline_raises(self):
+        loop = _eventloop()
+        strat = _strategy(
+            "s1",
+            [_ds("BTC/EUR", time_frame=TimeFrame.ONE_HOUR,
+                 warmup_window=200)],
+            [_DailyPipeline],
+        )
+        with self.assertRaises(OperationalException) as cm:
+            loop._validate_live_envelope([strat])
+        self.assertIn("sub-daily", str(cm.exception))
+
+    def test_too_many_symbols_raises(self):
+        loop = _eventloop()
+        sources = [
+            _ds(f"S{i}/EUR", time_frame=TimeFrame.ONE_DAY)
+            for i in range(51)
+        ]
+        strat = _strategy("s1", sources, [_DailyPipeline])
+        with self.assertRaises(OperationalException) as cm:
+            loop._validate_live_envelope([strat])
+        self.assertIn("exceeds the v1 live cap", str(cm.exception))
+
+    def test_daily_under_cap_passes(self):
+        loop = _eventloop()
+        sources = [
+            _ds(f"S{i}/EUR", time_frame=TimeFrame.ONE_DAY)
+            for i in range(50)
+        ]
+        strat = _strategy("s1", sources, [_DailyPipeline])
+        loop._validate_live_envelope([strat])  # no raise
+
+    def test_no_pipelines_skips_validation(self):
+        """Strategies without pipelines are unaffected — sub-daily +
+        many symbols must not raise."""
+        loop = _eventloop()
+        sources = [
+            _ds(f"S{i}/EUR", time_frame=TimeFrame.ONE_HOUR)
+            for i in range(100)
+        ]
+        strat = _strategy("s1", sources, [])
+        loop._validate_live_envelope([strat])  # no raise
+
+    def test_backtest_mode_skips_validation(self):
+        """``_maybe_validate_live_envelope`` is a no-op for BACKTEST
+        even when the strategy violates the live envelope."""
+        loop = _eventloop(env=Environment.BACKTEST)
+        strat = _strategy(
+            "s1",
+            [_ds("BTC/EUR", time_frame=TimeFrame.ONE_HOUR)],
+            [_DailyPipeline],
+        )
+        # Would raise via _validate_live_envelope, but
+        # _maybe_validate_live_envelope short-circuits in backtest.
+        loop._maybe_validate_live_envelope(
+            [strat], Environment.BACKTEST.value,
+        )
+
+    def test_validation_runs_only_once(self):
+        loop = _eventloop()
+        sources = [_ds("BTC/EUR", time_frame=TimeFrame.ONE_DAY)]
+        strat = _strategy("s1", sources, [_DailyPipeline])
+        loop._maybe_validate_live_envelope(
+            [strat], Environment.DEV.value,
+        )
+        self.assertTrue(loop._pipelines_live_validated)
+        # Even if we mutate the strategy to violate the envelope,
+        # subsequent calls don't re-run validation.
+        strat.data_sources = [
+            _ds("BTC/EUR", time_frame=TimeFrame.ONE_HOUR),
+        ]
+        loop._maybe_validate_live_envelope(
+            [strat], Environment.DEV.value,
+        )  # no raise
+
+
+# ----------------------------------------------------------------- #
+# 3c: refresh_universe_every cache
+# ----------------------------------------------------------------- #
+class TestUniverseRefreshCache(TestCase):
+    def test_no_attribute_returns_none(self):
+        loop = _eventloop()
+        result = loop._filter_symbols_for_universe_cache(
+            strategy_id="s1",
+            pipeline_cls=_DailyPipeline,  # no refresh_universe_every
+            symbol_to_identifier={"A": "id_a"},
+            as_of=datetime(2024, 1, 1),
+        )
+        self.assertIsNone(result)
+
+    def test_no_cache_entry_returns_none(self):
+        loop = _eventloop()
+        result = loop._filter_symbols_for_universe_cache(
+            strategy_id="s1",
+            pipeline_cls=_CadencePipeline,
+            symbol_to_identifier={"A": "id_a"},
+            as_of=datetime(2024, 1, 1),
+        )
+        self.assertIsNone(result)
+
+    def test_cache_hit_within_cadence_restricts_symbols(self):
+        loop = _eventloop()
+        loop._pipeline_universe_cache[("s1", _CadencePipeline)] = (
+            datetime(2024, 1, 1),
+            frozenset({"A", "B"}),
+        )
+        result = loop._filter_symbols_for_universe_cache(
+            strategy_id="s1",
+            pipeline_cls=_CadencePipeline,
+            symbol_to_identifier={"A": "id_a", "B": "id_b", "C": "id_c"},
+            as_of=datetime(2024, 1, 1, 12),  # 12h later, < 1d cadence
+        )
+        self.assertEqual(result, {"A": "id_a", "B": "id_b"})
+
+    def test_cache_miss_after_cadence_returns_none(self):
+        loop = _eventloop()
+        loop._pipeline_universe_cache[("s1", _CadencePipeline)] = (
+            datetime(2024, 1, 1),
+            frozenset({"A"}),
+        )
+        result = loop._filter_symbols_for_universe_cache(
+            strategy_id="s1",
+            pipeline_cls=_CadencePipeline,
+            symbol_to_identifier={"A": "id_a"},
+            as_of=datetime(2024, 1, 2, 1),  # > 1d after cache
+        )
+        self.assertIsNone(result)
+
+
+# ----------------------------------------------------------------- #
+# 3d: per-pipeline resilience
+# ----------------------------------------------------------------- #
+class _BoomEngine:
+    """Stand-in pipeline engine that always raises."""
+
+    def evaluate(self, **kwargs):
+        raise RuntimeError("boom")
+
+    @staticmethod
+    def _empty_output(pipeline_cls):
+        import polars as pl
+        return pl.DataFrame(
+            schema={"symbol": pl.Utf8, "sma": pl.Float64},
+        )
+
+
+class TestRunPipelinesResilience(TestCase):
+    def _setup(self, env):
+        loop = _eventloop(env=env)
+        loop._pipeline_engine = _BoomEngine()
+        strat = _strategy(
+            "s1",
+            [_ds("BTC/EUR", time_frame=TimeFrame.ONE_DAY)],
+            [_DailyPipeline],
+        )
+        return loop, strat
+
+    def test_live_mode_swallows_pipeline_error(self):
+        loop, strat = self._setup(Environment.DEV)
+        data = {}
+        loop._run_pipelines(
+            strategy=strat,
+            data=data,
+            data_object={},
+            as_of=datetime(2024, 1, 1),
+        )
+        self.assertIn("_DailyPipeline", data)
+        # Empty output — schema preserved, no rows.
+        self.assertEqual(data["_DailyPipeline"].height, 0)
+
+    def test_backtest_mode_reraises_pipeline_error(self):
+        loop, strat = self._setup(Environment.BACKTEST)
+        with self.assertRaises(RuntimeError):
+            loop._run_pipelines(
+                strategy=strat,
+                data={},
+                data_object={},
+                as_of=datetime(2024, 1, 1),
+            )

--- a/tests/app/test_pipeline_warmup_validation.py
+++ b/tests/app/test_pipeline_warmup_validation.py
@@ -1,0 +1,123 @@
+"""Phase 3 (#503): warmup_window validation for pipelines.
+
+When a strategy declares ``pipelines = [...]`` the framework now
+verifies at strategy construction time that every OHLCV data source
+has a ``warmup_window`` >= the pipeline's longest factor window.
+Without this check a live strategy starts silently emitting NaN
+columns until enough bars accrue.
+"""
+from unittest import TestCase
+
+from investing_algorithm_framework import (
+    DataSource,
+    DataType,
+    Pipeline,
+    Returns,
+    SMA,
+    TimeFrame,
+    TimeUnit,
+    TradingStrategy,
+)
+from investing_algorithm_framework.domain import OperationalException
+
+
+class _ShortPipeline(Pipeline):
+    momentum = Returns(window=5)
+
+
+class _LongPipeline(Pipeline):
+    sma = SMA(window=200)
+
+
+class _PipelineStrategy(TradingStrategy):
+    time_unit = TimeUnit.HOUR
+    interval = 1
+    symbols = ["BTC"]
+
+    def generate_buy_signals(self, data):  # pragma: no cover - not exercised
+        return {}
+
+    def generate_sell_signals(self, data):  # pragma: no cover - not exercised
+        return {}
+
+
+def _ds(warmup_window=None):
+    kwargs = dict(
+        symbol="BTC/EUR",
+        data_type=DataType.OHLCV,
+        time_frame=TimeFrame.ONE_HOUR,
+        market="BITVAVO",
+    )
+    if warmup_window is not None:
+        kwargs["warmup_window"] = warmup_window
+    return DataSource(**kwargs)
+
+
+class TestPipelineWarmupValidation(TestCase):
+    def test_sufficient_warmup_window_passes(self):
+        strategy = _PipelineStrategy(
+            data_sources=[_ds(warmup_window=10)],
+            decorated=None,
+        )
+        strategy.pipelines = [_ShortPipeline]
+        # Re-init to trigger validation with pipelines set.
+        strategy = _PipelineStrategy(
+            data_sources=[_ds(warmup_window=10)],
+        )
+        # Class-level pipelines = [] by default; explicitly set then
+        # reconstruct via subclass.
+
+        class _Strat(_PipelineStrategy):
+            pipelines = [_ShortPipeline]
+
+        instance = _Strat(data_sources=[_ds(warmup_window=10)])
+        self.assertEqual(instance.pipelines, [_ShortPipeline])
+
+    def test_insufficient_warmup_window_raises(self):
+        class _Strat(_PipelineStrategy):
+            pipelines = [_LongPipeline]
+
+        with self.assertRaises(OperationalException) as cm:
+            _Strat(data_sources=[_ds(warmup_window=50)])
+
+        msg = str(cm.exception)
+        self.assertIn("_LongPipeline", msg)
+        self.assertIn("200", msg)
+        self.assertIn("warmup_window", msg)
+
+    def test_unset_warmup_window_raises(self):
+        class _Strat(_PipelineStrategy):
+            pipelines = [_ShortPipeline]
+
+        with self.assertRaises(OperationalException) as cm:
+            _Strat(data_sources=[_ds()])
+
+        msg = str(cm.exception)
+        self.assertIn("unset", msg)
+
+    def test_no_ohlcv_data_sources_raises(self):
+        class _Strat(_PipelineStrategy):
+            pipelines = [_ShortPipeline]
+
+        with self.assertRaises(OperationalException) as cm:
+            _Strat(data_sources=[])
+
+        msg = str(cm.exception)
+        self.assertIn("no OHLCV data sources", msg)
+
+    def test_no_pipelines_skips_validation(self):
+        """Strategies that don't declare pipelines pay zero cost — even
+        a missing warmup_window must not raise."""
+        instance = _PipelineStrategy(data_sources=[_ds()])
+        self.assertEqual(instance.pipelines, [])
+
+    def test_multiple_pipelines_uses_max_window(self):
+        class _Strat(_PipelineStrategy):
+            pipelines = [_ShortPipeline, _LongPipeline]
+
+        # warmup of 199 satisfies _ShortPipeline (5) but not
+        # _LongPipeline (200). The error must mention _LongPipeline.
+        with self.assertRaises(OperationalException) as cm:
+            _Strat(data_sources=[_ds(warmup_window=199)])
+        msg = str(cm.exception)
+        self.assertIn("_LongPipeline", msg)

--- a/tests/domain/pipeline/test_factors.py
+++ b/tests/domain/pipeline/test_factors.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import math
+import unittest
 from datetime import datetime, timedelta
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -43,140 +43,153 @@ def _bar(dt_idx, close, volume=1.0):
     return (dt, close, close, close, close, volume)
 
 
-def test_returns_simple_percent_return():
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate([10, 11, 12, 13])]})
-    series = Returns(window=2).compute_panel(panel).to_list()
-    # Bar 0,1 → null; bar 2 → 12/10 - 1; bar 3 → 13/11 - 1
-    assert series[0] is None and series[1] is None
-    assert series[2] == pytest.approx(0.2)
-    assert series[3] == pytest.approx(13.0 / 11.0 - 1.0)
+class TestPipelineFactors(unittest.TestCase):
+
+    def test_returns_simple_percent_return(self):
+        panel = _panel(
+            {"X": [_bar(i, c) for i, c in enumerate([10, 11, 12, 13])]}
+        )
+        series = Returns(window=2).compute_panel(panel).to_list()
+        # Bar 0,1 → null; bar 2 → 12/10 - 1; bar 3 → 13/11 - 1
+        self.assertIsNone(series[0])
+        self.assertIsNone(series[1])
+        self.assertAlmostEqual(series[2], 0.2)
+        self.assertAlmostEqual(series[3], 13.0 / 11.0 - 1.0)
+
+    def test_average_dollar_volume_rolling_mean(self):
+        panel = _panel(
+            {
+                "X": [
+                    (datetime(2024, 1, 1) + timedelta(days=i), c, c, c, c, vol)
+                    for i, (c, vol) in enumerate(
+                        [(10, 1), (20, 2), (30, 3), (40, 4)]
+                    )
+                ]
+            }
+        )
+        series = AverageDollarVolume(window=2).compute_panel(panel).to_list()
+        # close*volume = [10, 40, 90, 160]; rolling mean window=2
+        self.assertIsNone(series[0])
+        self.assertAlmostEqual(series[1], 25.0)
+        self.assertAlmostEqual(series[2], 65.0)
+        self.assertAlmostEqual(series[3], 125.0)
+
+    def test_sma_rolling_mean(self):
+        panel = _panel(
+            {"X": [_bar(i, c) for i, c in enumerate([1, 2, 3, 4, 5])]}
+        )
+        series = SMA(window=3).compute_panel(panel).to_list()
+        self.assertIsNone(series[0])
+        self.assertIsNone(series[1])
+        self.assertAlmostEqual(series[2], 2.0)
+        self.assertAlmostEqual(series[3], 3.0)
+        self.assertAlmostEqual(series[4], 4.0)
+
+    def test_volatility_log_return_stdev_scaled(self):
+        closes = [100.0, 101.0, 99.0, 102.0, 100.0, 103.0]
+        panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
+        window = 4
+        pp_year = 252
+        series = (
+            Volatility(window=window, periods_per_year=pp_year)
+            .compute_panel(panel)
+            .to_list()
+        )
+        # Manually compute the last value
+        log_rets = [
+            math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))
+        ]
+        last_window = log_rets[-window:]
+        mean = sum(last_window) / window
+        var = sum((x - mean) ** 2 for x in last_window) / (window - 1)
+        expected = math.sqrt(var) * math.sqrt(pp_year)
+        self.assertAlmostEqual(series[-1], expected)
+
+    def test_rsi_all_gains_returns_100(self):
+        panel = _panel(
+            {"X": [_bar(i, c) for i, c in enumerate(range(1, 20))]}
+        )
+        series = RSI(window=4).compute_panel(panel).to_list()
+        # All gains, no losses → avg_loss == 0 → RSI clamped to 100
+        self.assertAlmostEqual(series[-1], 100.0)
+
+    def test_rsi_with_losses_strictly_between_0_and_100(self):
+        closes = [100, 102, 101, 103, 99, 104, 100, 106, 101]
+        panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
+        series = RSI(window=4).compute_panel(panel).to_list()
+        last = series[-1]
+        self.assertIsNotNone(last)
+        self.assertGreater(last, 0.0)
+        self.assertLess(last, 100.0)
+
+    def test_factor_rank_orders_within_each_bar(self):
+        # 3 symbols, 1 bar of meaningful data — rank needs Returns(window=1).
+        panel = _panel(
+            {
+                "AAA": [_bar(0, 100), _bar(1, 110)],  # +10%
+                "BBB": [_bar(0, 100), _bar(1, 105)],  # +5%
+                "CCC": [_bar(0, 100), _bar(1, 120)],  # +20%
+            }
+        )
+        ranked = Returns(window=1).rank().compute_panel(panel)
+        df = (
+            panel.select(["datetime", "symbol"])
+            .with_columns(ranked.alias("rk"))
+            .filter(pl.col("datetime") == datetime(2024, 1, 2))
+        )
+        out = {row["symbol"]: row["rk"] for row in df.to_dicts()}
+        # Ascending ordinal ranks: BBB=1, AAA=2, CCC=3
+        self.assertEqual(out["BBB"], 1.0)
+        self.assertEqual(out["AAA"], 2.0)
+        self.assertEqual(out["CCC"], 3.0)
+
+    def test_factor_top_filter_keeps_highest(self):
+        panel = _panel(
+            {
+                "AAA": [_bar(0, 100), _bar(1, 110)],
+                "BBB": [_bar(0, 100), _bar(1, 105)],
+                "CCC": [_bar(0, 100), _bar(1, 120)],
+            }
+        )
+        mask = Returns(window=1).top(2).compute_panel(panel)
+        df = (
+            panel.select(["datetime", "symbol"])
+            .with_columns(mask.alias("m"))
+            .filter(pl.col("datetime") == datetime(2024, 1, 2))
+        )
+        out = {row["symbol"]: row["m"] for row in df.to_dicts()}
+        # Top 2 by descending returns: CCC (20%) and AAA (10%)
+        self.assertTrue(out["AAA"])
+        self.assertTrue(out["CCC"])
+        self.assertFalse(out["BBB"])
+
+    def test_factor_bottom_filter_keeps_lowest(self):
+        panel = _panel(
+            {
+                "AAA": [_bar(0, 100), _bar(1, 110)],
+                "BBB": [_bar(0, 100), _bar(1, 105)],
+                "CCC": [_bar(0, 100), _bar(1, 120)],
+            }
+        )
+        mask = Returns(window=1).bottom(1).compute_panel(panel)
+        df = (
+            panel.select(["datetime", "symbol"])
+            .with_columns(mask.alias("m"))
+            .filter(pl.col("datetime") == datetime(2024, 1, 2))
+        )
+        out = {row["symbol"]: row["m"] for row in df.to_dicts()}
+        self.assertTrue(out["BBB"])
+        self.assertFalse(out["AAA"])
+        self.assertFalse(out["CCC"])
+
+    def test_factor_invalid_window_raises(self):
+        with self.assertRaises(ValueError):
+            Returns(window=0)
+
+    def test_volatility_invalid_periods_raises(self):
+        with self.assertRaises(ValueError):
+            Volatility(window=10, periods_per_year=0)
 
 
-def test_average_dollar_volume_rolling_mean():
-    panel = _panel(
-        {
-            "X": [
-                (datetime(2024, 1, 1) + timedelta(days=i), c, c, c, c, vol)
-                for i, (c, vol) in enumerate(
-                    [(10, 1), (20, 2), (30, 3), (40, 4)]
-                )
-            ]
-        }
-    )
-    series = AverageDollarVolume(window=2).compute_panel(panel).to_list()
-    # close*volume = [10, 40, 90, 160]; rolling mean window=2
-    assert series[0] is None
-    assert series[1] == pytest.approx(25.0)
-    assert series[2] == pytest.approx(65.0)
-    assert series[3] == pytest.approx(125.0)
-
-
-def test_sma_rolling_mean():
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate([1, 2, 3, 4, 5])]})
-    series = SMA(window=3).compute_panel(panel).to_list()
-    assert series[0] is None and series[1] is None
-    assert series[2] == pytest.approx(2.0)
-    assert series[3] == pytest.approx(3.0)
-    assert series[4] == pytest.approx(4.0)
-
-
-def test_volatility_log_return_stdev_scaled():
-    closes = [100.0, 101.0, 99.0, 102.0, 100.0, 103.0]
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
-    window = 4
-    pp_year = 252
-    series = (
-        Volatility(window=window, periods_per_year=pp_year)
-        .compute_panel(panel)
-        .to_list()
-    )
-    # Manually compute the last value
-    log_rets = [math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))]
-    last_window = log_rets[-window:]
-    mean = sum(last_window) / window
-    var = sum((x - mean) ** 2 for x in last_window) / (window - 1)
-    expected = math.sqrt(var) * math.sqrt(pp_year)
-    assert series[-1] == pytest.approx(expected)
-
-
-def test_rsi_all_gains_returns_100():
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate(range(1, 20))]})
-    series = RSI(window=4).compute_panel(panel).to_list()
-    # All gains, no losses → avg_loss == 0 → RSI clamped to 100
-    assert series[-1] == pytest.approx(100.0)
-
-
-def test_rsi_with_losses_strictly_between_0_and_100():
-    closes = [100, 102, 101, 103, 99, 104, 100, 106, 101]
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
-    series = RSI(window=4).compute_panel(panel).to_list()
-    last = series[-1]
-    assert last is not None
-    assert 0.0 < last < 100.0
-
-
-def test_factor_rank_orders_within_each_bar():
-    # 3 symbols, 1 bar of meaningful data — but rank needs Returns(window=1).
-    panel = _panel(
-        {
-            "AAA": [_bar(0, 100), _bar(1, 110)],  # +10%
-            "BBB": [_bar(0, 100), _bar(1, 105)],  # +5%
-            "CCC": [_bar(0, 100), _bar(1, 120)],  # +20%
-        }
-    )
-    ranked = Returns(window=1).rank().compute_panel(panel)
-    df = panel.select(["datetime", "symbol"]).with_columns(
-        ranked.alias("rk")
-    ).filter(pl.col("datetime") == datetime(2024, 1, 2))
-    out = {row["symbol"]: row["rk"] for row in df.to_dicts()}
-    # Ascending ordinal ranks: BBB=1, AAA=2, CCC=3
-    assert out["BBB"] == 1.0
-    assert out["AAA"] == 2.0
-    assert out["CCC"] == 3.0
-
-
-def test_factor_top_filter_keeps_highest():
-    panel = _panel(
-        {
-            "AAA": [_bar(0, 100), _bar(1, 110)],
-            "BBB": [_bar(0, 100), _bar(1, 105)],
-            "CCC": [_bar(0, 100), _bar(1, 120)],
-        }
-    )
-    mask = Returns(window=1).top(2).compute_panel(panel)
-    df = panel.select(["datetime", "symbol"]).with_columns(
-        mask.alias("m")
-    ).filter(pl.col("datetime") == datetime(2024, 1, 2))
-    out = {row["symbol"]: row["m"] for row in df.to_dicts()}
-    # Top 2 by descending returns: CCC (20%) and AAA (10%)
-    assert out["AAA"] is True
-    assert out["CCC"] is True
-    assert out["BBB"] is False
-
-
-def test_factor_bottom_filter_keeps_lowest():
-    panel = _panel(
-        {
-            "AAA": [_bar(0, 100), _bar(1, 110)],
-            "BBB": [_bar(0, 100), _bar(1, 105)],
-            "CCC": [_bar(0, 100), _bar(1, 120)],
-        }
-    )
-    mask = Returns(window=1).bottom(1).compute_panel(panel)
-    df = panel.select(["datetime", "symbol"]).with_columns(
-        mask.alias("m")
-    ).filter(pl.col("datetime") == datetime(2024, 1, 2))
-    out = {row["symbol"]: row["m"] for row in df.to_dicts()}
-    assert out["BBB"] is True
-    assert out["AAA"] is False
-    assert out["CCC"] is False
-
-
-def test_factor_invalid_window_raises():
-    with pytest.raises(ValueError):
-        Returns(window=0)
-
-
-def test_volatility_invalid_periods_raises():
-    with pytest.raises(ValueError):
-        Volatility(window=10, periods_per_year=0)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/domain/pipeline/test_pipeline.py
+++ b/tests/domain/pipeline/test_pipeline.py
@@ -5,7 +5,7 @@ See ``investing_algorithm_framework/domain/pipeline/pipeline.py`` and
 """
 from __future__ import annotations
 
-import pytest
+import unittest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -22,48 +22,50 @@ class _Screener(Pipeline):
     alpha = momentum.rank(mask=universe)
 
 
-def test_pipeline_collects_columns_excluding_universe():
-    cols = _Screener.get_columns()
-    assert list(cols.keys()) == ["dollar_volume", "momentum", "alpha"]
-    assert _Screener.get_universe() is _Screener.universe
+class TestPipelineIntrospection(unittest.TestCase):
+
+    def test_pipeline_collects_columns_excluding_universe(self):
+        cols = _Screener.get_columns()
+        self.assertEqual(
+            list(cols.keys()), ["dollar_volume", "momentum", "alpha"]
+        )
+        self.assertIs(_Screener.get_universe(), _Screener.universe)
+
+    def test_pipeline_required_columns_union(self):
+        required = _Screener.required_columns()
+        # AverageDollarVolume needs close+volume, Returns needs close
+        self.assertIn("close", required)
+        self.assertIn("volume", required)
+
+    def test_pipeline_required_window_is_max(self):
+        self.assertEqual(_Screener.required_window(), 5)
+
+    def test_pipeline_name_defaults_to_class_name(self):
+        self.assertEqual(_Screener.name(), "_Screener")
+
+    def test_pipeline_with_no_columns_raises(self):
+        with self.assertRaisesRegex(TypeError, "declares no factor columns"):
+            class _Empty(Pipeline):
+                pass
+
+    def test_pipeline_universe_must_be_filter(self):
+        with self.assertRaisesRegex(TypeError, "must be a Filter"):
+            class _BadUniverse(Pipeline):
+                momentum = Returns(window=3)
+                # Returns is a Factor, not a Filter
+                universe = momentum
+
+    def test_pipeline_inheritance_collects_parent_columns(self):
+        class _Child(_Screener):
+            sma = SMA(window=4)
+
+        cols = _Child.get_columns()
+        # Child columns + parent columns
+        self.assertIn("sma", cols)
+        self.assertIn("dollar_volume", cols)
+        self.assertIn("momentum", cols)
+        self.assertIn("alpha", cols)
 
 
-def test_pipeline_required_columns_union():
-    required = _Screener.required_columns()
-    # AverageDollarVolume needs close+volume, Returns needs close
-    assert "close" in required
-    assert "volume" in required
-
-
-def test_pipeline_required_window_is_max():
-    assert _Screener.required_window() == 5
-
-
-def test_pipeline_name_defaults_to_class_name():
-    assert _Screener.name() == "_Screener"
-
-
-def test_pipeline_with_no_columns_raises():
-    with pytest.raises(TypeError, match="declares no factor columns"):
-        class _Empty(Pipeline):
-            pass
-
-
-def test_pipeline_universe_must_be_filter():
-    with pytest.raises(TypeError, match="must be a Filter"):
-        class _BadUniverse(Pipeline):
-            momentum = Returns(window=3)
-            # Returns is a Factor, not a Filter
-            universe = momentum
-
-
-def test_pipeline_inheritance_collects_parent_columns():
-    class _Child(_Screener):
-        sma = SMA(window=4)
-
-    cols = _Child.get_columns()
-    # Child columns + parent columns
-    assert "sma" in cols
-    assert "dollar_volume" in cols
-    assert "momentum" in cols
-    assert "alpha" in cols
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infrastructure/services/backtesting/test_vector_backtest_pipeline_injection.py
+++ b/tests/infrastructure/services/backtesting/test_vector_backtest_pipeline_injection.py
@@ -8,11 +8,12 @@ directly without spinning up a full backtest.
 """
 from __future__ import annotations
 
+import logging
+import unittest
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -77,110 +78,27 @@ def _make_data_sources_and_data():
     return sources, data
 
 
-def test_inject_pipelines_no_pipelines_is_noop():
-    sources, data = _make_data_sources_and_data()
-    strategy = _StubStrategy(data_sources=sources, pipelines=None)
-    before = dict(data)
+class TestVectorBacktestPipelineInjection(unittest.TestCase):
 
-    VectorBacktestService._inject_pipelines(
-        strategy=strategy,
-        data=data,
-        backtest_date_range=BacktestDateRange(
-            start_date=datetime(2024, 1, 2),
-            end_date=datetime(2024, 1, 4),
-        ),
-    )
-    assert data == before
+    def test_inject_pipelines_no_pipelines_is_noop(self):
+        sources, data = _make_data_sources_and_data()
+        strategy = _StubStrategy(data_sources=sources, pipelines=None)
+        before = dict(data)
 
-
-def test_inject_pipelines_adds_long_frame_keyed_by_class_name():
-    sources, data = _make_data_sources_and_data()
-    strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
-
-    VectorBacktestService._inject_pipelines(
-        strategy=strategy,
-        data=data,
-        backtest_date_range=BacktestDateRange(
-            start_date=datetime(2024, 1, 2),
-            end_date=datetime(2024, 1, 4),
-        ),
-    )
-
-    assert "_Screener" in data
-    out = data["_Screener"]
-    assert isinstance(out, pl.DataFrame)
-    # Long format: datetime + symbol + factor columns (universe dropped)
-    assert set(out.columns) == {"datetime", "symbol", "adv", "momentum"}
-    # Universe restricts to top-2 by ADV every bar; BBB always loses
-    # (volume=1 vs 100/200) so it must never appear in the output.
-    assert "BBB/EUR" not in out["symbol"].to_list()
-
-
-def test_inject_pipelines_respects_end_date_no_lookahead():
-    sources, data = _make_data_sources_and_data()
-    strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
-
-    VectorBacktestService._inject_pipelines(
-        strategy=strategy,
-        data=data,
-        backtest_date_range=BacktestDateRange(
-            start_date=datetime(2024, 1, 2),
-            end_date=datetime(2024, 1, 3),
-        ),
-    )
-    out = data["_Screener"]
-    # No bars beyond end_date should leak in.
-    max_dt = out["datetime"].max()
-    assert max_dt <= datetime(2024, 1, 3)
-
-
-def test_inject_pipelines_skips_when_no_ohlcv_sources(caplog):
-    """A strategy with pipelines but no OHLCV data sources should log
-    and skip silently without raising."""
-    strategy = _StubStrategy(data_sources=[], pipelines=[_Screener])
-    data = {}
-
-    with caplog.at_level(
-        "WARNING",
-        logger=(
-            "investing_algorithm_framework.infrastructure.services."
-            "backtesting.vector_backtest_service"
-        ),
-    ):
         VectorBacktestService._inject_pipelines(
             strategy=strategy,
             data=data,
             backtest_date_range=BacktestDateRange(
                 start_date=datetime(2024, 1, 2),
-                end_date=datetime(2024, 1, 3),
+                end_date=datetime(2024, 1, 4),
             ),
         )
+        self.assertEqual(data, before)
 
-    assert "_Screener" not in data
-    assert any(
-        "no OHLCV data sources" in record.message
-        for record in caplog.records
-    )
+    def test_inject_pipelines_adds_long_frame_keyed_by_class_name(self):
+        sources, data = _make_data_sources_and_data()
+        strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
 
-
-def test_inject_pipelines_re_raises_engine_errors():
-    """Pipeline evaluation errors should propagate to the caller so
-    backtest authors see a clear failure rather than a silent skip."""
-
-    class _Broken(Pipeline):
-        adv = AverageDollarVolume(window=2)
-        momentum = Returns(window=2)
-
-    sources, data = _make_data_sources_and_data()
-    # Corrupt one of the inputs to force a polars-level error.
-    bad_id = sources[0].get_identifier()
-    data[bad_id] = pl.DataFrame(
-        {"Datetime": [datetime(2024, 1, 1)], "Close": [10.0]}
-    )
-
-    strategy = _StubStrategy(data_sources=sources, pipelines=[_Broken])
-
-    with pytest.raises(Exception):
         VectorBacktestService._inject_pipelines(
             strategy=strategy,
             data=data,
@@ -190,7 +108,91 @@ def test_inject_pipelines_re_raises_engine_errors():
             ),
         )
 
+        self.assertIn("_Screener", data)
+        out = data["_Screener"]
+        self.assertIsInstance(out, pl.DataFrame)
+        # Long format: datetime + symbol + factor columns (universe dropped)
+        self.assertEqual(
+            set(out.columns), {"datetime", "symbol", "adv", "momentum"}
+        )
+        # Universe restricts to top-2 by ADV every bar; BBB always loses
+        # (volume=1 vs 100/200) so it must never appear in the output.
+        self.assertNotIn("BBB/EUR", out["symbol"].to_list())
+
+    def test_inject_pipelines_respects_end_date_no_lookahead(self):
+        sources, data = _make_data_sources_and_data()
+        strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
+
+        VectorBacktestService._inject_pipelines(
+            strategy=strategy,
+            data=data,
+            backtest_date_range=BacktestDateRange(
+                start_date=datetime(2024, 1, 2),
+                end_date=datetime(2024, 1, 3),
+            ),
+        )
+        out = data["_Screener"]
+        # No bars beyond end_date should leak in.
+        max_dt = out["datetime"].max()
+        self.assertLessEqual(max_dt, datetime(2024, 1, 3))
+
+    def test_inject_pipelines_skips_when_no_ohlcv_sources(self):
+        """A strategy with pipelines but no OHLCV data sources should log
+        and skip silently without raising."""
+        strategy = _StubStrategy(data_sources=[], pipelines=[_Screener])
+        data = {}
+
+        logger_name = (
+            "investing_algorithm_framework.infrastructure.services."
+            "backtesting.vector_backtest_service"
+        )
+        with self.assertLogs(logger_name, level=logging.WARNING) as cm:
+            VectorBacktestService._inject_pipelines(
+                strategy=strategy,
+                data=data,
+                backtest_date_range=BacktestDateRange(
+                    start_date=datetime(2024, 1, 2),
+                    end_date=datetime(2024, 1, 3),
+                ),
+            )
+
+        self.assertNotIn("_Screener", data)
+        self.assertTrue(
+            any("no OHLCV data sources" in msg for msg in cm.output)
+        )
+
+    def test_inject_pipelines_re_raises_engine_errors(self):
+        """Pipeline evaluation errors should propagate to the caller so
+        backtest authors see a clear failure rather than a silent skip."""
+
+        class _Broken(Pipeline):
+            adv = AverageDollarVolume(window=2)
+            momentum = Returns(window=2)
+
+        sources, data = _make_data_sources_and_data()
+        # Corrupt one of the inputs to force a polars-level error.
+        bad_id = sources[0].get_identifier()
+        data[bad_id] = pl.DataFrame(
+            {"Datetime": [datetime(2024, 1, 1)], "Close": [10.0]}
+        )
+
+        strategy = _StubStrategy(data_sources=sources, pipelines=[_Broken])
+
+        with self.assertRaises(Exception):
+            VectorBacktestService._inject_pipelines(
+                strategy=strategy,
+                data=data,
+                backtest_date_range=BacktestDateRange(
+                    start_date=datetime(2024, 1, 2),
+                    end_date=datetime(2024, 1, 4),
+                ),
+            )
+
 
 # Suppress the unused import warning — kept for symmetry with other
 # vector-backtest tests in the suite.
 _ = SimpleNamespace, DataType
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/pipeline/test_factor_arithmetic_and_lazy.py
+++ b/tests/services/pipeline/test_factor_arithmetic_and_lazy.py
@@ -6,10 +6,10 @@ See ``investing_algorithm_framework/domain/pipeline/factor.py`` and
 """
 from __future__ import annotations
 
+import unittest
 from datetime import datetime, timedelta
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -55,160 +55,150 @@ def _fixed_data():
     )
 
 
-# --------------------------------------------------------------------- #
-# Arithmetic
-# --------------------------------------------------------------------- #
-def test_factor_addition_two_factors():
-    class _Pipe(Pipeline):
-        a = Returns(window=1)
-        b = Returns(window=2)
-        combined = a + b
+class TestFactorArithmetic(unittest.TestCase):
 
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=_fixed_data(),
-        symbol_to_identifier={s: s for s in _fixed_data()},
-        as_of=datetime(2024, 1, 4),
-    )
-    rows = {r["symbol"]: r for r in result.to_dicts()}
-    assert rows["AAA"]["combined"] == pytest.approx(
-        rows["AAA"]["a"] + rows["AAA"]["b"]
-    )
+    def test_factor_addition_two_factors(self):
+        class _Pipe(Pipeline):
+            a = Returns(window=1)
+            b = Returns(window=2)
+            combined = a + b
 
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=_fixed_data(),
+            symbol_to_identifier={s: s for s in _fixed_data()},
+            as_of=datetime(2024, 1, 4),
+        )
+        rows = {r["symbol"]: r for r in result.to_dicts()}
+        self.assertAlmostEqual(
+            rows["AAA"]["combined"], rows["AAA"]["a"] + rows["AAA"]["b"]
+        )
 
-def test_factor_scalar_arithmetic_left_and_right():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        plus_one = r + 1
-        one_minus_r = 1 - r
-        twice = 2 * r
-        half = r / 2
+    def test_factor_scalar_arithmetic_left_and_right(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            plus_one = r + 1
+            one_minus_r = 1 - r
+            twice = 2 * r
+            half = r / 2
 
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=_fixed_data(),
-        symbol_to_identifier={s: s for s in _fixed_data()},
-        as_of=datetime(2024, 1, 3),
-    )
-    row = result.to_dicts()[0]
-    r = row["r"]
-    assert row["plus_one"] == pytest.approx(r + 1)
-    assert row["one_minus_r"] == pytest.approx(1 - r)
-    assert row["twice"] == pytest.approx(2 * r)
-    assert row["half"] == pytest.approx(r / 2)
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=_fixed_data(),
+            symbol_to_identifier={s: s for s in _fixed_data()},
+            as_of=datetime(2024, 1, 3),
+        )
+        row = result.to_dicts()[0]
+        r = row["r"]
+        self.assertAlmostEqual(row["plus_one"], r + 1)
+        self.assertAlmostEqual(row["one_minus_r"], 1 - r)
+        self.assertAlmostEqual(row["twice"], 2 * r)
+        self.assertAlmostEqual(row["half"], r / 2)
 
+    def test_factor_negation(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            neg = -r
 
-def test_factor_negation():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        neg = -r
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=_fixed_data(),
+            symbol_to_identifier={s: s for s in _fixed_data()},
+            as_of=datetime(2024, 1, 3),
+        )
+        row = result.to_dicts()[0]
+        self.assertAlmostEqual(row["neg"], -row["r"])
 
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=_fixed_data(),
-        symbol_to_identifier={s: s for s in _fixed_data()},
-        as_of=datetime(2024, 1, 3),
-    )
-    row = result.to_dicts()[0]
-    assert row["neg"] == pytest.approx(-row["r"])
+    def test_factor_arithmetic_unsupported_type_raises(self):
+        with self.assertRaises(TypeError):
+            Returns(window=2) + "not a factor"
 
-
-def test_factor_arithmetic_unsupported_type_raises():
-    with pytest.raises(TypeError):
-        Returns(window=2) + "not a factor"
-
-
-def test_factor_arithmetic_propagates_window_max():
-    """A composite factor's required_window is the max of its inputs."""
-    a = Returns(window=3)
-    b = SMA(window=10)
-    composite = a + b
-    assert composite.required_window() == 10
+    def test_factor_arithmetic_propagates_window_max(self):
+        """A composite factor's required_window is the max of its inputs."""
+        a = Returns(window=3)
+        b = SMA(window=10)
+        composite = a + b
+        self.assertEqual(composite.required_window(), 10)
 
 
-# --------------------------------------------------------------------- #
-# Cross-sectional transforms
-# --------------------------------------------------------------------- #
-def test_zscore_per_bar_has_zero_mean_and_unit_std():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        z = r.zscore()
+class TestCrossSectionalTransforms(unittest.TestCase):
 
-    data = _fixed_data()
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    zs = [row["z"] for row in result.to_dicts() if row["z"] is not None]
-    # Cross-sectional z-score across symbols at one bar.
-    assert len(zs) >= 2
-    mean = sum(zs) / len(zs)
-    assert mean == pytest.approx(0.0, abs=1e-9)
+    def test_zscore_per_bar_has_zero_mean_and_unit_std(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            z = r.zscore()
 
+        data = _fixed_data()
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        zs = [
+            row["z"] for row in result.to_dicts() if row["z"] is not None
+        ]
+        # Cross-sectional z-score across symbols at one bar.
+        self.assertGreaterEqual(len(zs), 2)
+        mean = sum(zs) / len(zs)
+        self.assertAlmostEqual(mean, 0.0, places=9)
 
-def test_demean_per_bar_sums_to_zero():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        d = r.demean()
+    def test_demean_per_bar_sums_to_zero(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            d = r.demean()
 
-    data = _fixed_data()
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    demeaned = [
-        row["d"] for row in result.to_dicts() if row["d"] is not None
-    ]
-    assert sum(demeaned) == pytest.approx(0.0, abs=1e-9)
+        data = _fixed_data()
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        demeaned = [
+            row["d"] for row in result.to_dicts() if row["d"] is not None
+        ]
+        self.assertAlmostEqual(sum(demeaned), 0.0, places=9)
 
+    def test_winsorize_clips_to_quantile_bounds(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            clipped = r.winsorize(lower=0.25, upper=0.75)
 
-def test_winsorize_clips_to_quantile_bounds():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        clipped = r.winsorize(lower=0.25, upper=0.75)
+        data = _fixed_data()
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        rows = result.to_dicts()
+        raw = sorted(row["r"] for row in rows)
+        clipped = sorted(row["clipped"] for row in rows)
+        # Winsorisation cannot widen the range.
+        self.assertLessEqual(max(clipped), max(raw))
+        self.assertGreaterEqual(min(clipped), min(raw))
 
-    data = _fixed_data()
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    rows = result.to_dicts()
-    raw = sorted(row["r"] for row in rows)
-    clipped = sorted(row["clipped"] for row in rows)
-    # Winsorisation cannot widen the range.
-    assert max(clipped) <= max(raw)
-    assert min(clipped) >= min(raw)
+    def test_winsorize_invalid_bounds_raises(self):
+        with self.assertRaises(ValueError):
+            Returns(window=2).winsorize(lower=0.8, upper=0.2)
 
+    def test_zscore_with_mask_excludes_masked_symbols(self):
+        class _Pipe(Pipeline):
+            adv = AverageDollarVolume(window=2)
+            r = Returns(window=2)
+            universe = adv.top(2)
+            z = r.zscore(mask=universe)
 
-def test_winsorize_invalid_bounds_raises():
-    with pytest.raises(ValueError):
-        Returns(window=2).winsorize(lower=0.8, upper=0.2)
-
-
-def test_zscore_with_mask_excludes_masked_symbols():
-    class _Pipe(Pipeline):
-        adv = AverageDollarVolume(window=2)
-        r = Returns(window=2)
-        universe = adv.top(2)
-        z = r.zscore(mask=universe)
-
-    data = _fixed_data()  # all volumes equal so mask is deterministic
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    # The pipeline universe also drops the masked symbols from the
-    # output frame, so any surviving row must have a non-null zscore.
-    for row in result.to_dicts():
-        assert row["z"] is not None
+        data = _fixed_data()  # all volumes equal so mask is deterministic
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        for row in result.to_dicts():
+            self.assertIsNotNone(row["z"])
 
 
 # --------------------------------------------------------------------- #
@@ -221,87 +211,93 @@ class _Screener(Pipeline):
     alpha = momentum.rank(mask=universe)
 
 
-def test_lazy_engine_matches_eager_engine():
-    """Lazy mode must produce identical output to eager mode for the
-    same dataset and pipeline."""
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
+class TestLazyEngine(unittest.TestCase):
 
-    eager = VectorPipelineEngine(lazy=False).evaluate_window(
-        pipeline_cls=_Screener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-    )
-    lazy = VectorPipelineEngine(lazy=True).evaluate_window(
-        pipeline_cls=_Screener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-    )
-    assert eager.to_dicts() == lazy.to_dicts()
+    def test_lazy_engine_matches_eager_engine(self):
+        """Lazy mode must produce identical output to eager mode for the
+        same dataset and pipeline."""
+        data = _fixed_data()
+        sym_id = {s: s for s in data}
 
+        eager = VectorPipelineEngine(lazy=False).evaluate_window(
+            pipeline_cls=_Screener,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+        )
+        lazy = VectorPipelineEngine(lazy=True).evaluate_window(
+            pipeline_cls=_Screener,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+        )
+        self.assertEqual(eager.to_dicts(), lazy.to_dicts())
 
-def test_lazy_engine_without_universe():
-    """Lazy path with no universe filter still produces a sorted long
-    frame."""
+    def test_lazy_engine_without_universe(self):
+        """Lazy path with no universe filter still produces a sorted long
+        frame."""
 
-    class _NoUniverse(Pipeline):
-        momentum = Returns(window=2)
+        class _NoUniverse(Pipeline):
+            momentum = Returns(window=2)
 
-    data = _fixed_data()
-    result = VectorPipelineEngine(lazy=True).evaluate_window(
-        pipeline_cls=_NoUniverse,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    pairs = [(r["datetime"], r["symbol"]) for r in result.to_dicts()]
-    assert pairs == sorted(pairs)
+        data = _fixed_data()
+        result = VectorPipelineEngine(lazy=True).evaluate_window(
+            pipeline_cls=_NoUniverse,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
+        pairs = [(r["datetime"], r["symbol"]) for r in result.to_dicts()]
+        self.assertEqual(pairs, sorted(pairs))
 
+    def test_lazy_engine_empty_input(self):
+        class _NoUniverse(Pipeline):
+            momentum = Returns(window=2)
 
-def test_lazy_engine_empty_input():
-    class _NoUniverse(Pipeline):
-        momentum = Returns(window=2)
-
-    result = VectorPipelineEngine(lazy=True).evaluate_window(
-        pipeline_cls=_NoUniverse,
-        data_object={},
-        symbol_to_identifier={},
-    )
-    assert result.is_empty()
+        result = VectorPipelineEngine(lazy=True).evaluate_window(
+            pipeline_cls=_NoUniverse,
+            data_object={},
+            symbol_to_identifier={},
+        )
+        self.assertTrue(result.is_empty())
 
 
 # --------------------------------------------------------------------- #
 # Stateless / Lambda + Functions safety
 # --------------------------------------------------------------------- #
-def test_evaluation_does_not_leak_cache_state():
-    """Each ``evaluate`` call must reset the contextvar cache so that
-    a second invocation in the same process (e.g. an Azure Function or
-    AWS Lambda warm container) sees a fresh cache.
-    """
-    from investing_algorithm_framework.domain.pipeline.factor import (
-        _EVAL_CACHE,
-    )
+class TestEvaluationCacheState(unittest.TestCase):
 
-    class _NoUniverse(Pipeline):
-        momentum = Returns(window=2)
+    def test_evaluation_does_not_leak_cache_state(self):
+        """Each ``evaluate`` call must reset the contextvar cache so that
+        a second invocation in the same process (e.g. an Azure Function or
+        AWS Lambda warm container) sees a fresh cache.
+        """
+        from investing_algorithm_framework.domain.pipeline.factor import (
+            _EVAL_CACHE,
+        )
 
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
-    engine = PipelineEngine()
+        class _NoUniverse(Pipeline):
+            momentum = Returns(window=2)
 
-    assert _EVAL_CACHE.get() is None
+        data = _fixed_data()
+        sym_id = {s: s for s in data}
+        engine = PipelineEngine()
 
-    engine.evaluate(
-        pipeline_cls=_NoUniverse,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=datetime(2024, 1, 3),
-    )
-    assert _EVAL_CACHE.get() is None
+        self.assertIsNone(_EVAL_CACHE.get())
 
-    engine.evaluate(
-        pipeline_cls=_NoUniverse,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=datetime(2024, 1, 4),
-    )
-    assert _EVAL_CACHE.get() is None
+        engine.evaluate(
+            pipeline_cls=_NoUniverse,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            as_of=datetime(2024, 1, 3),
+        )
+        self.assertIsNone(_EVAL_CACHE.get())
+
+        engine.evaluate(
+            pipeline_cls=_NoUniverse,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            as_of=datetime(2024, 1, 4),
+        )
+        self.assertIsNone(_EVAL_CACHE.get())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/pipeline/test_pipeline_engine.py
+++ b/tests/services/pipeline/test_pipeline_engine.py
@@ -1,10 +1,10 @@
 """End-to-end tests for the eager Phase 1 PipelineEngine."""
 from __future__ import annotations
 
+import unittest
 from datetime import datetime, timedelta
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -44,124 +44,132 @@ class _MomentumScreener(Pipeline):
     alpha = momentum.rank(mask=universe)
 
 
-def test_engine_evaluates_pipeline_and_applies_universe():
-    data = _ohlcv(
-        {
-            "AAA": [(10, 100), (12, 100), (14, 100)],   # adv=1300
-            "BBB": [(10, 1), (11, 1), (12, 1)],          # adv=11.5 -> dropped
-            "CCC": [(10, 200), (11, 200), (13, 200)],    # adv=2400
-        }
-    )
-    symbol_to_identifier = {s: s for s in data}
-    as_of = datetime(2024, 1, 3)
+class TestPipelineEngine(unittest.TestCase):
 
-    engine = PipelineEngine()
-    result = engine.evaluate(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier=symbol_to_identifier,
-        as_of=as_of,
-    )
-
-    assert set(result.columns) == {"symbol", "adv", "momentum", "alpha"}
-    rows = {r["symbol"]: r for r in result.to_dicts()}
-    assert set(rows) == {"AAA", "CCC"}
-    # Momentum at as_of is close[t]/close[t-2] - 1
-    assert rows["AAA"]["momentum"] == pytest.approx(0.4)
-    assert rows["CCC"]["momentum"] == pytest.approx(0.3)
-    # alpha = ascending ordinal rank within universe → CCC=1, AAA=2
-    assert rows["CCC"]["alpha"] == 1.0
-    assert rows["AAA"]["alpha"] == 2.0
-
-
-def test_engine_no_lookahead_extra_future_bars_do_not_change_result():
-    """Adding bars strictly after ``as_of`` must not affect output."""
-    closes_short = [(10, 100), (12, 100), (14, 100)]
-    closes_long = closes_short + [(20, 100), (25, 100)]
-
-    class _Single(Pipeline):
-        momentum = Returns(window=2)
-
-    engine = PipelineEngine()
-    as_of = datetime(2024, 1, 3)
-
-    short = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object=_ohlcv({"AAA": closes_short}),
-        symbol_to_identifier={"AAA": "AAA"},
-        as_of=as_of,
-    )
-    long = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object=_ohlcv({"AAA": closes_long}),
-        symbol_to_identifier={"AAA": "AAA"},
-        as_of=as_of,
-    )
-    assert short.to_dicts() == long.to_dicts()
-
-
-def test_engine_handles_pandas_data_frames():
-    pd = pytest.importorskip("pandas")
-
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
-
-    bars = [
-        {
-            "Datetime": datetime(2024, 1, 1) + timedelta(days=i),
-            "Open": c, "High": c, "Low": c, "Close": c, "Volume": 1.0,
-        }
-        for i, c in enumerate([10, 11, 12])
-    ]
-    data = {"AAA": pd.DataFrame(bars)}
-
-    engine = PipelineEngine()
-    result = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object=data,
-        symbol_to_identifier={"AAA": "AAA"},
-        as_of=datetime(2024, 1, 3),
-    )
-    assert result.to_dicts() == [
-        {"symbol": "AAA", "momentum": pytest.approx(12.0 / 11.0 - 1.0)}
-    ]
-
-
-def test_engine_empty_panel_returns_empty_frame():
-    engine = PipelineEngine()
-
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
-
-    result = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object={},
-        symbol_to_identifier={},
-        as_of=datetime(2024, 1, 3),
-    )
-    assert result.is_empty()
-    assert set(result.columns) == {"symbol", "momentum"}
-
-
-def test_engine_missing_required_column_raises():
-    """A data source missing a required OHLCV column must error loudly."""
-    bad = {
-        "AAA": pl.DataFrame(
-            [
-                {"Datetime": datetime(2024, 1, 1), "Close": 10.0}
-                # Missing Open/High/Low/Volume
-            ]
+    def test_engine_evaluates_pipeline_and_applies_universe(self):
+        data = _ohlcv(
+            {
+                "AAA": [(10, 100), (12, 100), (14, 100)],   # adv=1300
+                "BBB": [(10, 1), (11, 1), (12, 1)],          # adv=11.5 -> dropped
+                "CCC": [(10, 200), (11, 200), (13, 200)],    # adv=2400
+            }
         )
-    }
+        symbol_to_identifier = {s: s for s in data}
+        as_of = datetime(2024, 1, 3)
 
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
+        engine = PipelineEngine()
+        result = engine.evaluate(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier=symbol_to_identifier,
+            as_of=as_of,
+        )
 
-    engine = PipelineEngine()
-    with pytest.raises(KeyError):
-        engine.evaluate(
+        self.assertEqual(
+            set(result.columns), {"symbol", "adv", "momentum", "alpha"}
+        )
+        rows = {r["symbol"]: r for r in result.to_dicts()}
+        self.assertEqual(set(rows), {"AAA", "CCC"})
+        # Momentum at as_of is close[t]/close[t-2] - 1
+        self.assertAlmostEqual(rows["AAA"]["momentum"], 0.4)
+        self.assertAlmostEqual(rows["CCC"]["momentum"], 0.3)
+        # alpha = ascending ordinal rank within universe → CCC=1, AAA=2
+        self.assertEqual(rows["CCC"]["alpha"], 1.0)
+        self.assertEqual(rows["AAA"]["alpha"], 2.0)
+
+    def test_engine_no_lookahead_extra_future_bars_do_not_change_result(self):
+        """Adding bars strictly after ``as_of`` must not affect output."""
+        closes_short = [(10, 100), (12, 100), (14, 100)]
+        closes_long = closes_short + [(20, 100), (25, 100)]
+
+        class _Single(Pipeline):
+            momentum = Returns(window=2)
+
+        engine = PipelineEngine()
+        as_of = datetime(2024, 1, 3)
+
+        short = engine.evaluate(
             pipeline_cls=_Single,
-            data_object=bad,
+            data_object=_ohlcv({"AAA": closes_short}),
             symbol_to_identifier={"AAA": "AAA"},
-            as_of=datetime(2024, 1, 1),
+            as_of=as_of,
         )
+        long = engine.evaluate(
+            pipeline_cls=_Single,
+            data_object=_ohlcv({"AAA": closes_long}),
+            symbol_to_identifier={"AAA": "AAA"},
+            as_of=as_of,
+        )
+        self.assertEqual(short.to_dicts(), long.to_dicts())
+
+    def test_engine_handles_pandas_data_frames(self):
+        try:
+            import pandas as pd
+        except ImportError:
+            self.skipTest("pandas not installed")
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        bars = [
+            {
+                "Datetime": datetime(2024, 1, 1) + timedelta(days=i),
+                "Open": c, "High": c, "Low": c, "Close": c, "Volume": 1.0,
+            }
+            for i, c in enumerate([10, 11, 12])
+        ]
+        data = {"AAA": pd.DataFrame(bars)}
+
+        engine = PipelineEngine()
+        result = engine.evaluate(
+            pipeline_cls=_Single,
+            data_object=data,
+            symbol_to_identifier={"AAA": "AAA"},
+            as_of=datetime(2024, 1, 3),
+        )
+        rows = result.to_dicts()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["symbol"], "AAA")
+        self.assertAlmostEqual(rows[0]["momentum"], 12.0 / 11.0 - 1.0)
+
+    def test_engine_empty_panel_returns_empty_frame(self):
+        engine = PipelineEngine()
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        result = engine.evaluate(
+            pipeline_cls=_Single,
+            data_object={},
+            symbol_to_identifier={},
+            as_of=datetime(2024, 1, 3),
+        )
+        self.assertTrue(result.is_empty())
+        self.assertEqual(set(result.columns), {"symbol", "momentum"})
+
+    def test_engine_missing_required_column_raises(self):
+        """A data source missing a required OHLCV column must error loudly."""
+        bad = {
+            "AAA": pl.DataFrame(
+                [
+                    {"Datetime": datetime(2024, 1, 1), "Close": 10.0}
+                    # Missing Open/High/Low/Volume
+                ]
+            )
+        }
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        engine = PipelineEngine()
+        with self.assertRaises(KeyError):
+            engine.evaluate(
+                pipeline_cls=_Single,
+                data_object=bad,
+                symbol_to_identifier={"AAA": "AAA"},
+                as_of=datetime(2024, 1, 1),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/pipeline/test_vector_pipeline_engine.py
+++ b/tests/services/pipeline/test_vector_pipeline_engine.py
@@ -12,10 +12,11 @@ Two layers of testing:
 """
 from __future__ import annotations
 
+import unittest
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -73,195 +74,194 @@ def _fixed_data():
     )
 
 
-# --------------------------------------------------------------------- #
-# Unit tests
-# --------------------------------------------------------------------- #
-def test_vector_engine_returns_full_long_frame():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    result = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-
-    # Long format: datetime + symbol + 3 factor columns (universe dropped)
-    assert set(result.columns) == {
-        "datetime", "symbol", "adv", "momentum", "alpha"
-    }
-    # Sorted by (datetime, symbol)
-    rows = result.to_dicts()
-    pairs = [(r["datetime"], r["symbol"]) for r in rows]
-    assert pairs == sorted(pairs)
-
-
-def test_vector_engine_universe_dropped_from_output():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    result = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    # Universe (adv.top(2)) drops BBB once both AAA and CCC have data.
-    # We only assert BBB is filtered on bars where it lost the universe
-    # contest — the equivalence test below is the strict check.
-    bbb_bars = result.filter(pl.col("symbol") == "BBB")
-    aaa_bars = result.filter(pl.col("symbol") == "AAA")
-    assert len(bbb_bars) <= len(aaa_bars)
-
-
-def test_vector_engine_empty_input_returns_empty_long_frame():
-    engine = VectorPipelineEngine()
-
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
-
-    result = engine.evaluate_window(
-        pipeline_cls=_Single,
-        data_object={},
-        symbol_to_identifier={},
-    )
-    assert result.is_empty()
-    assert set(result.columns) == {"datetime", "symbol", "momentum"}
-
-
-def test_vector_engine_start_end_bounds_applied():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    # ``start`` only excludes earlier bars from the *output*; the panel
-    # still goes back to day 1 because that's all the data we have.
-    # The bound is on the inclusive lower end of the resulting frame.
-    result = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        start=datetime(2024, 1, 3),
-        end=datetime(2024, 1, 4),
-    )
-    distinct_dts = sorted(result["datetime"].unique().to_list())
-    assert distinct_dts == [datetime(2024, 1, 3), datetime(2024, 1, 4)]
-
-
-def test_vector_engine_caches_factor_results(monkeypatch):
-    """A factor reused by ``rank(mask=...)`` should compute once."""
-    call_count = {"n": 0}
-
-    original = AverageDollarVolume.compute_panel
-
-    def counting_compute(self, panel):
-        call_count["n"] += 1
-        return original(self, panel)
-
-    monkeypatch.setattr(AverageDollarVolume, "compute_panel", counting_compute)
-
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    # adv is declared once and reused inside universe = adv.top(2).
-    # With caching, compute_panel must be called exactly once for the
-    # shared instance.
-    assert call_count["n"] == 1
-
-
-def test_vector_engine_slice_at_returns_event_shape():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    long = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    sliced = VectorPipelineEngine.slice_at(long, datetime(2024, 1, 3))
-    assert "datetime" not in sliced.columns
-    assert set(sliced.columns) == {"symbol", "adv", "momentum", "alpha"}
-
-
-# --------------------------------------------------------------------- #
-# Equivalence tests (2e) — vector vs event mode must match per bar
-# --------------------------------------------------------------------- #
 def _normalise(df: pl.DataFrame) -> list:
-    """Return a hashable, order-stable representation of the frame."""
+    """Return an order-stable representation of the frame, with floats
+    rounded so equality comparison is robust to fp wiggle."""
     rows = df.sort("symbol").to_dicts()
     out = []
     for row in rows:
         out.append(
             {
-                k: (
-                    pytest.approx(v, rel=1e-9, abs=1e-12)
-                    if isinstance(v, float)
-                    else v
-                )
+                k: (round(v, 9) if isinstance(v, float) else v)
                 for k, v in row.items()
             }
         )
     return out
 
 
-@pytest.mark.parametrize(
-    "as_of",
-    [
-        datetime(2024, 1, 2),
-        datetime(2024, 1, 3),
-        datetime(2024, 1, 4),
-    ],
-)
-def test_vector_matches_event_mode_per_bar(as_of):
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
+class TestVectorPipelineEngineUnit(unittest.TestCase):
 
-    event_engine = PipelineEngine()
-    vector_engine = VectorPipelineEngine()
+    def test_vector_engine_returns_full_long_frame(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        result = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
 
-    event_result = event_engine.evaluate(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=as_of,
-    )
+        # Long format: datetime + symbol + 3 factor columns (universe dropped)
+        self.assertEqual(
+            set(result.columns),
+            {"datetime", "symbol", "adv", "momentum", "alpha"},
+        )
+        rows = result.to_dicts()
+        pairs = [(r["datetime"], r["symbol"]) for r in rows]
+        self.assertEqual(pairs, sorted(pairs))
 
-    vector_long = vector_engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        end=as_of,
-    )
-    vector_sliced = VectorPipelineEngine.slice_at(vector_long, as_of)
+    def test_vector_engine_universe_dropped_from_output(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        result = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
+        bbb_bars = result.filter(pl.col("symbol") == "BBB")
+        aaa_bars = result.filter(pl.col("symbol") == "AAA")
+        self.assertLessEqual(len(bbb_bars), len(aaa_bars))
 
-    assert set(event_result.columns) == set(vector_sliced.columns)
-    assert _normalise(event_result) == _normalise(vector_sliced)
+    def test_vector_engine_empty_input_returns_empty_long_frame(self):
+        engine = VectorPipelineEngine()
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        result = engine.evaluate_window(
+            pipeline_cls=_Single,
+            data_object={},
+            symbol_to_identifier={},
+        )
+        self.assertTrue(result.is_empty())
+        self.assertEqual(
+            set(result.columns), {"datetime", "symbol", "momentum"}
+        )
+
+    def test_vector_engine_start_end_bounds_applied(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        result = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            start=datetime(2024, 1, 3),
+            end=datetime(2024, 1, 4),
+        )
+        distinct_dts = sorted(result["datetime"].unique().to_list())
+        self.assertEqual(
+            distinct_dts, [datetime(2024, 1, 3), datetime(2024, 1, 4)]
+        )
+
+    def test_vector_engine_caches_factor_results(self):
+        """A factor reused by ``rank(mask=...)`` should compute once."""
+        call_count = {"n": 0}
+        original = AverageDollarVolume.compute_panel
+
+        def counting_compute(self, panel):
+            call_count["n"] += 1
+            return original(self, panel)
+
+        with patch.object(
+            AverageDollarVolume, "compute_panel", counting_compute
+        ):
+            data = _fixed_data()
+            engine = VectorPipelineEngine()
+            engine.evaluate_window(
+                pipeline_cls=_MomentumScreener,
+                data_object=data,
+                symbol_to_identifier={s: s for s in data},
+            )
+        # adv is declared once and reused inside universe = adv.top(2).
+        # With caching, compute_panel must be called exactly once for the
+        # shared instance.
+        self.assertEqual(call_count["n"], 1)
+
+    def test_vector_engine_slice_at_returns_event_shape(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        long = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
+        sliced = VectorPipelineEngine.slice_at(long, datetime(2024, 1, 3))
+        self.assertNotIn("datetime", sliced.columns)
+        self.assertEqual(
+            set(sliced.columns), {"symbol", "adv", "momentum", "alpha"}
+        )
 
 
-def test_vector_matches_event_mode_with_volatility_factor():
-    """Add a heavier factor to widen coverage of the equivalence check."""
+class TestVectorPipelineEngineEquivalence(unittest.TestCase):
 
-    class _MultiFactor(Pipeline):
-        adv = AverageDollarVolume(window=2)
-        mom = Returns(window=2)
-        vol = Volatility(window=3)
-        universe = adv.top(2)
-        alpha = mom.rank(mask=universe)
+    def test_vector_matches_event_mode_per_bar(self):
+        for as_of in (
+            datetime(2024, 1, 2),
+            datetime(2024, 1, 3),
+            datetime(2024, 1, 4),
+        ):
+            with self.subTest(as_of=as_of):
+                data = _fixed_data()
+                sym_id = {s: s for s in data}
 
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
-    as_of = datetime(2024, 1, 4)
+                event_engine = PipelineEngine()
+                vector_engine = VectorPipelineEngine()
 
-    event_result = PipelineEngine().evaluate(
-        pipeline_cls=_MultiFactor,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=as_of,
-    )
-    vector_long = VectorPipelineEngine().evaluate_window(
-        pipeline_cls=_MultiFactor,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        end=as_of,
-    )
-    vector_sliced = VectorPipelineEngine.slice_at(vector_long, as_of)
+                event_result = event_engine.evaluate(
+                    pipeline_cls=_MomentumScreener,
+                    data_object=data,
+                    symbol_to_identifier=sym_id,
+                    as_of=as_of,
+                )
 
-    assert _normalise(event_result) == _normalise(vector_sliced)
+                vector_long = vector_engine.evaluate_window(
+                    pipeline_cls=_MomentumScreener,
+                    data_object=data,
+                    symbol_to_identifier=sym_id,
+                    end=as_of,
+                )
+                vector_sliced = VectorPipelineEngine.slice_at(
+                    vector_long, as_of
+                )
+
+                self.assertEqual(
+                    set(event_result.columns), set(vector_sliced.columns)
+                )
+                self.assertEqual(
+                    _normalise(event_result), _normalise(vector_sliced)
+                )
+
+    def test_vector_matches_event_mode_with_volatility_factor(self):
+        """Add a heavier factor to widen coverage of the equivalence check."""
+
+        class _MultiFactor(Pipeline):
+            adv = AverageDollarVolume(window=2)
+            mom = Returns(window=2)
+            vol = Volatility(window=3)
+            universe = adv.top(2)
+            alpha = mom.rank(mask=universe)
+
+        data = _fixed_data()
+        sym_id = {s: s for s in data}
+        as_of = datetime(2024, 1, 4)
+
+        event_result = PipelineEngine().evaluate(
+            pipeline_cls=_MultiFactor,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            as_of=as_of,
+        )
+        vector_long = VectorPipelineEngine().evaluate_window(
+            pipeline_cls=_MultiFactor,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            end=as_of,
+        )
+        vector_sliced = VectorPipelineEngine.slice_at(vector_long, as_of)
+
+        self.assertEqual(
+            _normalise(event_result), _normalise(vector_sliced)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #507 (Phase 2). Closes the first milestone of #503.

## What

When a strategy declares `pipelines = [...]`, `TradingStrategy.__init__` now validates that every OHLCV data source has `warmup_window >= pipeline.required_window()`. If any source is short — or `warmup_window` is left unset — strategy instantiation raises `OperationalException` with an actionable message listing the offending sources and the required window size.

## Why

Without this guard, a live bot silently trades on NaN factor columns until enough bars accrue. This is a known footgun for live deployments on AWS Lambda / Azure Functions where warm-container restarts can swallow startup warnings.

## What's not in scope

- 3b — streaming panel updates
- 3c — partial-bar handling
- 3d — live observability hooks

These will follow in stacked PRs.

## Tests

- 6 new tests in \`tests/app/test_pipeline_warmup_validation.py\` covering: sufficient/insufficient/unset warmup_window, no OHLCV source, no pipelines (zero-cost path), and multi-pipeline max-window aggregation.
- Full regression suite: 1400 passed, 42 skipped, no regressions.
- flake8 clean on touched files.

## Docs

- \`docusaurus/docs/Advanced Concepts/pipelines-live.md\` — added "Warmup validation (shipped)" section, marked the bullet ✅ in the Phase 3 plan.

Refs: #503