### PR TITLE
feat(pipeline): #504 risk-neutrality primitives (sector neutrality, beta neutralisation, OLS risk models)

### DIFF
--- a/docusaurus/docs/Advanced Concepts/pipelines.md
+++ b/docusaurus/docs/Advanced Concepts/pipelines.md
@@ -71,6 +71,10 @@ A per-symbol time-series computation. Phase 1 ships these built-ins:
 | `SMA(window)` | close | simple moving average |
 | `RSI(window)` | close | Wilder's RSI |
 | `Volatility(window, periods_per_year=252)` | close | annualised stdev of log returns |
+| `StaticPerSymbol(mapping, default=None)` | — | broadcasts a `dict[symbol, value]` (e.g. sector / market-cap) into the cross-section |
+| `CrossSectionalMean(base, mask=None)` | base factor | per-bar equal-weight mean across surviving symbols |
+| `RollingBeta(target, market, window>=2)` | two factors | rolling-window OLS beta `cov(t,m)/var(m)`; null when `var(m) == 0` |
+| `Neutralize(target, exposures=[...], mask=None, add_intercept=True)` | factors | per-bar OLS residualisation of `target` against `exposures`; null on rank-deficient bars |
 
 You can also subclass `CustomFactor` to compute your own.
 
@@ -101,6 +105,12 @@ factor.zscore(mask=universe)             # (x - mean) / std per bar
 factor.demean(mask=universe)             # x - mean per bar
 factor.winsorize(0.01, 0.99,             # clip to per-bar quantiles
                  mask=universe)
+
+# Group-relative variants — stats computed within each group
+# (typically sector). `groups` accepts a dict[symbol, key] or any
+# Factor that emits a per-symbol category.
+factor.zscore(groups=SECTORS)            # z-score within sector
+factor.demean(groups=SECTORS, mask=universe)
 ```
 
 Where the cross-sectional `std` is `0` or undefined (e.g. only one

--- a/docusaurus/docs/Advanced Concepts/pipelines.md
+++ b/docusaurus/docs/Advanced Concepts/pipelines.md
@@ -108,6 +108,59 @@ symbol survives the mask), `zscore` returns `null` rather than
 `inf`/`NaN`. Masked-out symbols are excluded from the bar's
 statistic *and* from the bar's output.
 
+### Risk neutrality
+
+When you want a factor's signal to be independent of structural
+exposures (sector, beta to the market, multi-factor risk model),
+use the built-in risk-neutrality primitives. They cover three
+common cases:
+
+**Sector neutrality** — z-score or demean *within* each sector
+instead of across the whole universe by passing `groups=`. The
+mapping can be a `dict[symbol, sector]` or any `Factor` that
+emits a per-symbol category:
+
+```python
+SECTORS = {"AAPL": "Tech", "MSFT": "Tech", "JPM": "Fin", ...}
+
+class SectorNeutralMomentum(Pipeline):
+    momentum = Returns(window=60)
+    signal = momentum.zscore(groups=SECTORS)   # z-score within sector
+```
+
+**Beta neutralisation** — strip a factor's exposure to the market
+(or any other reference series) using `RollingBeta` and
+`Neutralize`:
+
+```python
+from investing_algorithm_framework import (
+    Returns, RollingBeta, CrossSectionalMean, Neutralize,
+)
+
+class BetaNeutralAlpha(Pipeline):
+    r = Returns(window=1)
+    market = CrossSectionalMean(r)               # equal-weight market
+    beta = RollingBeta(r, market, window=60)
+    alpha = Neutralize(r, exposures=[beta])      # market-neutral residual
+```
+
+**Multi-factor risk model** — pass several exposures to
+`Neutralize` and the residual is orthogonal to all of them at
+each bar (per-bar OLS):
+
+```python
+class FactorNeutralAlpha(Pipeline):
+    r = Returns(window=1)
+    size = StaticPerSymbol(MARKET_CAPS)          # cross-sectional size
+    val = BookToPrice()
+    mom = Returns(window=252)
+    residual = Neutralize(r, exposures=[size, val, mom])
+```
+
+Bars where the system is rank-deficient (more exposures than
+surviving symbols) yield `null` residuals so they're skipped
+downstream rather than producing `NaN`.
+
 ### Factor algebra
 
 Factors compose via the standard arithmetic operators. The framework

--- a/investing_algorithm_framework/__init__.py
+++ b/investing_algorithm_framework/__init__.py
@@ -32,7 +32,9 @@ from .domain import ApiException, combine_backtests, PositionSize, \
     FillModel, FullFill, VolumeBasedFill, \
     FXRateProvider, StaticFXRateProvider, \
     Pipeline, Factor, CustomFactor, Filter, \
-    Returns, AverageDollarVolume, AverageTradedValue, SMA, RSI, Volatility
+    Returns, AverageDollarVolume, AverageTradedValue, SMA, RSI, \
+    Volatility, StaticPerSymbol, CrossSectionalMean, RollingBeta, \
+    Neutralize
 from .infrastructure import AzureBlobStorageStateHandler, \
     CSVOHLCVDataProvider, CSVTickerDataProvider, CSVURLDataProvider, \
     JSONURLDataProvider, ParquetURLDataProvider, \
@@ -269,6 +271,10 @@ __all__ = [
     "SMA",
     "RSI",
     "Volatility",
+    "StaticPerSymbol",
+    "CrossSectionalMean",
+    "RollingBeta",
+    "Neutralize",
     "load_ipython_extension",
     "get_cv_consistency",
     "get_normalized_stability",

--- a/investing_algorithm_framework/domain/__init__.py
+++ b/investing_algorithm_framework/domain/__init__.py
@@ -57,6 +57,10 @@ from .pipeline import (
     SMA,
     RSI,
     Volatility,
+    StaticPerSymbol,
+    CrossSectionalMean,
+    RollingBeta,
+    Neutralize,
 )
 
 __all__ = [
@@ -181,6 +185,10 @@ __all__ = [
     "SMA",
     "RSI",
     "Volatility",
+    "StaticPerSymbol",
+    "CrossSectionalMean",
+    "RollingBeta",
+    "Neutralize",
     "Blotter",
     "DefaultBlotter",
     "SimulationBlotter",

--- a/investing_algorithm_framework/domain/pipeline/__init__.py
+++ b/investing_algorithm_framework/domain/pipeline/__init__.py
@@ -10,11 +10,15 @@ from .custom_factor import CustomFactor
 from .filter import Filter
 from .pipeline import Pipeline
 from .factors import (
-    Returns,
     AverageDollarVolume,
     AverageTradedValue,
-    SMA,
+    CrossSectionalMean,
+    Neutralize,
+    Returns,
+    RollingBeta,
     RSI,
+    SMA,
+    StaticPerSymbol,
     Volatility,
 )
 
@@ -23,10 +27,14 @@ __all__ = [
     "Factor",
     "CustomFactor",
     "Filter",
-    "Returns",
     "AverageDollarVolume",
     "AverageTradedValue",
-    "SMA",
+    "CrossSectionalMean",
+    "Neutralize",
+    "Returns",
+    "RollingBeta",
     "RSI",
+    "SMA",
+    "StaticPerSymbol",
     "Volatility",
 ]

--- a/investing_algorithm_framework/domain/pipeline/factor.py
+++ b/investing_algorithm_framework/domain/pipeline/factor.py
@@ -127,23 +127,44 @@ class Factor:
     # ------------------------------------------------------------------ #
     # Cross-sectional transforms (Phase 2 / #502)
     # ------------------------------------------------------------------ #
-    def zscore(self, mask: Optional["Filter"] = None) -> "Factor":
+    def zscore(
+        self,
+        mask: Optional["Filter"] = None,
+        groups=None,
+    ) -> "Factor":
         """Cross-sectional z-score within each timestamp.
 
         Returns ``(x - mean) / std`` computed over the symbols at each
         bar. With ``mask``, symbols outside the mask are excluded from
         the mean/std and receive ``null`` in the output.
-        """
-        return _Zscore(self, mask=mask)
 
-    def demean(self, mask: Optional["Filter"] = None) -> "Factor":
+        ``groups`` enables **group-relative** (e.g. sector-neutral)
+        normalisation: the statistic is computed within each
+        ``(datetime, group)`` cell instead of across all symbols. It
+        accepts:
+
+        - a ``dict[str, Any]`` mapping ``symbol`` → group label —
+          internally wrapped in :class:`StaticPerSymbol`,
+        - a :class:`Factor` returning a categorical value per row
+          (e.g. a slow-moving fundamental bucket).
+        """
+        return _Zscore(self, mask=mask, groups=groups)
+
+    def demean(
+        self,
+        mask: Optional["Filter"] = None,
+        groups=None,
+    ) -> "Factor":
         """Cross-sectional mean removal within each timestamp.
 
         Returns ``x - mean(x)`` computed over the symbols at each bar.
         With ``mask``, symbols outside the mask are excluded from the
         mean and receive ``null`` in the output.
+
+        ``groups`` (same shape as in :meth:`zscore`) enables
+        group-relative demeaning — e.g. sector neutrality.
         """
-        return _Demean(self, mask=mask)
+        return _Demean(self, mask=mask, groups=groups)
 
     def winsorize(
         self,
@@ -272,6 +293,28 @@ def _coerce_operand(operand) -> "Factor":
     )
 
 
+def _coerce_groups(groups) -> Optional["Factor"]:
+    """Normalise the ``groups`` argument of cross-sectional transforms
+    into a :class:`Factor` (or ``None``).
+
+    Accepts ``None``, a ``dict[symbol, group]`` mapping (auto-wrapped
+    in :class:`StaticPerSymbol`), or any pre-existing :class:`Factor`.
+    """
+    if groups is None:
+        return None
+    if isinstance(groups, Factor):
+        return groups
+    if isinstance(groups, dict):
+        # Local import to avoid an import cycle at module load: the
+        # built-in factors module imports from this file.
+        from .factors.builtin import StaticPerSymbol
+        return StaticPerSymbol(groups)
+    raise TypeError(
+        f"Unsupported type for `groups`: {type(groups).__name__}. "
+        f"Expected None, dict[str, Any], or Factor."
+    )
+
+
 class _Constant(Factor):
     """A panel-aligned constant series. Window is 1 (no warmup needed)."""
 
@@ -371,22 +414,36 @@ class _CrossSectionalTransform(Factor):
     Polars expression for the (possibly mask-nulled) factor values and
     returns the transformed expression. The base class handles mask
     application and per-``datetime`` grouping.
+
+    When ``groups`` is provided, statistics are computed within each
+    ``(datetime, group)`` cell instead of across all symbols at a
+    bar — enabling sector-neutral or otherwise group-relative
+    transforms. ``groups`` may be a ``dict[symbol, group]`` (wrapped
+    in :class:`StaticPerSymbol` automatically) or any :class:`Factor`
+    returning a categorical value per row.
     """
 
     def __init__(
         self,
         base: Factor,
         mask: Optional["Filter"] = None,
+        groups=None,
     ) -> None:
         super().__init__(window=base.required_window())
         self._base = base
         self._mask = mask
+        self._groups = _coerce_groups(groups)
         cols = list(base.required_columns())
         if mask is not None:
             for c in mask.required_columns():
                 if c not in cols:
                     cols.append(c)
             self.window = max(self.window, mask.required_window())
+        if self._groups is not None:
+            for c in self._groups.required_columns():
+                if c not in cols:
+                    cols.append(c)
+            self.window = max(self.window, self._groups.required_window())
         self.inputs = cols
 
     def required_columns(self) -> List[str]:
@@ -397,6 +454,15 @@ class _CrossSectionalTransform(Factor):
 
     def _transform_expr(self) -> pl.Expr:
         raise NotImplementedError  # pragma: no cover
+
+    def _group_keys(self) -> List[str]:
+        """Return the columns to group by for the cross-sectional
+        statistic. ``["datetime"]`` for the standard case,
+        ``["datetime", "__group__"]`` when ``groups`` is set.
+        """
+        if self._groups is None:
+            return ["datetime"]
+        return ["datetime", "__group__"]
 
     def compute_panel(self, panel: pl.DataFrame) -> pl.Series:
         values = self._base.evaluate(panel)
@@ -411,17 +477,21 @@ class _CrossSectionalTransform(Factor):
                 .otherwise(None)
                 .alias("__x__")
             )
+        if self._groups is not None:
+            group_values = self._groups.evaluate(panel)
+            df = df.with_columns(group_values.alias("__group__"))
         df = df.with_columns(self._transform_expr().alias("__out__"))
         return df["__out__"]
 
 
 class _Zscore(_CrossSectionalTransform):
-    """Cross-sectional z-score per bar."""
+    """Cross-sectional z-score per bar (optionally per group)."""
 
     def _transform_expr(self) -> pl.Expr:
         x = pl.col("__x__")
-        mean = x.mean().over("datetime")
-        std = x.std().over("datetime")
+        keys = self._group_keys()
+        mean = x.mean().over(keys)
+        std = x.std().over(keys)
         # If std is 0 or null, returning null is the safe choice (it
         # signals "no dispersion" rather than producing inf/NaN that
         # poisons downstream rolling stats).
@@ -433,11 +503,12 @@ class _Zscore(_CrossSectionalTransform):
 
 
 class _Demean(_CrossSectionalTransform):
-    """Cross-sectional mean removal per bar."""
+    """Cross-sectional mean removal per bar (optionally per group)."""
 
     def _transform_expr(self) -> pl.Expr:
         x = pl.col("__x__")
-        return x - x.mean().over("datetime")
+        keys = self._group_keys()
+        return x - x.mean().over(keys)
 
 
 class _Winsorize(_CrossSectionalTransform):

--- a/investing_algorithm_framework/domain/pipeline/factors/__init__.py
+++ b/investing_algorithm_framework/domain/pipeline/factors/__init__.py
@@ -1,18 +1,26 @@
-"""Built-in factors shipped with the Pipeline API (Phase 1)."""
+"""Built-in factors shipped with the Pipeline API."""
 from .builtin import (
-    Returns,
     AverageDollarVolume,
     AverageTradedValue,
-    SMA,
+    CrossSectionalMean,
+    Neutralize,
+    Returns,
+    RollingBeta,
     RSI,
+    SMA,
+    StaticPerSymbol,
     Volatility,
 )
 
 __all__ = [
-    "Returns",
     "AverageDollarVolume",
     "AverageTradedValue",
-    "SMA",
+    "CrossSectionalMean",
+    "Neutralize",
+    "Returns",
+    "RollingBeta",
     "RSI",
+    "SMA",
+    "StaticPerSymbol",
     "Volatility",
 ]

--- a/investing_algorithm_framework/domain/pipeline/factors/builtin.py
+++ b/investing_algorithm_framework/domain/pipeline/factors/builtin.py
@@ -11,8 +11,9 @@ processed independently within a single Polars expression.
 from __future__ import annotations
 
 import math
-from typing import List
+from typing import Any, Dict, List, Sequence
 
+import numpy as np
 import polars as pl
 
 from ..factor import Factor
@@ -167,3 +168,329 @@ class Volatility(Factor):
             ).alias("__vol__")
         )
         return df["__vol__"]
+
+
+# --------------------------------------------------------------------- #
+# Risk / neutrality primitives (#504)
+# --------------------------------------------------------------------- #
+class StaticPerSymbol(Factor):
+    """Broadcast a static per-symbol mapping to every row of the panel.
+
+    Useful as input to risk / neutrality transforms: sector tags,
+    country codes, factor-model exposures from a fundamental snapshot,
+    or any per-symbol metadata that doesn't change within a single
+    pipeline evaluation.
+
+    Args:
+        mapping: ``dict[str, Any]`` keyed by symbol. The value may be
+            a string (e.g. sector label), int, float, or bool.
+        default: Value emitted for symbols missing from ``mapping``.
+            Defaults to ``None`` (which becomes a Polars null).
+
+    Example::
+
+        sectors = StaticPerSymbol({
+            "AAPL": "TECH", "MSFT": "TECH",
+            "JPM": "FIN",  "BAC":  "FIN",
+        })
+        neutral = my_alpha.zscore(groups=sectors)
+    """
+
+    inputs: List[str] = []
+
+    def __init__(
+        self,
+        mapping: Dict[str, Any],
+        default: Any = None,
+    ) -> None:
+        super().__init__(window=1)
+        if not isinstance(mapping, dict):
+            raise TypeError(
+                f"StaticPerSymbol expects a dict, "
+                f"got {type(mapping).__name__}"
+            )
+        self._mapping = dict(mapping)
+        self._default = default
+
+    def required_columns(self) -> List[str]:
+        return []
+
+    def compute_panel(self, panel: pl.DataFrame) -> pl.Series:
+        symbols = panel.get_column("symbol").to_list()
+        values = [self._mapping.get(s, self._default) for s in symbols]
+        return pl.Series("__static__", values)
+
+
+class CrossSectionalMean(Factor):
+    """Equal-weighted cross-sectional mean of ``base`` per bar.
+
+    Returns a panel-aligned series where every row at a given
+    ``datetime`` carries the mean of ``base`` across the surviving
+    symbols at that bar. Combined with :class:`Returns`, this is the
+    standard "equal-weighted market return" used as the market leg in
+    :class:`RollingBeta`.
+
+    Args:
+        base: Source factor whose values are averaged per bar.
+        mask: Optional :class:`Filter` restricting which symbols
+            contribute to the mean.
+    """
+
+    def __init__(self, base: Factor, mask=None) -> None:
+        super().__init__(window=base.required_window())
+        self._base = base
+        self._mask = mask
+        cols = list(base.required_columns())
+        if mask is not None:
+            for c in mask.required_columns():
+                if c not in cols:
+                    cols.append(c)
+            self.window = max(self.window, mask.required_window())
+        self.inputs = cols
+
+    def required_columns(self) -> List[str]:
+        return list(self.inputs)
+
+    def required_window(self) -> int:
+        return int(self.window)
+
+    def compute_panel(self, panel: pl.DataFrame) -> pl.Series:
+        values = self._base.evaluate(panel)
+        df = panel.select(["datetime", "symbol"]).with_columns(
+            values.alias("__x__")
+        )
+        if self._mask is not None:
+            mask_values = self._mask.evaluate(panel)
+            df = df.with_columns(
+                pl.when(mask_values)
+                .then(pl.col("__x__"))
+                .otherwise(None)
+                .alias("__x__")
+            )
+        df = df.with_columns(
+            pl.col("__x__").mean().over("datetime").alias("__cs_mean__")
+        )
+        return df["__cs_mean__"]
+
+
+class RollingBeta(Factor):
+    """Per-symbol rolling time-series beta of ``target`` vs ``market``.
+
+    Computes ``cov(target, market) / var(market)`` over the trailing
+    ``window`` bars within each symbol. Both ``target`` and
+    ``market`` are :class:`Factor` instances evaluated against the
+    same panel.
+
+    A typical setup uses :class:`Returns` for the target and
+    ``CrossSectionalMean(Returns(...))`` for the market \u2014 i.e. an
+    equal-weighted market return computed from the universe itself.
+
+    Args:
+        target: Per-symbol time-series factor (e.g. asset returns).
+        market: Per-row market series (typically broadcast across
+            symbols within a bar via :class:`CrossSectionalMean`).
+        window: Lookback in bars for the rolling cov/var.
+    """
+
+    def __init__(
+        self, target: Factor, market: Factor, window: int = 60
+    ) -> None:
+        super().__init__(
+            window=max(
+                target.required_window(),
+                market.required_window(),
+                window,
+            )
+        )
+        if window < 2:
+            raise ValueError("RollingBeta window must be >= 2")
+        self._target = target
+        self._market = market
+        self._beta_window = int(window)
+        cols = list(target.required_columns())
+        for c in market.required_columns():
+            if c not in cols:
+                cols.append(c)
+        self.inputs = cols
+
+    def required_columns(self) -> List[str]:
+        return list(self.inputs)
+
+    def required_window(self) -> int:
+        return int(self.window)
+
+    def compute_panel(self, panel: pl.DataFrame) -> pl.Series:
+        t = self._target.evaluate(panel)
+        m = self._market.evaluate(panel)
+        df = panel.select(["datetime", "symbol"]).with_columns(
+            t.alias("__t__"),
+            m.alias("__m__"),
+        )
+        w = self._beta_window
+        df = df.with_columns(
+            pl.col("__t__")
+            .rolling_mean(window_size=w)
+            .over("symbol")
+            .alias("__et__"),
+            pl.col("__m__")
+            .rolling_mean(window_size=w)
+            .over("symbol")
+            .alias("__em__"),
+            (pl.col("__t__") * pl.col("__m__"))
+            .rolling_mean(window_size=w)
+            .over("symbol")
+            .alias("__etm__"),
+            (pl.col("__m__") * pl.col("__m__"))
+            .rolling_mean(window_size=w)
+            .over("symbol")
+            .alias("__emm__"),
+        )
+        df = df.with_columns(
+            (pl.col("__etm__") - pl.col("__et__") * pl.col("__em__"))
+            .alias("__cov__"),
+            (pl.col("__emm__") - pl.col("__em__") * pl.col("__em__"))
+            .alias("__var__"),
+        )
+        df = df.with_columns(
+            pl.when(
+                (pl.col("__var__") == 0) | pl.col("__var__").is_null()
+            )
+            .then(None)
+            .otherwise(pl.col("__cov__") / pl.col("__var__"))
+            .alias("__beta__")
+        )
+        return df["__beta__"]
+
+
+class Neutralize(Factor):
+    """Cross-sectional OLS residualisation per bar.
+
+    For each ``datetime``, fits ``target ~ exposures`` via ordinary
+    least squares across the surviving symbols and returns the
+    residuals. Subsumes:
+
+    - **Sector neutrality** \u2014 pass sector dummies as ``exposures``
+      (or use the ergonomic :meth:`Factor.demean` / :meth:`zscore`
+      with ``groups=...`` for the simple one-sector case).
+    - **Beta neutralisation** \u2014 pass an equal-weighted market return
+      (e.g. ``CrossSectionalMean(Returns(...))``) as the sole
+      exposure.
+    - **Multi-factor risk models** \u2014 pass [size, value, momentum,
+      sector dummies, \u2026] as ``exposures``.
+
+    Symbols masked out (or rows where any exposure is null) are
+    excluded from the OLS fit and receive ``null`` in the output.
+    Bars where the design matrix is rank-deficient (e.g. fewer
+    surviving symbols than exposures) yield ``null`` for every
+    symbol at that bar.
+
+    Args:
+        target: The factor to residualise.
+        exposures: One or more :class:`Factor` instances forming the
+            design matrix.
+        mask: Optional :class:`Filter` restricting which symbols
+            contribute to the regression.
+        add_intercept: If ``True`` (default), prepends a column of
+            ones to the design matrix so the residuals are zero-mean
+            within each bar.
+    """
+
+    def __init__(
+        self,
+        target: Factor,
+        exposures: Sequence[Factor],
+        mask=None,
+        add_intercept: bool = True,
+    ) -> None:
+        if not exposures:
+            raise ValueError(
+                "Neutralize requires at least one exposure factor"
+            )
+        max_w = target.required_window()
+        for e in exposures:
+            max_w = max(max_w, e.required_window())
+        if mask is not None:
+            max_w = max(max_w, mask.required_window())
+        super().__init__(window=max_w)
+        self._target = target
+        self._exposures = list(exposures)
+        self._mask = mask
+        self._add_intercept = bool(add_intercept)
+        cols: List[str] = list(target.required_columns())
+        for e in self._exposures:
+            for c in e.required_columns():
+                if c not in cols:
+                    cols.append(c)
+        if mask is not None:
+            for c in mask.required_columns():
+                if c not in cols:
+                    cols.append(c)
+        self.inputs = cols
+
+    def required_columns(self) -> List[str]:
+        return list(self.inputs)
+
+    def required_window(self) -> int:
+        return int(self.window)
+
+    def compute_panel(self, panel: pl.DataFrame) -> pl.Series:
+        t_arr = self._target.evaluate(panel).to_numpy().astype(float)
+        e_arrs = [
+            e.evaluate(panel).to_numpy().astype(float)
+            for e in self._exposures
+        ]
+        if self._mask is not None:
+            mask_arr = self._mask.evaluate(panel).to_numpy().astype(bool)
+        else:
+            mask_arr = np.ones(len(t_arr), dtype=bool)
+        dt = panel.get_column("datetime").to_numpy()
+
+        # Stack exposures column-wise; optionally prepend an
+        # intercept so residuals are zero-mean within each bar.
+        X_full = np.column_stack(e_arrs)
+        if self._add_intercept:
+            X_full = np.column_stack(
+                [np.ones(len(t_arr), dtype=float), X_full]
+            )
+
+        result = np.full(len(t_arr), np.nan, dtype=float)
+
+        # Group rows by datetime via a single sort + boundary scan \u2014
+        # avoids the O(B*N) cost of np.where(inv == g) for every bar.
+        order = np.argsort(dt, kind="mergesort")
+        dt_sorted = dt[order]
+        # Bar boundaries: indices where dt changes.
+        change = np.concatenate(
+            ([True], dt_sorted[1:] != dt_sorted[:-1])
+        )
+        starts = np.flatnonzero(change)
+        ends = np.append(starts[1:], len(dt_sorted))
+
+        n_exposures_effective = X_full.shape[1]
+        for s, e in zip(starts, ends):
+            idx = order[s:e]
+            valid = (
+                mask_arr[idx]
+                & ~np.isnan(t_arr[idx])
+                & ~np.any(np.isnan(X_full[idx]), axis=1)
+            )
+            if int(valid.sum()) <= n_exposures_effective:
+                # Under-determined / rank-deficient: leave as null.
+                continue
+            idx_v = idx[valid]
+            X_v = X_full[idx_v]
+            t_v = t_arr[idx_v]
+            try:
+                beta, *_ = np.linalg.lstsq(X_v, t_v, rcond=None)
+            except np.linalg.LinAlgError:  # pragma: no cover - defensive
+                continue
+            pred = X_v @ beta
+            result[idx_v] = t_v - pred
+
+        # Convert NaN sentinels (rank-deficient bars, masked rows) into
+        # Polars nulls so downstream consumers can use ``is_null()``
+        # uniformly. ``fill_nan(None)`` is the documented way to do
+        # this conversion in Polars.
+        return pl.Series(
+            "__neutralized__", result, dtype=pl.Float64
+        ).fill_nan(None)

--- a/tests/domain/pipeline/test_factors.py
+++ b/tests/domain/pipeline/test_factors.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import math
+import unittest
 from datetime import datetime, timedelta
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -43,140 +43,153 @@ def _bar(dt_idx, close, volume=1.0):
     return (dt, close, close, close, close, volume)
 
 
-def test_returns_simple_percent_return():
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate([10, 11, 12, 13])]})
-    series = Returns(window=2).compute_panel(panel).to_list()
-    # Bar 0,1 → null; bar 2 → 12/10 - 1; bar 3 → 13/11 - 1
-    assert series[0] is None and series[1] is None
-    assert series[2] == pytest.approx(0.2)
-    assert series[3] == pytest.approx(13.0 / 11.0 - 1.0)
+class TestPipelineFactors(unittest.TestCase):
+
+    def test_returns_simple_percent_return(self):
+        panel = _panel(
+            {"X": [_bar(i, c) for i, c in enumerate([10, 11, 12, 13])]}
+        )
+        series = Returns(window=2).compute_panel(panel).to_list()
+        # Bar 0,1 → null; bar 2 → 12/10 - 1; bar 3 → 13/11 - 1
+        self.assertIsNone(series[0])
+        self.assertIsNone(series[1])
+        self.assertAlmostEqual(series[2], 0.2)
+        self.assertAlmostEqual(series[3], 13.0 / 11.0 - 1.0)
+
+    def test_average_dollar_volume_rolling_mean(self):
+        panel = _panel(
+            {
+                "X": [
+                    (datetime(2024, 1, 1) + timedelta(days=i), c, c, c, c, vol)
+                    for i, (c, vol) in enumerate(
+                        [(10, 1), (20, 2), (30, 3), (40, 4)]
+                    )
+                ]
+            }
+        )
+        series = AverageDollarVolume(window=2).compute_panel(panel).to_list()
+        # close*volume = [10, 40, 90, 160]; rolling mean window=2
+        self.assertIsNone(series[0])
+        self.assertAlmostEqual(series[1], 25.0)
+        self.assertAlmostEqual(series[2], 65.0)
+        self.assertAlmostEqual(series[3], 125.0)
+
+    def test_sma_rolling_mean(self):
+        panel = _panel(
+            {"X": [_bar(i, c) for i, c in enumerate([1, 2, 3, 4, 5])]}
+        )
+        series = SMA(window=3).compute_panel(panel).to_list()
+        self.assertIsNone(series[0])
+        self.assertIsNone(series[1])
+        self.assertAlmostEqual(series[2], 2.0)
+        self.assertAlmostEqual(series[3], 3.0)
+        self.assertAlmostEqual(series[4], 4.0)
+
+    def test_volatility_log_return_stdev_scaled(self):
+        closes = [100.0, 101.0, 99.0, 102.0, 100.0, 103.0]
+        panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
+        window = 4
+        pp_year = 252
+        series = (
+            Volatility(window=window, periods_per_year=pp_year)
+            .compute_panel(panel)
+            .to_list()
+        )
+        # Manually compute the last value
+        log_rets = [
+            math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))
+        ]
+        last_window = log_rets[-window:]
+        mean = sum(last_window) / window
+        var = sum((x - mean) ** 2 for x in last_window) / (window - 1)
+        expected = math.sqrt(var) * math.sqrt(pp_year)
+        self.assertAlmostEqual(series[-1], expected)
+
+    def test_rsi_all_gains_returns_100(self):
+        panel = _panel(
+            {"X": [_bar(i, c) for i, c in enumerate(range(1, 20))]}
+        )
+        series = RSI(window=4).compute_panel(panel).to_list()
+        # All gains, no losses → avg_loss == 0 → RSI clamped to 100
+        self.assertAlmostEqual(series[-1], 100.0)
+
+    def test_rsi_with_losses_strictly_between_0_and_100(self):
+        closes = [100, 102, 101, 103, 99, 104, 100, 106, 101]
+        panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
+        series = RSI(window=4).compute_panel(panel).to_list()
+        last = series[-1]
+        self.assertIsNotNone(last)
+        self.assertGreater(last, 0.0)
+        self.assertLess(last, 100.0)
+
+    def test_factor_rank_orders_within_each_bar(self):
+        # 3 symbols, 1 bar of meaningful data — rank needs Returns(window=1).
+        panel = _panel(
+            {
+                "AAA": [_bar(0, 100), _bar(1, 110)],  # +10%
+                "BBB": [_bar(0, 100), _bar(1, 105)],  # +5%
+                "CCC": [_bar(0, 100), _bar(1, 120)],  # +20%
+            }
+        )
+        ranked = Returns(window=1).rank().compute_panel(panel)
+        df = (
+            panel.select(["datetime", "symbol"])
+            .with_columns(ranked.alias("rk"))
+            .filter(pl.col("datetime") == datetime(2024, 1, 2))
+        )
+        out = {row["symbol"]: row["rk"] for row in df.to_dicts()}
+        # Ascending ordinal ranks: BBB=1, AAA=2, CCC=3
+        self.assertEqual(out["BBB"], 1.0)
+        self.assertEqual(out["AAA"], 2.0)
+        self.assertEqual(out["CCC"], 3.0)
+
+    def test_factor_top_filter_keeps_highest(self):
+        panel = _panel(
+            {
+                "AAA": [_bar(0, 100), _bar(1, 110)],
+                "BBB": [_bar(0, 100), _bar(1, 105)],
+                "CCC": [_bar(0, 100), _bar(1, 120)],
+            }
+        )
+        mask = Returns(window=1).top(2).compute_panel(panel)
+        df = (
+            panel.select(["datetime", "symbol"])
+            .with_columns(mask.alias("m"))
+            .filter(pl.col("datetime") == datetime(2024, 1, 2))
+        )
+        out = {row["symbol"]: row["m"] for row in df.to_dicts()}
+        # Top 2 by descending returns: CCC (20%) and AAA (10%)
+        self.assertTrue(out["AAA"])
+        self.assertTrue(out["CCC"])
+        self.assertFalse(out["BBB"])
+
+    def test_factor_bottom_filter_keeps_lowest(self):
+        panel = _panel(
+            {
+                "AAA": [_bar(0, 100), _bar(1, 110)],
+                "BBB": [_bar(0, 100), _bar(1, 105)],
+                "CCC": [_bar(0, 100), _bar(1, 120)],
+            }
+        )
+        mask = Returns(window=1).bottom(1).compute_panel(panel)
+        df = (
+            panel.select(["datetime", "symbol"])
+            .with_columns(mask.alias("m"))
+            .filter(pl.col("datetime") == datetime(2024, 1, 2))
+        )
+        out = {row["symbol"]: row["m"] for row in df.to_dicts()}
+        self.assertTrue(out["BBB"])
+        self.assertFalse(out["AAA"])
+        self.assertFalse(out["CCC"])
+
+    def test_factor_invalid_window_raises(self):
+        with self.assertRaises(ValueError):
+            Returns(window=0)
+
+    def test_volatility_invalid_periods_raises(self):
+        with self.assertRaises(ValueError):
+            Volatility(window=10, periods_per_year=0)
 
 
-def test_average_dollar_volume_rolling_mean():
-    panel = _panel(
-        {
-            "X": [
-                (datetime(2024, 1, 1) + timedelta(days=i), c, c, c, c, vol)
-                for i, (c, vol) in enumerate(
-                    [(10, 1), (20, 2), (30, 3), (40, 4)]
-                )
-            ]
-        }
-    )
-    series = AverageDollarVolume(window=2).compute_panel(panel).to_list()
-    # close*volume = [10, 40, 90, 160]; rolling mean window=2
-    assert series[0] is None
-    assert series[1] == pytest.approx(25.0)
-    assert series[2] == pytest.approx(65.0)
-    assert series[3] == pytest.approx(125.0)
-
-
-def test_sma_rolling_mean():
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate([1, 2, 3, 4, 5])]})
-    series = SMA(window=3).compute_panel(panel).to_list()
-    assert series[0] is None and series[1] is None
-    assert series[2] == pytest.approx(2.0)
-    assert series[3] == pytest.approx(3.0)
-    assert series[4] == pytest.approx(4.0)
-
-
-def test_volatility_log_return_stdev_scaled():
-    closes = [100.0, 101.0, 99.0, 102.0, 100.0, 103.0]
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
-    window = 4
-    pp_year = 252
-    series = (
-        Volatility(window=window, periods_per_year=pp_year)
-        .compute_panel(panel)
-        .to_list()
-    )
-    # Manually compute the last value
-    log_rets = [math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))]
-    last_window = log_rets[-window:]
-    mean = sum(last_window) / window
-    var = sum((x - mean) ** 2 for x in last_window) / (window - 1)
-    expected = math.sqrt(var) * math.sqrt(pp_year)
-    assert series[-1] == pytest.approx(expected)
-
-
-def test_rsi_all_gains_returns_100():
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate(range(1, 20))]})
-    series = RSI(window=4).compute_panel(panel).to_list()
-    # All gains, no losses → avg_loss == 0 → RSI clamped to 100
-    assert series[-1] == pytest.approx(100.0)
-
-
-def test_rsi_with_losses_strictly_between_0_and_100():
-    closes = [100, 102, 101, 103, 99, 104, 100, 106, 101]
-    panel = _panel({"X": [_bar(i, c) for i, c in enumerate(closes)]})
-    series = RSI(window=4).compute_panel(panel).to_list()
-    last = series[-1]
-    assert last is not None
-    assert 0.0 < last < 100.0
-
-
-def test_factor_rank_orders_within_each_bar():
-    # 3 symbols, 1 bar of meaningful data — but rank needs Returns(window=1).
-    panel = _panel(
-        {
-            "AAA": [_bar(0, 100), _bar(1, 110)],  # +10%
-            "BBB": [_bar(0, 100), _bar(1, 105)],  # +5%
-            "CCC": [_bar(0, 100), _bar(1, 120)],  # +20%
-        }
-    )
-    ranked = Returns(window=1).rank().compute_panel(panel)
-    df = panel.select(["datetime", "symbol"]).with_columns(
-        ranked.alias("rk")
-    ).filter(pl.col("datetime") == datetime(2024, 1, 2))
-    out = {row["symbol"]: row["rk"] for row in df.to_dicts()}
-    # Ascending ordinal ranks: BBB=1, AAA=2, CCC=3
-    assert out["BBB"] == 1.0
-    assert out["AAA"] == 2.0
-    assert out["CCC"] == 3.0
-
-
-def test_factor_top_filter_keeps_highest():
-    panel = _panel(
-        {
-            "AAA": [_bar(0, 100), _bar(1, 110)],
-            "BBB": [_bar(0, 100), _bar(1, 105)],
-            "CCC": [_bar(0, 100), _bar(1, 120)],
-        }
-    )
-    mask = Returns(window=1).top(2).compute_panel(panel)
-    df = panel.select(["datetime", "symbol"]).with_columns(
-        mask.alias("m")
-    ).filter(pl.col("datetime") == datetime(2024, 1, 2))
-    out = {row["symbol"]: row["m"] for row in df.to_dicts()}
-    # Top 2 by descending returns: CCC (20%) and AAA (10%)
-    assert out["AAA"] is True
-    assert out["CCC"] is True
-    assert out["BBB"] is False
-
-
-def test_factor_bottom_filter_keeps_lowest():
-    panel = _panel(
-        {
-            "AAA": [_bar(0, 100), _bar(1, 110)],
-            "BBB": [_bar(0, 100), _bar(1, 105)],
-            "CCC": [_bar(0, 100), _bar(1, 120)],
-        }
-    )
-    mask = Returns(window=1).bottom(1).compute_panel(panel)
-    df = panel.select(["datetime", "symbol"]).with_columns(
-        mask.alias("m")
-    ).filter(pl.col("datetime") == datetime(2024, 1, 2))
-    out = {row["symbol"]: row["m"] for row in df.to_dicts()}
-    assert out["BBB"] is True
-    assert out["AAA"] is False
-    assert out["CCC"] is False
-
-
-def test_factor_invalid_window_raises():
-    with pytest.raises(ValueError):
-        Returns(window=0)
-
-
-def test_volatility_invalid_periods_raises():
-    with pytest.raises(ValueError):
-        Volatility(window=10, periods_per_year=0)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/domain/pipeline/test_pipeline.py
+++ b/tests/domain/pipeline/test_pipeline.py
@@ -5,7 +5,7 @@ See ``investing_algorithm_framework/domain/pipeline/pipeline.py`` and
 """
 from __future__ import annotations
 
-import pytest
+import unittest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -22,48 +22,50 @@ class _Screener(Pipeline):
     alpha = momentum.rank(mask=universe)
 
 
-def test_pipeline_collects_columns_excluding_universe():
-    cols = _Screener.get_columns()
-    assert list(cols.keys()) == ["dollar_volume", "momentum", "alpha"]
-    assert _Screener.get_universe() is _Screener.universe
+class TestPipelineIntrospection(unittest.TestCase):
+
+    def test_pipeline_collects_columns_excluding_universe(self):
+        cols = _Screener.get_columns()
+        self.assertEqual(
+            list(cols.keys()), ["dollar_volume", "momentum", "alpha"]
+        )
+        self.assertIs(_Screener.get_universe(), _Screener.universe)
+
+    def test_pipeline_required_columns_union(self):
+        required = _Screener.required_columns()
+        # AverageDollarVolume needs close+volume, Returns needs close
+        self.assertIn("close", required)
+        self.assertIn("volume", required)
+
+    def test_pipeline_required_window_is_max(self):
+        self.assertEqual(_Screener.required_window(), 5)
+
+    def test_pipeline_name_defaults_to_class_name(self):
+        self.assertEqual(_Screener.name(), "_Screener")
+
+    def test_pipeline_with_no_columns_raises(self):
+        with self.assertRaisesRegex(TypeError, "declares no factor columns"):
+            class _Empty(Pipeline):
+                pass
+
+    def test_pipeline_universe_must_be_filter(self):
+        with self.assertRaisesRegex(TypeError, "must be a Filter"):
+            class _BadUniverse(Pipeline):
+                momentum = Returns(window=3)
+                # Returns is a Factor, not a Filter
+                universe = momentum
+
+    def test_pipeline_inheritance_collects_parent_columns(self):
+        class _Child(_Screener):
+            sma = SMA(window=4)
+
+        cols = _Child.get_columns()
+        # Child columns + parent columns
+        self.assertIn("sma", cols)
+        self.assertIn("dollar_volume", cols)
+        self.assertIn("momentum", cols)
+        self.assertIn("alpha", cols)
 
 
-def test_pipeline_required_columns_union():
-    required = _Screener.required_columns()
-    # AverageDollarVolume needs close+volume, Returns needs close
-    assert "close" in required
-    assert "volume" in required
-
-
-def test_pipeline_required_window_is_max():
-    assert _Screener.required_window() == 5
-
-
-def test_pipeline_name_defaults_to_class_name():
-    assert _Screener.name() == "_Screener"
-
-
-def test_pipeline_with_no_columns_raises():
-    with pytest.raises(TypeError, match="declares no factor columns"):
-        class _Empty(Pipeline):
-            pass
-
-
-def test_pipeline_universe_must_be_filter():
-    with pytest.raises(TypeError, match="must be a Filter"):
-        class _BadUniverse(Pipeline):
-            momentum = Returns(window=3)
-            # Returns is a Factor, not a Filter
-            universe = momentum
-
-
-def test_pipeline_inheritance_collects_parent_columns():
-    class _Child(_Screener):
-        sma = SMA(window=4)
-
-    cols = _Child.get_columns()
-    # Child columns + parent columns
-    assert "sma" in cols
-    assert "dollar_volume" in cols
-    assert "momentum" in cols
-    assert "alpha" in cols
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/domain/pipeline/test_risk_neutrality.py
+++ b/tests/domain/pipeline/test_risk_neutrality.py
@@ -1,0 +1,360 @@
+"""Tests for risk-neutrality primitives (#504).
+
+Covers:
+- ``StaticPerSymbol`` broadcasting
+- ``CrossSectionalMean``
+- ``Factor.zscore(groups=...)`` and ``Factor.demean(groups=...)``
+- ``RollingBeta``
+- ``Neutralize`` (cross-sectional OLS residualisation)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from investing_algorithm_framework import (
+    AverageDollarVolume,
+    CrossSectionalMean,
+    Neutralize,
+    Pipeline,
+    Returns,
+    RollingBeta,
+    StaticPerSymbol,
+)
+from investing_algorithm_framework.services.pipeline import PipelineEngine
+
+
+def _ohlcv(symbol_to_closes):
+    out = {}
+    for sym, closes in symbol_to_closes.items():
+        rows = []
+        for i, close in enumerate(closes):
+            rows.append(
+                {
+                    "Datetime": datetime(2024, 1, 1) + timedelta(days=i),
+                    "Open": close,
+                    "High": close,
+                    "Low": close,
+                    "Close": close,
+                    "Volume": 100,
+                }
+            )
+        out[sym] = pl.DataFrame(rows)
+    return out
+
+
+# --------------------------------------------------------------------- #
+# StaticPerSymbol
+# --------------------------------------------------------------------- #
+def test_static_per_symbol_broadcasts_dict():
+    class _Pipe(Pipeline):
+        sectors = StaticPerSymbol(
+            {"AAA": "TECH", "BBB": "FIN", "CCC": "TECH"}
+        )
+        # Need a numeric column so the pipeline produces output.
+        r = Returns(window=1)
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12],
+            "BBB": [10, 11, 12],
+            "CCC": [10, 11, 12],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 3),
+    )
+    rows = {row["symbol"]: row["sectors"] for row in result.to_dicts()}
+    assert rows == {"AAA": "TECH", "BBB": "FIN", "CCC": "TECH"}
+
+
+def test_static_per_symbol_default_for_missing():
+    factor = StaticPerSymbol({"AAA": 1.0}, default=0.0)
+    assert factor._mapping == {"AAA": 1.0}
+    assert factor._default == 0.0
+
+
+def test_static_per_symbol_rejects_non_dict():
+    with pytest.raises(TypeError):
+        StaticPerSymbol([("AAA", "TECH")])  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------- #
+# Sector-neutral demean / zscore via groups=
+# --------------------------------------------------------------------- #
+def test_demean_with_groups_is_sector_relative():
+    """With sector groups, mean of demeaned values is zero *within
+    each sector* per bar, not across the whole universe."""
+
+    class _Pipe(Pipeline):
+        sectors = StaticPerSymbol(
+            {"AAA": "T", "BBB": "T", "CCC": "F", "DDD": "F"}
+        )
+        r = Returns(window=1)
+        sector_neutral = r.demean(groups=sectors)
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12],
+            "BBB": [10, 11, 13],
+            "CCC": [10, 11, 14],
+            "DDD": [10, 11, 15],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 3),
+    )
+    by_sector = {"T": [], "F": []}
+    for row in result.to_dicts():
+        by_sector[row["sectors"]].append(row["sector_neutral"])
+    for vals in by_sector.values():
+        assert sum(vals) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_zscore_with_groups_dict_argument():
+    """Passing a dict directly (not a StaticPerSymbol) works."""
+
+    class _Pipe(Pipeline):
+        r = Returns(window=1)
+        z = r.zscore(
+            groups={"AAA": "T", "BBB": "T", "CCC": "F", "DDD": "F"}
+        )
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12],
+            "BBB": [10, 11, 13],
+            "CCC": [10, 11, 14],
+            "DDD": [10, 11, 15],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 3),
+    )
+    zs = [row["z"] for row in result.to_dicts() if row["z"] is not None]
+    assert len(zs) == 4
+    # In each 2-symbol sector the z-scores must be +/- 1 (or null if std=0).
+    pairs = sorted(zs)
+    assert pairs[0] == pytest.approx(-pairs[-1], abs=1e-9)
+
+
+# --------------------------------------------------------------------- #
+# CrossSectionalMean
+# --------------------------------------------------------------------- #
+def test_cross_sectional_mean_equals_average_per_bar():
+    class _Pipe(Pipeline):
+        r = Returns(window=1)
+        market = CrossSectionalMean(r)
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12],
+            "BBB": [10, 12, 14],
+            "CCC": [10, 13, 16],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 3),
+    )
+    rows = result.to_dicts()
+    expected = sum(row["r"] for row in rows) / len(rows)
+    for row in rows:
+        assert row["market"] == pytest.approx(expected)
+
+
+# --------------------------------------------------------------------- #
+# RollingBeta
+# --------------------------------------------------------------------- #
+def test_rolling_beta_of_market_with_itself_is_one():
+    """Beta of any series against itself is identically 1 (where
+    variance is non-zero)."""
+
+    class _Pipe(Pipeline):
+        r = Returns(window=1)
+        beta = RollingBeta(r, r, window=5)
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+            "BBB": [10, 12, 14, 16, 18, 20, 22, 24, 26, 28],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 10),
+    )
+    for row in result.to_dicts():
+        if row["beta"] is not None:
+            assert row["beta"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_rolling_beta_zero_variance_yields_null():
+    """When the market series has zero variance over the window,
+    beta is null (not inf)."""
+
+    class _Pipe(Pipeline):
+        r = Returns(window=1)
+        # Use a CrossSectionalMean of a constant-return series \u2014
+        # variance will be zero except at the boundary.
+        beta = RollingBeta(r, CrossSectionalMean(r), window=5)
+
+    data = _ohlcv(
+        {
+            "AAA": [10] * 10,  # zero returns \u2192 zero variance
+            "BBB": [10] * 10,
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 10),
+    )
+    for row in result.to_dicts():
+        assert row["beta"] is None
+
+
+def test_rolling_beta_window_validation():
+    with pytest.raises(ValueError):
+        RollingBeta(Returns(1), Returns(1), window=1)
+
+
+# --------------------------------------------------------------------- #
+# Neutralize (cross-sectional OLS)
+# --------------------------------------------------------------------- #
+def test_neutralize_residuals_are_orthogonal_to_exposures():
+    """Residuals from OLS must be orthogonal to the design matrix in
+    each bar (a fundamental property of least-squares)."""
+
+    class _Pipe(Pipeline):
+        r = Returns(window=1)
+        size = StaticPerSymbol(
+            {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0}
+        )
+        residual = Neutralize(r, exposures=[size])
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12],
+            "BBB": [10, 12, 14],
+            "CCC": [10, 13, 16],
+            "DDD": [10, 14, 18],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 3),
+    )
+    rows = result.to_dicts()
+    residuals = np.array([row["residual"] for row in rows])
+    sizes = np.array([row["size"] for row in rows])
+    # With an intercept, residuals must sum to zero AND be orthogonal
+    # to the size column.
+    assert residuals.sum() == pytest.approx(0.0, abs=1e-9)
+    assert (residuals * sizes).sum() == pytest.approx(0.0, abs=1e-9)
+
+
+def test_neutralize_rank_deficient_bar_yields_null():
+    """When fewer surviving symbols than exposures+intercept, the
+    bar's residuals are null (system is under-determined)."""
+
+    class _Pipe(Pipeline):
+        r = Returns(window=1)
+        e1 = StaticPerSymbol({"AAA": 1.0, "BBB": 2.0})
+        e2 = StaticPerSymbol({"AAA": 3.0, "BBB": 4.0})
+        # 2 exposures + intercept = 3 parameters, only 2 symbols \u2192
+        # under-determined.
+        residual = Neutralize(r, exposures=[e1, e2])
+
+    data = _ohlcv({"AAA": [10, 11, 12], "BBB": [10, 12, 14]})
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 3),
+    )
+    for row in result.to_dicts():
+        assert row["residual"] is None
+
+
+def test_neutralize_with_market_factor_strips_beta():
+    """Neutralizing returns against an equal-weighted market return
+    leaves residuals whose dot product with the market is zero."""
+
+    class _Pipe(Pipeline):
+        r = Returns(window=1)
+        market = CrossSectionalMean(r)
+        residual = Neutralize(r, exposures=[market])
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12, 13, 14],
+            "BBB": [10, 12, 13, 15, 16],
+            "CCC": [10, 13, 14, 16, 18],
+            "DDD": [10, 9, 11, 10, 12],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 5),
+    )
+    rows = result.to_dicts()
+    residuals = np.array([row["residual"] for row in rows])
+    market = np.array([row["market"] for row in rows])
+    assert (residuals * market).sum() == pytest.approx(0.0, abs=1e-9)
+
+
+def test_neutralize_requires_at_least_one_exposure():
+    with pytest.raises(ValueError):
+        Neutralize(Returns(1), exposures=[])
+
+
+def test_neutralize_with_mask_excludes_filtered_symbols():
+    class _Pipe(Pipeline):
+        adv = AverageDollarVolume(window=1)
+        r = Returns(window=1)
+        size = StaticPerSymbol(
+            {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0}
+        )
+        universe = adv.top(3)
+        residual = Neutralize(r, exposures=[size], mask=universe)
+
+    data = _ohlcv(
+        {
+            "AAA": [10, 11, 12],
+            "BBB": [10, 12, 14],
+            "CCC": [10, 13, 16],
+            "DDD": [10, 14, 18],
+        }
+    )
+    result = PipelineEngine().evaluate(
+        pipeline_cls=_Pipe,
+        data_object=data,
+        symbol_to_identifier={s: s for s in data},
+        as_of=datetime(2024, 1, 3),
+    )
+    # Universe filter drops one symbol \u2014 surviving rows must have
+    # non-null residuals (3 symbols, 1 exposure + intercept = 2 params).
+    for row in result.to_dicts():
+        assert row["residual"] is not None

--- a/tests/domain/pipeline/test_risk_neutrality.py
+++ b/tests/domain/pipeline/test_risk_neutrality.py
@@ -9,11 +9,11 @@ Covers:
 """
 from __future__ import annotations
 
+import unittest
 from datetime import datetime, timedelta
 
 import numpy as np
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -46,315 +46,310 @@ def _ohlcv(symbol_to_closes):
     return out
 
 
-# --------------------------------------------------------------------- #
-# StaticPerSymbol
-# --------------------------------------------------------------------- #
-def test_static_per_symbol_broadcasts_dict():
-    class _Pipe(Pipeline):
-        sectors = StaticPerSymbol(
-            {"AAA": "TECH", "BBB": "FIN", "CCC": "TECH"}
+class TestStaticPerSymbol(unittest.TestCase):
+
+    def test_static_per_symbol_broadcasts_dict(self):
+        class _Pipe(Pipeline):
+            sectors = StaticPerSymbol(
+                {"AAA": "TECH", "BBB": "FIN", "CCC": "TECH"}
+            )
+            # Need a numeric column so the pipeline produces output.
+            r = Returns(window=1)
+
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12],
+                "BBB": [10, 11, 12],
+                "CCC": [10, 11, 12],
+            }
         )
-        # Need a numeric column so the pipeline produces output.
-        r = Returns(window=1)
-
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12],
-            "BBB": [10, 11, 12],
-            "CCC": [10, 11, 12],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    rows = {row["symbol"]: row["sectors"] for row in result.to_dicts()}
-    assert rows == {"AAA": "TECH", "BBB": "FIN", "CCC": "TECH"}
-
-
-def test_static_per_symbol_default_for_missing():
-    factor = StaticPerSymbol({"AAA": 1.0}, default=0.0)
-    assert factor._mapping == {"AAA": 1.0}
-    assert factor._default == 0.0
-
-
-def test_static_per_symbol_rejects_non_dict():
-    with pytest.raises(TypeError):
-        StaticPerSymbol([("AAA", "TECH")])  # type: ignore[arg-type]
-
-
-# --------------------------------------------------------------------- #
-# Sector-neutral demean / zscore via groups=
-# --------------------------------------------------------------------- #
-def test_demean_with_groups_is_sector_relative():
-    """With sector groups, mean of demeaned values is zero *within
-    each sector* per bar, not across the whole universe."""
-
-    class _Pipe(Pipeline):
-        sectors = StaticPerSymbol(
-            {"AAA": "T", "BBB": "T", "CCC": "F", "DDD": "F"}
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
         )
-        r = Returns(window=1)
-        sector_neutral = r.demean(groups=sectors)
-
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12],
-            "BBB": [10, 11, 13],
-            "CCC": [10, 11, 14],
-            "DDD": [10, 11, 15],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    by_sector = {"T": [], "F": []}
-    for row in result.to_dicts():
-        by_sector[row["sectors"]].append(row["sector_neutral"])
-    for vals in by_sector.values():
-        assert sum(vals) == pytest.approx(0.0, abs=1e-9)
-
-
-def test_zscore_with_groups_dict_argument():
-    """Passing a dict directly (not a StaticPerSymbol) works."""
-
-    class _Pipe(Pipeline):
-        r = Returns(window=1)
-        z = r.zscore(
-            groups={"AAA": "T", "BBB": "T", "CCC": "F", "DDD": "F"}
+        rows = {row["symbol"]: row["sectors"] for row in result.to_dicts()}
+        self.assertEqual(
+            rows, {"AAA": "TECH", "BBB": "FIN", "CCC": "TECH"}
         )
 
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12],
-            "BBB": [10, 11, 13],
-            "CCC": [10, 11, 14],
-            "DDD": [10, 11, 15],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    zs = [row["z"] for row in result.to_dicts() if row["z"] is not None]
-    assert len(zs) == 4
-    # In each 2-symbol sector the z-scores must be +/- 1 (or null if std=0).
-    pairs = sorted(zs)
-    assert pairs[0] == pytest.approx(-pairs[-1], abs=1e-9)
+    def test_static_per_symbol_default_for_missing(self):
+        factor = StaticPerSymbol({"AAA": 1.0}, default=0.0)
+        self.assertEqual(factor._mapping, {"AAA": 1.0})
+        self.assertEqual(factor._default, 0.0)
+
+    def test_static_per_symbol_rejects_non_dict(self):
+        with self.assertRaises(TypeError):
+            StaticPerSymbol([("AAA", "TECH")])  # type: ignore[arg-type]
 
 
-# --------------------------------------------------------------------- #
-# CrossSectionalMean
-# --------------------------------------------------------------------- #
-def test_cross_sectional_mean_equals_average_per_bar():
-    class _Pipe(Pipeline):
-        r = Returns(window=1)
-        market = CrossSectionalMean(r)
+class TestSectorNeutralTransforms(unittest.TestCase):
 
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12],
-            "BBB": [10, 12, 14],
-            "CCC": [10, 13, 16],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    rows = result.to_dicts()
-    expected = sum(row["r"] for row in rows) / len(rows)
-    for row in rows:
-        assert row["market"] == pytest.approx(expected)
+    def test_demean_with_groups_is_sector_relative(self):
+        """With sector groups, mean of demeaned values is zero *within
+        each sector* per bar, not across the whole universe."""
 
+        class _Pipe(Pipeline):
+            sectors = StaticPerSymbol(
+                {"AAA": "T", "BBB": "T", "CCC": "F", "DDD": "F"}
+            )
+            r = Returns(window=1)
+            sector_neutral = r.demean(groups=sectors)
 
-# --------------------------------------------------------------------- #
-# RollingBeta
-# --------------------------------------------------------------------- #
-def test_rolling_beta_of_market_with_itself_is_one():
-    """Beta of any series against itself is identically 1 (where
-    variance is non-zero)."""
-
-    class _Pipe(Pipeline):
-        r = Returns(window=1)
-        beta = RollingBeta(r, r, window=5)
-
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
-            "BBB": [10, 12, 14, 16, 18, 20, 22, 24, 26, 28],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 10),
-    )
-    for row in result.to_dicts():
-        if row["beta"] is not None:
-            assert row["beta"] == pytest.approx(1.0, abs=1e-6)
-
-
-def test_rolling_beta_zero_variance_yields_null():
-    """When the market series has zero variance over the window,
-    beta is null (not inf)."""
-
-    class _Pipe(Pipeline):
-        r = Returns(window=1)
-        # Use a CrossSectionalMean of a constant-return series \u2014
-        # variance will be zero except at the boundary.
-        beta = RollingBeta(r, CrossSectionalMean(r), window=5)
-
-    data = _ohlcv(
-        {
-            "AAA": [10] * 10,  # zero returns \u2192 zero variance
-            "BBB": [10] * 10,
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 10),
-    )
-    for row in result.to_dicts():
-        assert row["beta"] is None
-
-
-def test_rolling_beta_window_validation():
-    with pytest.raises(ValueError):
-        RollingBeta(Returns(1), Returns(1), window=1)
-
-
-# --------------------------------------------------------------------- #
-# Neutralize (cross-sectional OLS)
-# --------------------------------------------------------------------- #
-def test_neutralize_residuals_are_orthogonal_to_exposures():
-    """Residuals from OLS must be orthogonal to the design matrix in
-    each bar (a fundamental property of least-squares)."""
-
-    class _Pipe(Pipeline):
-        r = Returns(window=1)
-        size = StaticPerSymbol(
-            {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0}
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12],
+                "BBB": [10, 11, 13],
+                "CCC": [10, 11, 14],
+                "DDD": [10, 11, 15],
+            }
         )
-        residual = Neutralize(r, exposures=[size])
-
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12],
-            "BBB": [10, 12, 14],
-            "CCC": [10, 13, 16],
-            "DDD": [10, 14, 18],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    rows = result.to_dicts()
-    residuals = np.array([row["residual"] for row in rows])
-    sizes = np.array([row["size"] for row in rows])
-    # With an intercept, residuals must sum to zero AND be orthogonal
-    # to the size column.
-    assert residuals.sum() == pytest.approx(0.0, abs=1e-9)
-    assert (residuals * sizes).sum() == pytest.approx(0.0, abs=1e-9)
-
-
-def test_neutralize_rank_deficient_bar_yields_null():
-    """When fewer surviving symbols than exposures+intercept, the
-    bar's residuals are null (system is under-determined)."""
-
-    class _Pipe(Pipeline):
-        r = Returns(window=1)
-        e1 = StaticPerSymbol({"AAA": 1.0, "BBB": 2.0})
-        e2 = StaticPerSymbol({"AAA": 3.0, "BBB": 4.0})
-        # 2 exposures + intercept = 3 parameters, only 2 symbols \u2192
-        # under-determined.
-        residual = Neutralize(r, exposures=[e1, e2])
-
-    data = _ohlcv({"AAA": [10, 11, 12], "BBB": [10, 12, 14]})
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    for row in result.to_dicts():
-        assert row["residual"] is None
-
-
-def test_neutralize_with_market_factor_strips_beta():
-    """Neutralizing returns against an equal-weighted market return
-    leaves residuals whose dot product with the market is zero."""
-
-    class _Pipe(Pipeline):
-        r = Returns(window=1)
-        market = CrossSectionalMean(r)
-        residual = Neutralize(r, exposures=[market])
-
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12, 13, 14],
-            "BBB": [10, 12, 13, 15, 16],
-            "CCC": [10, 13, 14, 16, 18],
-            "DDD": [10, 9, 11, 10, 12],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 5),
-    )
-    rows = result.to_dicts()
-    residuals = np.array([row["residual"] for row in rows])
-    market = np.array([row["market"] for row in rows])
-    assert (residuals * market).sum() == pytest.approx(0.0, abs=1e-9)
-
-
-def test_neutralize_requires_at_least_one_exposure():
-    with pytest.raises(ValueError):
-        Neutralize(Returns(1), exposures=[])
-
-
-def test_neutralize_with_mask_excludes_filtered_symbols():
-    class _Pipe(Pipeline):
-        adv = AverageDollarVolume(window=1)
-        r = Returns(window=1)
-        size = StaticPerSymbol(
-            {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0}
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
         )
-        universe = adv.top(3)
-        residual = Neutralize(r, exposures=[size], mask=universe)
+        by_sector = {"T": [], "F": []}
+        for row in result.to_dicts():
+            by_sector[row["sectors"]].append(row["sector_neutral"])
+        for vals in by_sector.values():
+            self.assertAlmostEqual(sum(vals), 0.0, places=9)
 
-    data = _ohlcv(
-        {
-            "AAA": [10, 11, 12],
-            "BBB": [10, 12, 14],
-            "CCC": [10, 13, 16],
-            "DDD": [10, 14, 18],
-        }
-    )
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    # Universe filter drops one symbol \u2014 surviving rows must have
-    # non-null residuals (3 symbols, 1 exposure + intercept = 2 params).
-    for row in result.to_dicts():
-        assert row["residual"] is not None
+    def test_zscore_with_groups_dict_argument(self):
+        """Passing a dict directly (not a StaticPerSymbol) works."""
+
+        class _Pipe(Pipeline):
+            r = Returns(window=1)
+            z = r.zscore(
+                groups={"AAA": "T", "BBB": "T", "CCC": "F", "DDD": "F"}
+            )
+
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12],
+                "BBB": [10, 11, 13],
+                "CCC": [10, 11, 14],
+                "DDD": [10, 11, 15],
+            }
+        )
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        zs = [
+            row["z"] for row in result.to_dicts() if row["z"] is not None
+        ]
+        self.assertEqual(len(zs), 4)
+        # In each 2-symbol sector the z-scores must be +/- 1
+        # (or null if std=0).
+        pairs = sorted(zs)
+        self.assertAlmostEqual(pairs[0], -pairs[-1], places=9)
+
+
+class TestCrossSectionalMean(unittest.TestCase):
+
+    def test_cross_sectional_mean_equals_average_per_bar(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=1)
+            market = CrossSectionalMean(r)
+
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12],
+                "BBB": [10, 12, 14],
+                "CCC": [10, 13, 16],
+            }
+        )
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        rows = result.to_dicts()
+        expected = sum(row["r"] for row in rows) / len(rows)
+        for row in rows:
+            self.assertAlmostEqual(row["market"], expected)
+
+
+class TestRollingBeta(unittest.TestCase):
+
+    def test_rolling_beta_of_market_with_itself_is_one(self):
+        """Beta of any series against itself is identically 1 (where
+        variance is non-zero)."""
+
+        class _Pipe(Pipeline):
+            r = Returns(window=1)
+            beta = RollingBeta(r, r, window=5)
+
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+                "BBB": [10, 12, 14, 16, 18, 20, 22, 24, 26, 28],
+            }
+        )
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 10),
+        )
+        for row in result.to_dicts():
+            if row["beta"] is not None:
+                self.assertAlmostEqual(row["beta"], 1.0, places=6)
+
+    def test_rolling_beta_zero_variance_yields_null(self):
+        """When the market series has zero variance over the window,
+        beta is null (not inf)."""
+
+        class _Pipe(Pipeline):
+            r = Returns(window=1)
+            # Use a CrossSectionalMean of a constant-return series \u2014
+            # variance will be zero except at the boundary.
+            beta = RollingBeta(r, CrossSectionalMean(r), window=5)
+
+        data = _ohlcv(
+            {
+                "AAA": [10] * 10,  # zero returns -> zero variance
+                "BBB": [10] * 10,
+            }
+        )
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 10),
+        )
+        for row in result.to_dicts():
+            self.assertIsNone(row["beta"])
+
+    def test_rolling_beta_window_validation(self):
+        with self.assertRaises(ValueError):
+            RollingBeta(Returns(1), Returns(1), window=1)
+
+
+class TestNeutralize(unittest.TestCase):
+
+    def test_neutralize_residuals_are_orthogonal_to_exposures(self):
+        """Residuals from OLS must be orthogonal to the design matrix in
+        each bar (a fundamental property of least-squares)."""
+
+        class _Pipe(Pipeline):
+            r = Returns(window=1)
+            size = StaticPerSymbol(
+                {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0}
+            )
+            residual = Neutralize(r, exposures=[size])
+
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12],
+                "BBB": [10, 12, 14],
+                "CCC": [10, 13, 16],
+                "DDD": [10, 14, 18],
+            }
+        )
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        rows = result.to_dicts()
+        residuals = np.array([row["residual"] for row in rows])
+        sizes = np.array([row["size"] for row in rows])
+        # With an intercept, residuals must sum to zero AND be orthogonal
+        # to the size column.
+        self.assertAlmostEqual(residuals.sum(), 0.0, places=9)
+        self.assertAlmostEqual((residuals * sizes).sum(), 0.0, places=9)
+
+    def test_neutralize_rank_deficient_bar_yields_null(self):
+        """When fewer surviving symbols than exposures+intercept, the
+        bar's residuals are null (system is under-determined)."""
+
+        class _Pipe(Pipeline):
+            r = Returns(window=1)
+            e1 = StaticPerSymbol({"AAA": 1.0, "BBB": 2.0})
+            e2 = StaticPerSymbol({"AAA": 3.0, "BBB": 4.0})
+            # 2 exposures + intercept = 3 parameters, only 2 symbols ->
+            # under-determined.
+            residual = Neutralize(r, exposures=[e1, e2])
+
+        data = _ohlcv({"AAA": [10, 11, 12], "BBB": [10, 12, 14]})
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        for row in result.to_dicts():
+            self.assertIsNone(row["residual"])
+
+    def test_neutralize_with_market_factor_strips_beta(self):
+        """Neutralizing returns against an equal-weighted market return
+        leaves residuals whose dot product with the market is zero."""
+
+        class _Pipe(Pipeline):
+            r = Returns(window=1)
+            market = CrossSectionalMean(r)
+            residual = Neutralize(r, exposures=[market])
+
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12, 13, 14],
+                "BBB": [10, 12, 13, 15, 16],
+                "CCC": [10, 13, 14, 16, 18],
+                "DDD": [10, 9, 11, 10, 12],
+            }
+        )
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 5),
+        )
+        rows = result.to_dicts()
+        residuals = np.array([row["residual"] for row in rows])
+        market = np.array([row["market"] for row in rows])
+        self.assertAlmostEqual((residuals * market).sum(), 0.0, places=9)
+
+    def test_neutralize_requires_at_least_one_exposure(self):
+        with self.assertRaises(ValueError):
+            Neutralize(Returns(1), exposures=[])
+
+    def test_neutralize_with_mask_excludes_filtered_symbols(self):
+        class _Pipe(Pipeline):
+            adv = AverageDollarVolume(window=1)
+            r = Returns(window=1)
+            size = StaticPerSymbol(
+                {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0, "DDD": 4.0}
+            )
+            universe = adv.top(3)
+            residual = Neutralize(r, exposures=[size], mask=universe)
+
+        data = _ohlcv(
+            {
+                "AAA": [10, 11, 12],
+                "BBB": [10, 12, 14],
+                "CCC": [10, 13, 16],
+                "DDD": [10, 14, 18],
+            }
+        )
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        # Universe filter drops one symbol -- surviving rows must have
+        # non-null residuals (3 symbols, 1 exposure + intercept = 2 params).
+        for row in result.to_dicts():
+            self.assertIsNotNone(row["residual"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infrastructure/services/backtesting/test_vector_backtest_pipeline_injection.py
+++ b/tests/infrastructure/services/backtesting/test_vector_backtest_pipeline_injection.py
@@ -8,11 +8,12 @@ directly without spinning up a full backtest.
 """
 from __future__ import annotations
 
+import logging
+import unittest
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -77,110 +78,27 @@ def _make_data_sources_and_data():
     return sources, data
 
 
-def test_inject_pipelines_no_pipelines_is_noop():
-    sources, data = _make_data_sources_and_data()
-    strategy = _StubStrategy(data_sources=sources, pipelines=None)
-    before = dict(data)
+class TestVectorBacktestPipelineInjection(unittest.TestCase):
 
-    VectorBacktestService._inject_pipelines(
-        strategy=strategy,
-        data=data,
-        backtest_date_range=BacktestDateRange(
-            start_date=datetime(2024, 1, 2),
-            end_date=datetime(2024, 1, 4),
-        ),
-    )
-    assert data == before
+    def test_inject_pipelines_no_pipelines_is_noop(self):
+        sources, data = _make_data_sources_and_data()
+        strategy = _StubStrategy(data_sources=sources, pipelines=None)
+        before = dict(data)
 
-
-def test_inject_pipelines_adds_long_frame_keyed_by_class_name():
-    sources, data = _make_data_sources_and_data()
-    strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
-
-    VectorBacktestService._inject_pipelines(
-        strategy=strategy,
-        data=data,
-        backtest_date_range=BacktestDateRange(
-            start_date=datetime(2024, 1, 2),
-            end_date=datetime(2024, 1, 4),
-        ),
-    )
-
-    assert "_Screener" in data
-    out = data["_Screener"]
-    assert isinstance(out, pl.DataFrame)
-    # Long format: datetime + symbol + factor columns (universe dropped)
-    assert set(out.columns) == {"datetime", "symbol", "adv", "momentum"}
-    # Universe restricts to top-2 by ADV every bar; BBB always loses
-    # (volume=1 vs 100/200) so it must never appear in the output.
-    assert "BBB/EUR" not in out["symbol"].to_list()
-
-
-def test_inject_pipelines_respects_end_date_no_lookahead():
-    sources, data = _make_data_sources_and_data()
-    strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
-
-    VectorBacktestService._inject_pipelines(
-        strategy=strategy,
-        data=data,
-        backtest_date_range=BacktestDateRange(
-            start_date=datetime(2024, 1, 2),
-            end_date=datetime(2024, 1, 3),
-        ),
-    )
-    out = data["_Screener"]
-    # No bars beyond end_date should leak in.
-    max_dt = out["datetime"].max()
-    assert max_dt <= datetime(2024, 1, 3)
-
-
-def test_inject_pipelines_skips_when_no_ohlcv_sources(caplog):
-    """A strategy with pipelines but no OHLCV data sources should log
-    and skip silently without raising."""
-    strategy = _StubStrategy(data_sources=[], pipelines=[_Screener])
-    data = {}
-
-    with caplog.at_level(
-        "WARNING",
-        logger=(
-            "investing_algorithm_framework.infrastructure.services."
-            "backtesting.vector_backtest_service"
-        ),
-    ):
         VectorBacktestService._inject_pipelines(
             strategy=strategy,
             data=data,
             backtest_date_range=BacktestDateRange(
                 start_date=datetime(2024, 1, 2),
-                end_date=datetime(2024, 1, 3),
+                end_date=datetime(2024, 1, 4),
             ),
         )
+        self.assertEqual(data, before)
 
-    assert "_Screener" not in data
-    assert any(
-        "no OHLCV data sources" in record.message
-        for record in caplog.records
-    )
+    def test_inject_pipelines_adds_long_frame_keyed_by_class_name(self):
+        sources, data = _make_data_sources_and_data()
+        strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
 
-
-def test_inject_pipelines_re_raises_engine_errors():
-    """Pipeline evaluation errors should propagate to the caller so
-    backtest authors see a clear failure rather than a silent skip."""
-
-    class _Broken(Pipeline):
-        adv = AverageDollarVolume(window=2)
-        momentum = Returns(window=2)
-
-    sources, data = _make_data_sources_and_data()
-    # Corrupt one of the inputs to force a polars-level error.
-    bad_id = sources[0].get_identifier()
-    data[bad_id] = pl.DataFrame(
-        {"Datetime": [datetime(2024, 1, 1)], "Close": [10.0]}
-    )
-
-    strategy = _StubStrategy(data_sources=sources, pipelines=[_Broken])
-
-    with pytest.raises(Exception):
         VectorBacktestService._inject_pipelines(
             strategy=strategy,
             data=data,
@@ -190,7 +108,91 @@ def test_inject_pipelines_re_raises_engine_errors():
             ),
         )
 
+        self.assertIn("_Screener", data)
+        out = data["_Screener"]
+        self.assertIsInstance(out, pl.DataFrame)
+        # Long format: datetime + symbol + factor columns (universe dropped)
+        self.assertEqual(
+            set(out.columns), {"datetime", "symbol", "adv", "momentum"}
+        )
+        # Universe restricts to top-2 by ADV every bar; BBB always loses
+        # (volume=1 vs 100/200) so it must never appear in the output.
+        self.assertNotIn("BBB/EUR", out["symbol"].to_list())
+
+    def test_inject_pipelines_respects_end_date_no_lookahead(self):
+        sources, data = _make_data_sources_and_data()
+        strategy = _StubStrategy(data_sources=sources, pipelines=[_Screener])
+
+        VectorBacktestService._inject_pipelines(
+            strategy=strategy,
+            data=data,
+            backtest_date_range=BacktestDateRange(
+                start_date=datetime(2024, 1, 2),
+                end_date=datetime(2024, 1, 3),
+            ),
+        )
+        out = data["_Screener"]
+        # No bars beyond end_date should leak in.
+        max_dt = out["datetime"].max()
+        self.assertLessEqual(max_dt, datetime(2024, 1, 3))
+
+    def test_inject_pipelines_skips_when_no_ohlcv_sources(self):
+        """A strategy with pipelines but no OHLCV data sources should log
+        and skip silently without raising."""
+        strategy = _StubStrategy(data_sources=[], pipelines=[_Screener])
+        data = {}
+
+        logger_name = (
+            "investing_algorithm_framework.infrastructure.services."
+            "backtesting.vector_backtest_service"
+        )
+        with self.assertLogs(logger_name, level=logging.WARNING) as cm:
+            VectorBacktestService._inject_pipelines(
+                strategy=strategy,
+                data=data,
+                backtest_date_range=BacktestDateRange(
+                    start_date=datetime(2024, 1, 2),
+                    end_date=datetime(2024, 1, 3),
+                ),
+            )
+
+        self.assertNotIn("_Screener", data)
+        self.assertTrue(
+            any("no OHLCV data sources" in msg for msg in cm.output)
+        )
+
+    def test_inject_pipelines_re_raises_engine_errors(self):
+        """Pipeline evaluation errors should propagate to the caller so
+        backtest authors see a clear failure rather than a silent skip."""
+
+        class _Broken(Pipeline):
+            adv = AverageDollarVolume(window=2)
+            momentum = Returns(window=2)
+
+        sources, data = _make_data_sources_and_data()
+        # Corrupt one of the inputs to force a polars-level error.
+        bad_id = sources[0].get_identifier()
+        data[bad_id] = pl.DataFrame(
+            {"Datetime": [datetime(2024, 1, 1)], "Close": [10.0]}
+        )
+
+        strategy = _StubStrategy(data_sources=sources, pipelines=[_Broken])
+
+        with self.assertRaises(Exception):
+            VectorBacktestService._inject_pipelines(
+                strategy=strategy,
+                data=data,
+                backtest_date_range=BacktestDateRange(
+                    start_date=datetime(2024, 1, 2),
+                    end_date=datetime(2024, 1, 4),
+                ),
+            )
+
 
 # Suppress the unused import warning — kept for symmetry with other
 # vector-backtest tests in the suite.
 _ = SimpleNamespace, DataType
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/pipeline/test_factor_arithmetic_and_lazy.py
+++ b/tests/services/pipeline/test_factor_arithmetic_and_lazy.py
@@ -6,10 +6,10 @@ See ``investing_algorithm_framework/domain/pipeline/factor.py`` and
 """
 from __future__ import annotations
 
+import unittest
 from datetime import datetime, timedelta
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -55,160 +55,150 @@ def _fixed_data():
     )
 
 
-# --------------------------------------------------------------------- #
-# Arithmetic
-# --------------------------------------------------------------------- #
-def test_factor_addition_two_factors():
-    class _Pipe(Pipeline):
-        a = Returns(window=1)
-        b = Returns(window=2)
-        combined = a + b
+class TestFactorArithmetic(unittest.TestCase):
 
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=_fixed_data(),
-        symbol_to_identifier={s: s for s in _fixed_data()},
-        as_of=datetime(2024, 1, 4),
-    )
-    rows = {r["symbol"]: r for r in result.to_dicts()}
-    assert rows["AAA"]["combined"] == pytest.approx(
-        rows["AAA"]["a"] + rows["AAA"]["b"]
-    )
+    def test_factor_addition_two_factors(self):
+        class _Pipe(Pipeline):
+            a = Returns(window=1)
+            b = Returns(window=2)
+            combined = a + b
 
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=_fixed_data(),
+            symbol_to_identifier={s: s for s in _fixed_data()},
+            as_of=datetime(2024, 1, 4),
+        )
+        rows = {r["symbol"]: r for r in result.to_dicts()}
+        self.assertAlmostEqual(
+            rows["AAA"]["combined"], rows["AAA"]["a"] + rows["AAA"]["b"]
+        )
 
-def test_factor_scalar_arithmetic_left_and_right():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        plus_one = r + 1
-        one_minus_r = 1 - r
-        twice = 2 * r
-        half = r / 2
+    def test_factor_scalar_arithmetic_left_and_right(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            plus_one = r + 1
+            one_minus_r = 1 - r
+            twice = 2 * r
+            half = r / 2
 
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=_fixed_data(),
-        symbol_to_identifier={s: s for s in _fixed_data()},
-        as_of=datetime(2024, 1, 3),
-    )
-    row = result.to_dicts()[0]
-    r = row["r"]
-    assert row["plus_one"] == pytest.approx(r + 1)
-    assert row["one_minus_r"] == pytest.approx(1 - r)
-    assert row["twice"] == pytest.approx(2 * r)
-    assert row["half"] == pytest.approx(r / 2)
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=_fixed_data(),
+            symbol_to_identifier={s: s for s in _fixed_data()},
+            as_of=datetime(2024, 1, 3),
+        )
+        row = result.to_dicts()[0]
+        r = row["r"]
+        self.assertAlmostEqual(row["plus_one"], r + 1)
+        self.assertAlmostEqual(row["one_minus_r"], 1 - r)
+        self.assertAlmostEqual(row["twice"], 2 * r)
+        self.assertAlmostEqual(row["half"], r / 2)
 
+    def test_factor_negation(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            neg = -r
 
-def test_factor_negation():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        neg = -r
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=_fixed_data(),
+            symbol_to_identifier={s: s for s in _fixed_data()},
+            as_of=datetime(2024, 1, 3),
+        )
+        row = result.to_dicts()[0]
+        self.assertAlmostEqual(row["neg"], -row["r"])
 
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=_fixed_data(),
-        symbol_to_identifier={s: s for s in _fixed_data()},
-        as_of=datetime(2024, 1, 3),
-    )
-    row = result.to_dicts()[0]
-    assert row["neg"] == pytest.approx(-row["r"])
+    def test_factor_arithmetic_unsupported_type_raises(self):
+        with self.assertRaises(TypeError):
+            Returns(window=2) + "not a factor"
 
-
-def test_factor_arithmetic_unsupported_type_raises():
-    with pytest.raises(TypeError):
-        Returns(window=2) + "not a factor"
-
-
-def test_factor_arithmetic_propagates_window_max():
-    """A composite factor's required_window is the max of its inputs."""
-    a = Returns(window=3)
-    b = SMA(window=10)
-    composite = a + b
-    assert composite.required_window() == 10
+    def test_factor_arithmetic_propagates_window_max(self):
+        """A composite factor's required_window is the max of its inputs."""
+        a = Returns(window=3)
+        b = SMA(window=10)
+        composite = a + b
+        self.assertEqual(composite.required_window(), 10)
 
 
-# --------------------------------------------------------------------- #
-# Cross-sectional transforms
-# --------------------------------------------------------------------- #
-def test_zscore_per_bar_has_zero_mean_and_unit_std():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        z = r.zscore()
+class TestCrossSectionalTransforms(unittest.TestCase):
 
-    data = _fixed_data()
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    zs = [row["z"] for row in result.to_dicts() if row["z"] is not None]
-    # Cross-sectional z-score across symbols at one bar.
-    assert len(zs) >= 2
-    mean = sum(zs) / len(zs)
-    assert mean == pytest.approx(0.0, abs=1e-9)
+    def test_zscore_per_bar_has_zero_mean_and_unit_std(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            z = r.zscore()
 
+        data = _fixed_data()
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        zs = [
+            row["z"] for row in result.to_dicts() if row["z"] is not None
+        ]
+        # Cross-sectional z-score across symbols at one bar.
+        self.assertGreaterEqual(len(zs), 2)
+        mean = sum(zs) / len(zs)
+        self.assertAlmostEqual(mean, 0.0, places=9)
 
-def test_demean_per_bar_sums_to_zero():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        d = r.demean()
+    def test_demean_per_bar_sums_to_zero(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            d = r.demean()
 
-    data = _fixed_data()
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    demeaned = [
-        row["d"] for row in result.to_dicts() if row["d"] is not None
-    ]
-    assert sum(demeaned) == pytest.approx(0.0, abs=1e-9)
+        data = _fixed_data()
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        demeaned = [
+            row["d"] for row in result.to_dicts() if row["d"] is not None
+        ]
+        self.assertAlmostEqual(sum(demeaned), 0.0, places=9)
 
+    def test_winsorize_clips_to_quantile_bounds(self):
+        class _Pipe(Pipeline):
+            r = Returns(window=2)
+            clipped = r.winsorize(lower=0.25, upper=0.75)
 
-def test_winsorize_clips_to_quantile_bounds():
-    class _Pipe(Pipeline):
-        r = Returns(window=2)
-        clipped = r.winsorize(lower=0.25, upper=0.75)
+        data = _fixed_data()
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        rows = result.to_dicts()
+        raw = sorted(row["r"] for row in rows)
+        clipped = sorted(row["clipped"] for row in rows)
+        # Winsorisation cannot widen the range.
+        self.assertLessEqual(max(clipped), max(raw))
+        self.assertGreaterEqual(min(clipped), min(raw))
 
-    data = _fixed_data()
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    rows = result.to_dicts()
-    raw = sorted(row["r"] for row in rows)
-    clipped = sorted(row["clipped"] for row in rows)
-    # Winsorisation cannot widen the range.
-    assert max(clipped) <= max(raw)
-    assert min(clipped) >= min(raw)
+    def test_winsorize_invalid_bounds_raises(self):
+        with self.assertRaises(ValueError):
+            Returns(window=2).winsorize(lower=0.8, upper=0.2)
 
+    def test_zscore_with_mask_excludes_masked_symbols(self):
+        class _Pipe(Pipeline):
+            adv = AverageDollarVolume(window=2)
+            r = Returns(window=2)
+            universe = adv.top(2)
+            z = r.zscore(mask=universe)
 
-def test_winsorize_invalid_bounds_raises():
-    with pytest.raises(ValueError):
-        Returns(window=2).winsorize(lower=0.8, upper=0.2)
-
-
-def test_zscore_with_mask_excludes_masked_symbols():
-    class _Pipe(Pipeline):
-        adv = AverageDollarVolume(window=2)
-        r = Returns(window=2)
-        universe = adv.top(2)
-        z = r.zscore(mask=universe)
-
-    data = _fixed_data()  # all volumes equal so mask is deterministic
-    result = PipelineEngine().evaluate(
-        pipeline_cls=_Pipe,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        as_of=datetime(2024, 1, 3),
-    )
-    # The pipeline universe also drops the masked symbols from the
-    # output frame, so any surviving row must have a non-null zscore.
-    for row in result.to_dicts():
-        assert row["z"] is not None
+        data = _fixed_data()  # all volumes equal so mask is deterministic
+        result = PipelineEngine().evaluate(
+            pipeline_cls=_Pipe,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            as_of=datetime(2024, 1, 3),
+        )
+        for row in result.to_dicts():
+            self.assertIsNotNone(row["z"])
 
 
 # --------------------------------------------------------------------- #
@@ -221,87 +211,93 @@ class _Screener(Pipeline):
     alpha = momentum.rank(mask=universe)
 
 
-def test_lazy_engine_matches_eager_engine():
-    """Lazy mode must produce identical output to eager mode for the
-    same dataset and pipeline."""
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
+class TestLazyEngine(unittest.TestCase):
 
-    eager = VectorPipelineEngine(lazy=False).evaluate_window(
-        pipeline_cls=_Screener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-    )
-    lazy = VectorPipelineEngine(lazy=True).evaluate_window(
-        pipeline_cls=_Screener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-    )
-    assert eager.to_dicts() == lazy.to_dicts()
+    def test_lazy_engine_matches_eager_engine(self):
+        """Lazy mode must produce identical output to eager mode for the
+        same dataset and pipeline."""
+        data = _fixed_data()
+        sym_id = {s: s for s in data}
 
+        eager = VectorPipelineEngine(lazy=False).evaluate_window(
+            pipeline_cls=_Screener,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+        )
+        lazy = VectorPipelineEngine(lazy=True).evaluate_window(
+            pipeline_cls=_Screener,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+        )
+        self.assertEqual(eager.to_dicts(), lazy.to_dicts())
 
-def test_lazy_engine_without_universe():
-    """Lazy path with no universe filter still produces a sorted long
-    frame."""
+    def test_lazy_engine_without_universe(self):
+        """Lazy path with no universe filter still produces a sorted long
+        frame."""
 
-    class _NoUniverse(Pipeline):
-        momentum = Returns(window=2)
+        class _NoUniverse(Pipeline):
+            momentum = Returns(window=2)
 
-    data = _fixed_data()
-    result = VectorPipelineEngine(lazy=True).evaluate_window(
-        pipeline_cls=_NoUniverse,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    pairs = [(r["datetime"], r["symbol"]) for r in result.to_dicts()]
-    assert pairs == sorted(pairs)
+        data = _fixed_data()
+        result = VectorPipelineEngine(lazy=True).evaluate_window(
+            pipeline_cls=_NoUniverse,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
+        pairs = [(r["datetime"], r["symbol"]) for r in result.to_dicts()]
+        self.assertEqual(pairs, sorted(pairs))
 
+    def test_lazy_engine_empty_input(self):
+        class _NoUniverse(Pipeline):
+            momentum = Returns(window=2)
 
-def test_lazy_engine_empty_input():
-    class _NoUniverse(Pipeline):
-        momentum = Returns(window=2)
-
-    result = VectorPipelineEngine(lazy=True).evaluate_window(
-        pipeline_cls=_NoUniverse,
-        data_object={},
-        symbol_to_identifier={},
-    )
-    assert result.is_empty()
+        result = VectorPipelineEngine(lazy=True).evaluate_window(
+            pipeline_cls=_NoUniverse,
+            data_object={},
+            symbol_to_identifier={},
+        )
+        self.assertTrue(result.is_empty())
 
 
 # --------------------------------------------------------------------- #
 # Stateless / Lambda + Functions safety
 # --------------------------------------------------------------------- #
-def test_evaluation_does_not_leak_cache_state():
-    """Each ``evaluate`` call must reset the contextvar cache so that
-    a second invocation in the same process (e.g. an Azure Function or
-    AWS Lambda warm container) sees a fresh cache.
-    """
-    from investing_algorithm_framework.domain.pipeline.factor import (
-        _EVAL_CACHE,
-    )
+class TestEvaluationCacheState(unittest.TestCase):
 
-    class _NoUniverse(Pipeline):
-        momentum = Returns(window=2)
+    def test_evaluation_does_not_leak_cache_state(self):
+        """Each ``evaluate`` call must reset the contextvar cache so that
+        a second invocation in the same process (e.g. an Azure Function or
+        AWS Lambda warm container) sees a fresh cache.
+        """
+        from investing_algorithm_framework.domain.pipeline.factor import (
+            _EVAL_CACHE,
+        )
 
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
-    engine = PipelineEngine()
+        class _NoUniverse(Pipeline):
+            momentum = Returns(window=2)
 
-    assert _EVAL_CACHE.get() is None
+        data = _fixed_data()
+        sym_id = {s: s for s in data}
+        engine = PipelineEngine()
 
-    engine.evaluate(
-        pipeline_cls=_NoUniverse,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=datetime(2024, 1, 3),
-    )
-    assert _EVAL_CACHE.get() is None
+        self.assertIsNone(_EVAL_CACHE.get())
 
-    engine.evaluate(
-        pipeline_cls=_NoUniverse,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=datetime(2024, 1, 4),
-    )
-    assert _EVAL_CACHE.get() is None
+        engine.evaluate(
+            pipeline_cls=_NoUniverse,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            as_of=datetime(2024, 1, 3),
+        )
+        self.assertIsNone(_EVAL_CACHE.get())
+
+        engine.evaluate(
+            pipeline_cls=_NoUniverse,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            as_of=datetime(2024, 1, 4),
+        )
+        self.assertIsNone(_EVAL_CACHE.get())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/pipeline/test_pipeline_engine.py
+++ b/tests/services/pipeline/test_pipeline_engine.py
@@ -1,10 +1,10 @@
 """End-to-end tests for the eager Phase 1 PipelineEngine."""
 from __future__ import annotations
 
+import unittest
 from datetime import datetime, timedelta
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -44,124 +44,132 @@ class _MomentumScreener(Pipeline):
     alpha = momentum.rank(mask=universe)
 
 
-def test_engine_evaluates_pipeline_and_applies_universe():
-    data = _ohlcv(
-        {
-            "AAA": [(10, 100), (12, 100), (14, 100)],   # adv=1300
-            "BBB": [(10, 1), (11, 1), (12, 1)],          # adv=11.5 -> dropped
-            "CCC": [(10, 200), (11, 200), (13, 200)],    # adv=2400
-        }
-    )
-    symbol_to_identifier = {s: s for s in data}
-    as_of = datetime(2024, 1, 3)
+class TestPipelineEngine(unittest.TestCase):
 
-    engine = PipelineEngine()
-    result = engine.evaluate(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier=symbol_to_identifier,
-        as_of=as_of,
-    )
-
-    assert set(result.columns) == {"symbol", "adv", "momentum", "alpha"}
-    rows = {r["symbol"]: r for r in result.to_dicts()}
-    assert set(rows) == {"AAA", "CCC"}
-    # Momentum at as_of is close[t]/close[t-2] - 1
-    assert rows["AAA"]["momentum"] == pytest.approx(0.4)
-    assert rows["CCC"]["momentum"] == pytest.approx(0.3)
-    # alpha = ascending ordinal rank within universe → CCC=1, AAA=2
-    assert rows["CCC"]["alpha"] == 1.0
-    assert rows["AAA"]["alpha"] == 2.0
-
-
-def test_engine_no_lookahead_extra_future_bars_do_not_change_result():
-    """Adding bars strictly after ``as_of`` must not affect output."""
-    closes_short = [(10, 100), (12, 100), (14, 100)]
-    closes_long = closes_short + [(20, 100), (25, 100)]
-
-    class _Single(Pipeline):
-        momentum = Returns(window=2)
-
-    engine = PipelineEngine()
-    as_of = datetime(2024, 1, 3)
-
-    short = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object=_ohlcv({"AAA": closes_short}),
-        symbol_to_identifier={"AAA": "AAA"},
-        as_of=as_of,
-    )
-    long = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object=_ohlcv({"AAA": closes_long}),
-        symbol_to_identifier={"AAA": "AAA"},
-        as_of=as_of,
-    )
-    assert short.to_dicts() == long.to_dicts()
-
-
-def test_engine_handles_pandas_data_frames():
-    pd = pytest.importorskip("pandas")
-
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
-
-    bars = [
-        {
-            "Datetime": datetime(2024, 1, 1) + timedelta(days=i),
-            "Open": c, "High": c, "Low": c, "Close": c, "Volume": 1.0,
-        }
-        for i, c in enumerate([10, 11, 12])
-    ]
-    data = {"AAA": pd.DataFrame(bars)}
-
-    engine = PipelineEngine()
-    result = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object=data,
-        symbol_to_identifier={"AAA": "AAA"},
-        as_of=datetime(2024, 1, 3),
-    )
-    assert result.to_dicts() == [
-        {"symbol": "AAA", "momentum": pytest.approx(12.0 / 11.0 - 1.0)}
-    ]
-
-
-def test_engine_empty_panel_returns_empty_frame():
-    engine = PipelineEngine()
-
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
-
-    result = engine.evaluate(
-        pipeline_cls=_Single,
-        data_object={},
-        symbol_to_identifier={},
-        as_of=datetime(2024, 1, 3),
-    )
-    assert result.is_empty()
-    assert set(result.columns) == {"symbol", "momentum"}
-
-
-def test_engine_missing_required_column_raises():
-    """A data source missing a required OHLCV column must error loudly."""
-    bad = {
-        "AAA": pl.DataFrame(
-            [
-                {"Datetime": datetime(2024, 1, 1), "Close": 10.0}
-                # Missing Open/High/Low/Volume
-            ]
+    def test_engine_evaluates_pipeline_and_applies_universe(self):
+        data = _ohlcv(
+            {
+                "AAA": [(10, 100), (12, 100), (14, 100)],   # adv=1300
+                "BBB": [(10, 1), (11, 1), (12, 1)],          # adv=11.5 -> dropped
+                "CCC": [(10, 200), (11, 200), (13, 200)],    # adv=2400
+            }
         )
-    }
+        symbol_to_identifier = {s: s for s in data}
+        as_of = datetime(2024, 1, 3)
 
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
+        engine = PipelineEngine()
+        result = engine.evaluate(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier=symbol_to_identifier,
+            as_of=as_of,
+        )
 
-    engine = PipelineEngine()
-    with pytest.raises(KeyError):
-        engine.evaluate(
+        self.assertEqual(
+            set(result.columns), {"symbol", "adv", "momentum", "alpha"}
+        )
+        rows = {r["symbol"]: r for r in result.to_dicts()}
+        self.assertEqual(set(rows), {"AAA", "CCC"})
+        # Momentum at as_of is close[t]/close[t-2] - 1
+        self.assertAlmostEqual(rows["AAA"]["momentum"], 0.4)
+        self.assertAlmostEqual(rows["CCC"]["momentum"], 0.3)
+        # alpha = ascending ordinal rank within universe → CCC=1, AAA=2
+        self.assertEqual(rows["CCC"]["alpha"], 1.0)
+        self.assertEqual(rows["AAA"]["alpha"], 2.0)
+
+    def test_engine_no_lookahead_extra_future_bars_do_not_change_result(self):
+        """Adding bars strictly after ``as_of`` must not affect output."""
+        closes_short = [(10, 100), (12, 100), (14, 100)]
+        closes_long = closes_short + [(20, 100), (25, 100)]
+
+        class _Single(Pipeline):
+            momentum = Returns(window=2)
+
+        engine = PipelineEngine()
+        as_of = datetime(2024, 1, 3)
+
+        short = engine.evaluate(
             pipeline_cls=_Single,
-            data_object=bad,
+            data_object=_ohlcv({"AAA": closes_short}),
             symbol_to_identifier={"AAA": "AAA"},
-            as_of=datetime(2024, 1, 1),
+            as_of=as_of,
         )
+        long = engine.evaluate(
+            pipeline_cls=_Single,
+            data_object=_ohlcv({"AAA": closes_long}),
+            symbol_to_identifier={"AAA": "AAA"},
+            as_of=as_of,
+        )
+        self.assertEqual(short.to_dicts(), long.to_dicts())
+
+    def test_engine_handles_pandas_data_frames(self):
+        try:
+            import pandas as pd
+        except ImportError:
+            self.skipTest("pandas not installed")
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        bars = [
+            {
+                "Datetime": datetime(2024, 1, 1) + timedelta(days=i),
+                "Open": c, "High": c, "Low": c, "Close": c, "Volume": 1.0,
+            }
+            for i, c in enumerate([10, 11, 12])
+        ]
+        data = {"AAA": pd.DataFrame(bars)}
+
+        engine = PipelineEngine()
+        result = engine.evaluate(
+            pipeline_cls=_Single,
+            data_object=data,
+            symbol_to_identifier={"AAA": "AAA"},
+            as_of=datetime(2024, 1, 3),
+        )
+        rows = result.to_dicts()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["symbol"], "AAA")
+        self.assertAlmostEqual(rows[0]["momentum"], 12.0 / 11.0 - 1.0)
+
+    def test_engine_empty_panel_returns_empty_frame(self):
+        engine = PipelineEngine()
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        result = engine.evaluate(
+            pipeline_cls=_Single,
+            data_object={},
+            symbol_to_identifier={},
+            as_of=datetime(2024, 1, 3),
+        )
+        self.assertTrue(result.is_empty())
+        self.assertEqual(set(result.columns), {"symbol", "momentum"})
+
+    def test_engine_missing_required_column_raises(self):
+        """A data source missing a required OHLCV column must error loudly."""
+        bad = {
+            "AAA": pl.DataFrame(
+                [
+                    {"Datetime": datetime(2024, 1, 1), "Close": 10.0}
+                    # Missing Open/High/Low/Volume
+                ]
+            )
+        }
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        engine = PipelineEngine()
+        with self.assertRaises(KeyError):
+            engine.evaluate(
+                pipeline_cls=_Single,
+                data_object=bad,
+                symbol_to_identifier={"AAA": "AAA"},
+                as_of=datetime(2024, 1, 1),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/pipeline/test_vector_pipeline_engine.py
+++ b/tests/services/pipeline/test_vector_pipeline_engine.py
@@ -12,10 +12,11 @@ Two layers of testing:
 """
 from __future__ import annotations
 
+import unittest
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import polars as pl
-import pytest
 
 from investing_algorithm_framework import (
     AverageDollarVolume,
@@ -73,195 +74,194 @@ def _fixed_data():
     )
 
 
-# --------------------------------------------------------------------- #
-# Unit tests
-# --------------------------------------------------------------------- #
-def test_vector_engine_returns_full_long_frame():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    result = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-
-    # Long format: datetime + symbol + 3 factor columns (universe dropped)
-    assert set(result.columns) == {
-        "datetime", "symbol", "adv", "momentum", "alpha"
-    }
-    # Sorted by (datetime, symbol)
-    rows = result.to_dicts()
-    pairs = [(r["datetime"], r["symbol"]) for r in rows]
-    assert pairs == sorted(pairs)
-
-
-def test_vector_engine_universe_dropped_from_output():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    result = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    # Universe (adv.top(2)) drops BBB once both AAA and CCC have data.
-    # We only assert BBB is filtered on bars where it lost the universe
-    # contest — the equivalence test below is the strict check.
-    bbb_bars = result.filter(pl.col("symbol") == "BBB")
-    aaa_bars = result.filter(pl.col("symbol") == "AAA")
-    assert len(bbb_bars) <= len(aaa_bars)
-
-
-def test_vector_engine_empty_input_returns_empty_long_frame():
-    engine = VectorPipelineEngine()
-
-    class _Single(Pipeline):
-        momentum = Returns(window=1)
-
-    result = engine.evaluate_window(
-        pipeline_cls=_Single,
-        data_object={},
-        symbol_to_identifier={},
-    )
-    assert result.is_empty()
-    assert set(result.columns) == {"datetime", "symbol", "momentum"}
-
-
-def test_vector_engine_start_end_bounds_applied():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    # ``start`` only excludes earlier bars from the *output*; the panel
-    # still goes back to day 1 because that's all the data we have.
-    # The bound is on the inclusive lower end of the resulting frame.
-    result = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-        start=datetime(2024, 1, 3),
-        end=datetime(2024, 1, 4),
-    )
-    distinct_dts = sorted(result["datetime"].unique().to_list())
-    assert distinct_dts == [datetime(2024, 1, 3), datetime(2024, 1, 4)]
-
-
-def test_vector_engine_caches_factor_results(monkeypatch):
-    """A factor reused by ``rank(mask=...)`` should compute once."""
-    call_count = {"n": 0}
-
-    original = AverageDollarVolume.compute_panel
-
-    def counting_compute(self, panel):
-        call_count["n"] += 1
-        return original(self, panel)
-
-    monkeypatch.setattr(AverageDollarVolume, "compute_panel", counting_compute)
-
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    # adv is declared once and reused inside universe = adv.top(2).
-    # With caching, compute_panel must be called exactly once for the
-    # shared instance.
-    assert call_count["n"] == 1
-
-
-def test_vector_engine_slice_at_returns_event_shape():
-    data = _fixed_data()
-    engine = VectorPipelineEngine()
-    long = engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier={s: s for s in data},
-    )
-    sliced = VectorPipelineEngine.slice_at(long, datetime(2024, 1, 3))
-    assert "datetime" not in sliced.columns
-    assert set(sliced.columns) == {"symbol", "adv", "momentum", "alpha"}
-
-
-# --------------------------------------------------------------------- #
-# Equivalence tests (2e) — vector vs event mode must match per bar
-# --------------------------------------------------------------------- #
 def _normalise(df: pl.DataFrame) -> list:
-    """Return a hashable, order-stable representation of the frame."""
+    """Return an order-stable representation of the frame, with floats
+    rounded so equality comparison is robust to fp wiggle."""
     rows = df.sort("symbol").to_dicts()
     out = []
     for row in rows:
         out.append(
             {
-                k: (
-                    pytest.approx(v, rel=1e-9, abs=1e-12)
-                    if isinstance(v, float)
-                    else v
-                )
+                k: (round(v, 9) if isinstance(v, float) else v)
                 for k, v in row.items()
             }
         )
     return out
 
 
-@pytest.mark.parametrize(
-    "as_of",
-    [
-        datetime(2024, 1, 2),
-        datetime(2024, 1, 3),
-        datetime(2024, 1, 4),
-    ],
-)
-def test_vector_matches_event_mode_per_bar(as_of):
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
+class TestVectorPipelineEngineUnit(unittest.TestCase):
 
-    event_engine = PipelineEngine()
-    vector_engine = VectorPipelineEngine()
+    def test_vector_engine_returns_full_long_frame(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        result = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
 
-    event_result = event_engine.evaluate(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=as_of,
-    )
+        # Long format: datetime + symbol + 3 factor columns (universe dropped)
+        self.assertEqual(
+            set(result.columns),
+            {"datetime", "symbol", "adv", "momentum", "alpha"},
+        )
+        rows = result.to_dicts()
+        pairs = [(r["datetime"], r["symbol"]) for r in rows]
+        self.assertEqual(pairs, sorted(pairs))
 
-    vector_long = vector_engine.evaluate_window(
-        pipeline_cls=_MomentumScreener,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        end=as_of,
-    )
-    vector_sliced = VectorPipelineEngine.slice_at(vector_long, as_of)
+    def test_vector_engine_universe_dropped_from_output(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        result = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
+        bbb_bars = result.filter(pl.col("symbol") == "BBB")
+        aaa_bars = result.filter(pl.col("symbol") == "AAA")
+        self.assertLessEqual(len(bbb_bars), len(aaa_bars))
 
-    assert set(event_result.columns) == set(vector_sliced.columns)
-    assert _normalise(event_result) == _normalise(vector_sliced)
+    def test_vector_engine_empty_input_returns_empty_long_frame(self):
+        engine = VectorPipelineEngine()
+
+        class _Single(Pipeline):
+            momentum = Returns(window=1)
+
+        result = engine.evaluate_window(
+            pipeline_cls=_Single,
+            data_object={},
+            symbol_to_identifier={},
+        )
+        self.assertTrue(result.is_empty())
+        self.assertEqual(
+            set(result.columns), {"datetime", "symbol", "momentum"}
+        )
+
+    def test_vector_engine_start_end_bounds_applied(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        result = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+            start=datetime(2024, 1, 3),
+            end=datetime(2024, 1, 4),
+        )
+        distinct_dts = sorted(result["datetime"].unique().to_list())
+        self.assertEqual(
+            distinct_dts, [datetime(2024, 1, 3), datetime(2024, 1, 4)]
+        )
+
+    def test_vector_engine_caches_factor_results(self):
+        """A factor reused by ``rank(mask=...)`` should compute once."""
+        call_count = {"n": 0}
+        original = AverageDollarVolume.compute_panel
+
+        def counting_compute(self, panel):
+            call_count["n"] += 1
+            return original(self, panel)
+
+        with patch.object(
+            AverageDollarVolume, "compute_panel", counting_compute
+        ):
+            data = _fixed_data()
+            engine = VectorPipelineEngine()
+            engine.evaluate_window(
+                pipeline_cls=_MomentumScreener,
+                data_object=data,
+                symbol_to_identifier={s: s for s in data},
+            )
+        # adv is declared once and reused inside universe = adv.top(2).
+        # With caching, compute_panel must be called exactly once for the
+        # shared instance.
+        self.assertEqual(call_count["n"], 1)
+
+    def test_vector_engine_slice_at_returns_event_shape(self):
+        data = _fixed_data()
+        engine = VectorPipelineEngine()
+        long = engine.evaluate_window(
+            pipeline_cls=_MomentumScreener,
+            data_object=data,
+            symbol_to_identifier={s: s for s in data},
+        )
+        sliced = VectorPipelineEngine.slice_at(long, datetime(2024, 1, 3))
+        self.assertNotIn("datetime", sliced.columns)
+        self.assertEqual(
+            set(sliced.columns), {"symbol", "adv", "momentum", "alpha"}
+        )
 
 
-def test_vector_matches_event_mode_with_volatility_factor():
-    """Add a heavier factor to widen coverage of the equivalence check."""
+class TestVectorPipelineEngineEquivalence(unittest.TestCase):
 
-    class _MultiFactor(Pipeline):
-        adv = AverageDollarVolume(window=2)
-        mom = Returns(window=2)
-        vol = Volatility(window=3)
-        universe = adv.top(2)
-        alpha = mom.rank(mask=universe)
+    def test_vector_matches_event_mode_per_bar(self):
+        for as_of in (
+            datetime(2024, 1, 2),
+            datetime(2024, 1, 3),
+            datetime(2024, 1, 4),
+        ):
+            with self.subTest(as_of=as_of):
+                data = _fixed_data()
+                sym_id = {s: s for s in data}
 
-    data = _fixed_data()
-    sym_id = {s: s for s in data}
-    as_of = datetime(2024, 1, 4)
+                event_engine = PipelineEngine()
+                vector_engine = VectorPipelineEngine()
 
-    event_result = PipelineEngine().evaluate(
-        pipeline_cls=_MultiFactor,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        as_of=as_of,
-    )
-    vector_long = VectorPipelineEngine().evaluate_window(
-        pipeline_cls=_MultiFactor,
-        data_object=data,
-        symbol_to_identifier=sym_id,
-        end=as_of,
-    )
-    vector_sliced = VectorPipelineEngine.slice_at(vector_long, as_of)
+                event_result = event_engine.evaluate(
+                    pipeline_cls=_MomentumScreener,
+                    data_object=data,
+                    symbol_to_identifier=sym_id,
+                    as_of=as_of,
+                )
 
-    assert _normalise(event_result) == _normalise(vector_sliced)
+                vector_long = vector_engine.evaluate_window(
+                    pipeline_cls=_MomentumScreener,
+                    data_object=data,
+                    symbol_to_identifier=sym_id,
+                    end=as_of,
+                )
+                vector_sliced = VectorPipelineEngine.slice_at(
+                    vector_long, as_of
+                )
+
+                self.assertEqual(
+                    set(event_result.columns), set(vector_sliced.columns)
+                )
+                self.assertEqual(
+                    _normalise(event_result), _normalise(vector_sliced)
+                )
+
+    def test_vector_matches_event_mode_with_volatility_factor(self):
+        """Add a heavier factor to widen coverage of the equivalence check."""
+
+        class _MultiFactor(Pipeline):
+            adv = AverageDollarVolume(window=2)
+            mom = Returns(window=2)
+            vol = Volatility(window=3)
+            universe = adv.top(2)
+            alpha = mom.rank(mask=universe)
+
+        data = _fixed_data()
+        sym_id = {s: s for s in data}
+        as_of = datetime(2024, 1, 4)
+
+        event_result = PipelineEngine().evaluate(
+            pipeline_cls=_MultiFactor,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            as_of=as_of,
+        )
+        vector_long = VectorPipelineEngine().evaluate_window(
+            pipeline_cls=_MultiFactor,
+            data_object=data,
+            symbol_to_identifier=sym_id,
+            end=as_of,
+        )
+        vector_sliced = VectorPipelineEngine.slice_at(vector_long, as_of)
+
+        self.assertEqual(
+            _normalise(event_result), _normalise(vector_sliced)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #504. Stacked on top of #508 (`feat/503-pipeline-api-phase3-live`).

Adds first-class risk-neutrality primitives to the pipeline DSL so users can build sector-neutral, beta-neutral, and multi-factor-neutral signals without leaving the framework.

## What's new

### `StaticPerSymbol(mapping, default=None)`
Broadcasts a `dict[symbol, value]` across the cross-section. `window=1`, no inputs. Useful for sector tags, market-cap tiers, fundamental snapshots.

### `CrossSectionalMean(base, mask=None)`
Per-bar equal-weight mean of any factor — the canonical "market" series for beta neutralisation.

### `RollingBeta(target, market, window>=2)`
Time-series OLS beta via `cov(t,m)/var(m)` on a rolling window. Returns null when `var(market) == 0` instead of `inf`.

### `Neutralize(target, exposures=[...], mask=None, add_intercept=True)`
Per-bar OLS residualisation. Residuals are orthogonal to each exposure within each bar by construction. Rank-deficient bars (`n_surviving <= n_params`) yield null residuals.

### `groups=` on `zscore` / `demean`
`Factor.zscore(groups=...)` and `Factor.demean(groups=...)` now accept either a `dict[symbol, key]` (auto-wrapped via `StaticPerSymbol`) or any `Factor` that emits a per-symbol category. Stats are computed within each `(datetime, group)` — i.e. sector-relative normalisation.

## How the three canonical use cases compose

```python
# Sector neutrality
signal = momentum.zscore(groups=SECTORS)

# Beta neutralisation
market = CrossSectionalMean(Returns(window=1))
beta   = RollingBeta(Returns(window=1), market, window=60)
alpha  = Neutralize(Returns(window=1), exposures=[beta])

# Multi-factor risk model
residual = Neutralize(r, exposures=[size, value, mom])
```

## Tests
14 new tests in `tests/domain/pipeline/test_risk_neutrality.py` covering:
- dict broadcast + default for missing symbols
- sector-relative demean sums to 0 per sector
- `groups=dict` shorthand wires through `StaticPerSymbol`
- `CrossSectionalMean` equals per-bar avg
- `RollingBeta(x, x) == 1`, zero-variance → null, `window<2` raises
- OLS orthogonality: `residuals.sum() == 0` and `(residuals * exposure).sum() == 0`
- market-factor stripping leaves zero residual
- empty exposures raises
- mask excludes symbols from both the fit and the output
- rank-deficient bars yield null (not NaN)

Full pipeline suite green (61 tests). Full regression: **1346 passed**.

## Docs
`docusaurus/docs/Advanced Concepts/pipelines.md` gains a "Risk neutrality" section with worked examples for all three patterns.
