### PR TITLE
fix(backtesting): aggregate summary.json across all walk-forward runs (#511)

### DIFF
--- a/investing_algorithm_framework/domain/backtesting/backtest.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest.py
@@ -418,6 +418,23 @@ class Backtest:
                 os.makedirs(destination_run_path, exist_ok=True)
                 br.save(destination_run_path)
 
+        # Always rebuild the summary from the current set of backtest runs
+        # before writing it to disk. This guarantees that summary.json is
+        # self-consistent with the per-run metrics.json files (e.g.
+        # number_of_windows == number of runs, total_net_gain == sum of
+        # per-run total_net_gain, etc.) regardless of how the in-memory
+        # Backtest was constructed (single backtest, walk-forward,
+        # merge(), …). See issue #511.
+        if self.backtest_runs:
+            per_run_metrics = [
+                br.backtest_metrics for br in self.backtest_runs
+                if br.backtest_metrics is not None
+            ]
+            if per_run_metrics:
+                self.backtest_summary = generate_backtest_summary_metrics(
+                    per_run_metrics
+                )
+
         # Save combined backtest metrics if available
         if self.backtest_summary:
             summary_file = os.path.join(
@@ -517,15 +534,22 @@ class Backtest:
             Backtest: The merged Backtest instance.
         """
 
-        merged = Backtest()
+        merged = Backtest(algorithm_id=self.algorithm_id)
         merged.backtest_runs = self.backtest_runs + other.backtest_runs
 
-        summary = BacktestSummaryMetrics()
+        # Rebuild the summary from the full set of merged backtest runs.
+        # `BacktestSummaryMetrics` is a plain dataclass and does not expose
+        # an `add()` method, so the previous incremental approach raised
+        # AttributeError and silently produced a stale / single-window
+        # summary. See issue #511.
+        merged_metrics = merged.get_all_backtest_metrics()
+        if merged_metrics:
+            merged.backtest_summary = generate_backtest_summary_metrics(
+                merged_metrics
+            )
+        else:
+            merged.backtest_summary = BacktestSummaryMetrics()
 
-        for bt_run in merged.get_all_backtest_metrics():
-            summary.add(bt_run)
-
-        merged.backtest_summary = summary
         merged.backtest_permutation_tests = \
             self.backtest_permutation_tests + other.backtest_permutation_tests
 

--- a/investing_algorithm_framework/domain/backtesting/backtest_metrics.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest_metrics.py
@@ -20,6 +20,21 @@ class BacktestMetrics:
     total return, annualized return, volatility, Sharpe ratio,
     and maximum drawdown.
 
+    .. note:: Field semantics & known duplicates (issue #511)
+
+        - ``total_loss`` is the **gross loss magnitude** (a non-negative
+          number equal to ``sum(abs(net_gain))`` over losing trades).
+          ``total_loss_percentage`` is ``total_loss /
+          initial_unallocated`` (decimal, non-negative). These fields
+          no longer mirror ``total_net_gain`` / ``total_net_gain_pct``;
+          see B1 in issue #511.
+
+        - ``total_growth`` / ``total_growth_percentage`` are
+          numerically equivalent to ``total_net_gain`` /
+          ``total_net_gain_percentage`` for the standard
+          mark-to-market portfolio used in backtests. They are kept as
+          legacy aliases. See B3 in issue #511.
+
     Attributes:
         backtest_date_range_name (str): The name of the date range
             used for the backtest.

--- a/investing_algorithm_framework/domain/backtesting/backtest_summary_metrics.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest_summary_metrics.py
@@ -13,6 +13,30 @@ class BacktestSummaryMetrics:
     Represents the summarized results of a backtest,
     focusing on key headline performance and risk metrics.
 
+    .. note:: Field semantics & known duplicates (issue #511)
+
+        - ``total_loss`` / ``total_loss_percentage`` are gross-loss
+          based: ``total_loss`` is ``sum(per-run gross_loss)`` (a
+          non-negative magnitude in account currency) and
+          ``total_loss_percentage`` is ``total_loss /
+          sum(initial_unallocated)`` (decimal). They no longer mix
+          with net-return semantics. See B1/B2 in issue #511.
+
+        - ``total_growth`` / ``total_growth_percentage`` are
+          numerically equivalent to ``total_net_gain`` /
+          ``total_net_gain_percentage`` for closed-position backtests
+          because both are derived from the same start/end portfolio
+          values. They are kept for backwards compatibility but should
+          be considered legacy aliases. See B3 in issue #511.
+
+        - ``average_net_gain``, ``average_loss``, ``average_growth``
+          (and their ``*_percentage`` counterparts) are time-weighted
+          means **across windows**. For a single-window backtest they
+          collapse to the corresponding ``total_*`` value by
+          definition (weighted mean of one element equals that
+          element). See B4 in issue #511. For per-trade averages use
+          ``average_trade_*`` instead.
+
     Attributes:
         total_net_gain (float): Total net gain from the backtest.
         total_net_gain_percentage (float): Total net gain percentage

--- a/investing_algorithm_framework/domain/backtesting/combine_backtests.py
+++ b/investing_algorithm_framework/domain/backtesting/combine_backtests.py
@@ -39,28 +39,32 @@ def _compound_percentage_returns(percentages):
     Compound percentage returns across multiple periods.
 
     For example, if period 1 has 10% return and period 2 has 5% return,
-    the compounded return is: (1 + 0.10) * (1 + 0.05) - 1 = 15.5%
-    NOT simply 10% + 5% = 15%
+    the compounded return is: (1 + 0.10) * (1 + 0.05) - 1 = 0.155 = 15.5%
+    NOT simply 0.10 + 0.05 = 0.15.
+
+    The framework consistently represents percentages as **decimals**
+    (e.g. ``0.10`` for 10%), so this helper expects decimal inputs and
+    returns a decimal. See issue #511 (B5) — earlier versions assumed
+    whole-number percentages, which silently produced results off by a
+    factor of ~100 once multi-window aggregation was exercised.
 
     Args:
-        percentages (List[float | None]): List of percentage returns
-            (as whole numbers, e.g., 10 for 10%).
+        percentages (List[float | None]): List of period returns expressed
+            as decimals (e.g. ``0.10`` for 10%).
 
     Returns:
-        float | None: The compounded percentage return, or None if no
-            valid percentages.
+        float | None: The compounded return as a decimal, or ``None`` if
+            no valid percentages.
     """
     valid_percentages = [p for p in percentages if p is not None]
     if not valid_percentages:
         return None
 
-    # Convert percentages to decimals, compound, then convert back
     compounded = 1.0
     for pct in valid_percentages:
-        compounded *= (1 + pct / 100)
+        compounded *= (1 + pct)
 
-    # Convert back to percentage
-    return (compounded - 1) * 100
+    return compounded - 1
 
 
 def combine_backtests(backtests):
@@ -173,9 +177,13 @@ def generate_backtest_summary_metrics(
         b.total_net_gain for b in valid_metrics
         if b.total_net_gain is not None
     )
+    # B1/B2 fix (issue #511): per-run ``total_loss`` is now the gross
+    # loss magnitude, so the aggregate is simply the sum of per-run
+    # ``total_loss`` (equivalent to ``sum(gross_loss)``). Both per-run
+    # and aggregate use the same unit (positive currency).
     total_loss = sum(
-        b.gross_loss for b in valid_metrics
-        if b.gross_loss is not None
+        b.total_loss for b in valid_metrics
+        if b.total_loss is not None
     )
     total_growth = sum(
         b.total_growth for b in valid_metrics
@@ -184,13 +192,24 @@ def generate_backtest_summary_metrics(
 
     # === PERCENTAGE RETURNS (compounded, not summed) ===
     # Compound returns: (1 + r1) * (1 + r2) * ... - 1
-    # For percentages stored as whole numbers (e.g., 10 for 10%)
+    # All percentages are stored as decimals (e.g. 0.10 for 10%).
     total_net_gain_percentage = _compound_percentage_returns(
         [b.total_net_gain_percentage for b in valid_metrics]
     )
-    total_loss_percentage = _compound_percentage_returns(
-        [b.total_loss_percentage for b in valid_metrics]
-    )
+    # ``total_loss`` is a non-multiplicative magnitude (it does not
+    # compound across windows). Express the aggregate as the sum of
+    # gross losses divided by the sum of initial capital across
+    # windows, which keeps the unit (decimal fraction) consistent
+    # with the per-run definition. See issue #511 (B2).
+    total_initial_value = 0.0
+    for b in valid_metrics:
+        iv = getattr(b, "initial_unallocated", None)
+        if isinstance(iv, (int, float)) and iv > 0:
+            total_initial_value += iv
+    if total_initial_value > 0 and total_loss is not None:
+        total_loss_percentage = total_loss / total_initial_value
+    else:
+        total_loss_percentage = None
     total_growth_percentage = _compound_percentage_returns(
         [b.total_growth_percentage for b in valid_metrics]
     )

--- a/investing_algorithm_framework/services/metrics/generate.py
+++ b/investing_algorithm_framework/services/metrics/generate.py
@@ -21,7 +21,7 @@ from .returns import get_monthly_returns, get_yearly_returns, \
     get_average_monthly_return, get_average_monthly_return_winning_months, \
     get_average_monthly_return_losing_months, get_cumulative_return, \
     get_cumulative_return_series
-from .returns import get_total_return, get_final_value, get_total_loss, \
+from .returns import get_total_return, get_final_value, \
     get_total_growth
 from .sharpe_ratio import get_sharpe_ratio, get_rolling_sharpe_ratio
 from .sortino_ratio import get_sortino_ratio
@@ -232,6 +232,11 @@ def create_backtest_metrics(
     backtest_metrics = BacktestMetrics(
         backtest_start_date=backtest_run.backtest_start_date,
         backtest_end_date=backtest_run.backtest_end_date,
+        backtest_date_range_name=(
+            backtest_run.backtest_date_range_name or ""
+        ),
+        trading_symbol=backtest_run.trading_symbol or "",
+        initial_unallocated=backtest_run.initial_unallocated or 0.0,
     )
 
     def safe_set(metric_name, func, *args, index=None):
@@ -268,11 +273,26 @@ def create_backtest_metrics(
 
     if "total_loss" in metrics or "total_loss_percentage" in metrics:
         try:
-            total_loss = get_total_loss(backtest_run.portfolio_snapshots)
+            # B1 fix (issue #511): "total_loss" is now the **gross loss**
+            # (sum of P&L of all losing trades, expressed as a non-negative
+            # magnitude) rather than the snapshot net-return clamped at
+            # zero. The latter was indistinguishable from
+            # ``total_net_gain`` whenever the period was unprofitable and
+            # always 0 otherwise. ``total_loss_percentage`` is the gross
+            # loss expressed as a fraction of the initial unallocated
+            # capital (decimal, e.g. ``0.05`` for a 5% loss magnitude).
+            gross_loss_value = get_gross_loss(backtest_run.trades)
+            initial_value = backtest_run.initial_unallocated or 0.0
+
             if "total_loss" in metrics:
-                backtest_metrics.total_loss = total_loss[0]
+                backtest_metrics.total_loss = gross_loss_value
             if "total_loss_percentage" in metrics:
-                backtest_metrics.total_loss_percentage = total_loss[1]
+                if initial_value > 0:
+                    backtest_metrics.total_loss_percentage = (
+                        gross_loss_value / initial_value
+                    )
+                else:
+                    backtest_metrics.total_loss_percentage = 0.0
         except OperationalException as e:
             logger.warning(f"total_loss failed: {e}")
 

--- a/investing_algorithm_framework/services/metrics/returns.py
+++ b/investing_algorithm_framework/services/metrics/returns.py
@@ -302,10 +302,19 @@ def get_total_loss(
     snapshots: List[PortfolioSnapshot]
 ) -> Tuple[float, float]:
     """
-    Calculate the total loss from portfolio snapshots.
+    Legacy helper — net portfolio change clamped at zero when positive.
 
-    The total loss is calculated as the percentage change in portfolio value
-    from the first snapshot to the last snapshot, only if there is a loss.
+    .. deprecated::
+        This is **not** a real loss metric. It is the net portfolio
+        return clamped to zero whenever the period was profitable, which
+        means it is identical to ``total_net_gain`` whenever the period
+        is unprofitable and ``0.0`` otherwise. It is no longer used to
+        populate ``BacktestMetrics.total_loss`` — that field now holds
+        the **gross loss** (sum of P&L of all losing trades). See issue
+        #511 (B1). This function is kept for backwards compatibility and
+        will be removed in a future release; prefer
+        :func:`get_gross_loss` from
+        ``investing_algorithm_framework.services.metrics.profit_factor``.
 
     Args:
         snapshots (List[PortfolioSnapshot]): List of portfolio snapshots.

--- a/tests/domain/backtests/test_backtest_save.py
+++ b/tests/domain/backtests/test_backtest_save.py
@@ -6,6 +6,7 @@ save method produces the expected directory structure and files.
 
 Moved from: tests/app/reporting/test_backtest_report.py
 """
+import json
 import os
 import shutil
 from datetime import datetime, timezone
@@ -152,4 +153,158 @@ class TestBacktestSave(TestCase):
         )
         self.assertTrue(
             os.path.exists(os.path.join(backtest_run_dir, "metrics.json"))
+        )
+
+    def _make_run(self, start, end, name, total_net_gain, trades_closed,
+                  win_rate, gross_profit, gross_loss):
+        """Helper: build a BacktestRun with pre-computed metrics."""
+        date_range = BacktestDateRange(
+            start_date=start, end_date=end, name=name
+        )
+        return BacktestRun(
+            backtest_start_date=date_range.start_date,
+            backtest_end_date=date_range.end_date,
+            backtest_date_range_name=date_range.name,
+            created_at=datetime.now(tz=timezone.utc),
+            orders=[],
+            trades=[],
+            positions=[],
+            portfolio_snapshots=self._create_snapshots(),
+            trading_symbol="EUR",
+            number_of_runs=1000,
+            initial_unallocated=1000,
+            backtest_metrics=BacktestMetrics(
+                backtest_start_date=start.replace(tzinfo=None),
+                backtest_end_date=end.replace(tzinfo=None),
+                total_net_gain=total_net_gain,
+                total_net_gain_percentage=total_net_gain / 1000.0,
+                number_of_trades=trades_closed,
+                number_of_trades_closed=trades_closed,
+                win_rate=win_rate,
+                gross_profit=gross_profit,
+                gross_loss=gross_loss,
+                total_number_of_days=365,
+            ),
+        )
+
+    def test_save_multi_window_summary_aggregates_all_runs(self):
+        """Regression test for issue #511.
+
+        When saving a Backtest containing multiple BacktestRun instances
+        (e.g. a walk-forward run), `summary.json` must reflect the
+        aggregate of all runs — not just one of them. Specifically:
+        - number_of_windows == len(runs)
+        - total_net_gain == sum(per-run total_net_gain)
+        - number_of_trades_closed == sum(per-run number_of_trades_closed)
+        """
+        runs = [
+            self._make_run(
+                start=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2023, 12, 31, tzinfo=timezone.utc),
+                name="window-1",
+                total_net_gain=499.21,
+                trades_closed=56,
+                win_rate=0.393,
+                gross_profit=900.0,
+                gross_loss=-400.79,
+            ),
+            self._make_run(
+                start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 12, 31, tzinfo=timezone.utc),
+                name="window-2",
+                total_net_gain=222.75,
+                trades_closed=63,
+                win_rate=0.333,
+                gross_profit=600.0,
+                gross_loss=-377.25,
+            ),
+            self._make_run(
+                start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                name="window-3",
+                total_net_gain=-24.75,
+                trades_closed=57,
+                win_rate=0.316,
+                gross_profit=300.0,
+                gross_loss=-324.75,
+            ),
+        ]
+
+        # Simulate the buggy upstream pre-condition: backtest_summary
+        # was set from a single window only.
+        from investing_algorithm_framework.domain.backtesting \
+            .combine_backtests import generate_backtest_summary_metrics
+
+        stale_summary = generate_backtest_summary_metrics(
+            [runs[-1].backtest_metrics]
+        )
+
+        backtest = Backtest(
+            algorithm_id="alg-511",
+            backtest_runs=runs,
+            backtest_summary=stale_summary,
+            risk_free_rate=0.0,
+        )
+        backtest.save(self.output_path)
+
+        summary_path = os.path.join(self.output_path, "summary.json")
+        self.assertTrue(os.path.exists(summary_path))
+
+        with open(summary_path, "r") as f:
+            summary = json.load(f)
+
+        self.assertEqual(summary["number_of_windows"], 3)
+        self.assertAlmostEqual(
+            summary["total_net_gain"],
+            499.21 + 222.75 + -24.75,
+            places=4,
+        )
+        self.assertEqual(
+            summary["number_of_trades_closed"], 56 + 63 + 57
+        )
+        self.assertEqual(summary["number_of_profitable_windows"], 2)
+        self.assertEqual(summary["number_of_windows_with_trades"], 3)
+
+    def test_merge_rebuilds_summary_from_all_runs(self):
+        """Regression test for issue #511.
+
+        `Backtest.merge()` previously called the non-existent
+        `BacktestSummaryMetrics.add()` method, which silently produced
+        a wrong / stale summary. After merging, the summary must
+        aggregate the runs from both backtests.
+        """
+        run_a = self._make_run(
+            start=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2023, 12, 31, tzinfo=timezone.utc),
+            name="window-a",
+            total_net_gain=100.0,
+            trades_closed=10,
+            win_rate=0.5,
+            gross_profit=200.0,
+            gross_loss=-100.0,
+        )
+        run_b = self._make_run(
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 12, 31, tzinfo=timezone.utc),
+            name="window-b",
+            total_net_gain=50.0,
+            trades_closed=20,
+            win_rate=0.4,
+            gross_profit=150.0,
+            gross_loss=-100.0,
+        )
+
+        bt_a = Backtest(algorithm_id="alg-511", backtest_runs=[run_a])
+        bt_b = Backtest(algorithm_id="alg-511", backtest_runs=[run_b])
+
+        merged = bt_a.merge(bt_b)
+
+        self.assertEqual(len(merged.backtest_runs), 2)
+        self.assertIsNotNone(merged.backtest_summary)
+        self.assertEqual(merged.backtest_summary.number_of_windows, 2)
+        self.assertAlmostEqual(
+            merged.backtest_summary.total_net_gain, 150.0, places=4
+        )
+        self.assertEqual(
+            merged.backtest_summary.number_of_trades_closed, 30
         )

--- a/tests/domain/models/backtesting/test_combine.py
+++ b/tests/domain/models/backtesting/test_combine.py
@@ -27,10 +27,13 @@ class TestCombine(TestCase):
             backtest_end_date=datetime(2020, 12, 31),
             equity_curve=[(1000, datetime(2020, 1, 1)),
                           (1500, datetime(2020, 12, 31))],
+            initial_unallocated=1000,
             total_growth=500,
             total_growth_percentage=50.0,
             total_net_gain=500,
             total_net_gain_percentage=50.0,
+            total_loss=200,
+            total_loss_percentage=0.2,
             final_value=1500.0,
             cagr=0.1,
             sharpe_ratio=1.2,
@@ -39,7 +42,7 @@ class TestCombine(TestCase):
             calmar_ratio=0.8,
             profit_factor=1.5,
             gross_profit=700,
-            gross_loss=-200,
+            gross_loss=200,
             annual_volatility=0.15,
             monthly_returns=[],
             yearly_returns=[],
@@ -89,10 +92,13 @@ class TestCombine(TestCase):
             backtest_end_date=datetime(2021, 12, 31),
             equity_curve=[(2000, datetime(2021, 1, 1)),
                           (1800, datetime(2021, 12, 31))],
+            initial_unallocated=2000,
             total_growth=-200,
             total_growth_percentage=-10.0,
             total_net_gain=-200,
             total_net_gain_percentage=-10.0,
+            total_loss=500,
+            total_loss_percentage=0.25,
             final_value=1800.0,
             cagr=-0.05,
             sharpe_ratio=-0.5,
@@ -101,7 +107,7 @@ class TestCombine(TestCase):
             calmar_ratio=-0.3,
             profit_factor=0.7,
             gross_profit=300,
-            gross_loss=-500,
+            gross_loss=500,
             annual_volatility=0.25,
             monthly_returns=[],
             yearly_returns=[],
@@ -151,7 +157,13 @@ class TestCombine(TestCase):
         # --- Assertions ---
         # Sum metrics
         self.assertEqual(summary.total_net_gain, 300)  # 500 + (-200)
-        self.assertEqual(summary.total_loss, -700)  # -200 + -500
+        # B1/B2 fix (#511): total_loss is the gross loss magnitude
+        # summed across windows.
+        self.assertEqual(summary.total_loss, 700)  # 200 + 500
+        # total_loss_percentage = sum(gross_loss) / sum(initial)
+        self.assertAlmostEqual(
+            summary.total_loss_percentage, 700 / 3000, places=4
+        )
         self.assertEqual(summary.number_of_trades, 30)  # 10 + 20
 
         # Mean metrics

--- a/tests/domain/models/backtesting/test_generate_backtest_summary_metrics.py
+++ b/tests/domain/models/backtesting/test_generate_backtest_summary_metrics.py
@@ -20,12 +20,14 @@ from investing_algorithm_framework.domain.backtesting.combine_backtests import (
 
 def create_mock_backtest_metrics(
     total_net_gain=100.0,
-    total_net_gain_percentage=10.0,
-    gross_loss=-50.0,
-    total_loss_percentage=-5.0,
+    total_net_gain_percentage=0.10,
+    total_loss=50.0,
+    gross_loss=50.0,
+    total_loss_percentage=0.05,
     total_growth=100.0,
-    total_growth_percentage=10.0,
+    total_growth_percentage=0.10,
     gross_profit=150.0,
+    initial_unallocated=1000.0,
     cagr=0.12,
     sharpe_ratio=1.5,
     sortino_ratio=2.0,
@@ -55,11 +57,13 @@ def create_mock_backtest_metrics(
     metrics = MagicMock()
     metrics.total_net_gain = total_net_gain
     metrics.total_net_gain_percentage = total_net_gain_percentage
+    metrics.total_loss = total_loss
     metrics.gross_loss = gross_loss
     metrics.total_loss_percentage = total_loss_percentage
     metrics.total_growth = total_growth
     metrics.total_growth_percentage = total_growth_percentage
     metrics.gross_profit = gross_profit
+    metrics.initial_unallocated = initial_unallocated
     metrics.cagr = cagr
     metrics.sharpe_ratio = sharpe_ratio
     metrics.sortino_ratio = sortino_ratio
@@ -184,57 +188,62 @@ class TestSafeWeightedMean(unittest.TestCase):
 
 
 class TestCompoundPercentageReturns(unittest.TestCase):
-    """Tests for _compound_percentage_returns helper function."""
+    """Tests for _compound_percentage_returns helper function.
+
+    The framework uses **decimal** percentages (e.g. ``0.10`` for 10%),
+    so all inputs and outputs of this helper are decimals. See issue
+    #511 (B5).
+    """
 
     def test_basic_compounding(self):
         """Test basic percentage compounding."""
         # 10% followed by 5%
         # (1 + 0.10) * (1 + 0.05) - 1 = 1.155 - 1 = 0.155 = 15.5%
-        percentages = [10, 5]
+        percentages = [0.10, 0.05]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, 15.5, places=5)
+        self.assertAlmostEqual(result, 0.155, places=5)
 
     def test_simple_compounding_not_addition(self):
         """Verify compounding is used, not simple addition."""
-        # If using addition: 10 + 10 = 20%
-        # If using compounding: (1.1) * (1.1) - 1 = 0.21 = 21%
-        percentages = [10, 10]
+        # If using addition: 0.10 + 0.10 = 0.20
+        # If using compounding: (1.1) * (1.1) - 1 = 0.21
+        percentages = [0.10, 0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        # Should be 21%, not 20%
-        self.assertAlmostEqual(result, 21.0, places=5)
+        # Should be 0.21, not 0.20
+        self.assertAlmostEqual(result, 0.21, places=5)
 
     def test_negative_returns(self):
         """Test compounding with negative returns."""
         # -10% followed by -10%
-        # (1 - 0.10) * (1 - 0.10) - 1 = 0.81 - 1 = -0.19 = -19%
-        percentages = [-10, -10]
+        # (1 - 0.10) * (1 - 0.10) - 1 = 0.81 - 1 = -0.19
+        percentages = [-0.10, -0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, -19.0, places=5)
+        self.assertAlmostEqual(result, -0.19, places=5)
 
     def test_mixed_positive_negative(self):
         """Test compounding with mixed positive and negative returns."""
         # +20% followed by -10%
-        # (1 + 0.20) * (1 - 0.10) - 1 = 1.2 * 0.9 - 1 = 1.08 - 1 = 0.08 = 8%
-        percentages = [20, -10]
+        # (1 + 0.20) * (1 - 0.10) - 1 = 1.2 * 0.9 - 1 = 0.08
+        percentages = [0.20, -0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, 8.0, places=5)
+        self.assertAlmostEqual(result, 0.08, places=5)
 
     def test_ignores_none(self):
         """Test that None values are ignored."""
-        percentages = [10, None, 10]
+        percentages = [0.10, None, 0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        # Only 10% and 10%: 21%
-        self.assertAlmostEqual(result, 21.0, places=5)
+        # Only 0.10 and 0.10: 0.21
+        self.assertAlmostEqual(result, 0.21, places=5)
 
     def test_empty_list(self):
         """Test with empty list."""
@@ -249,27 +258,27 @@ class TestCompoundPercentageReturns(unittest.TestCase):
 
     def test_single_return(self):
         """Test with single return."""
-        percentages = [15]
+        percentages = [0.15]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, 15.0, places=5)
+        self.assertAlmostEqual(result, 0.15, places=5)
 
     def test_zero_returns(self):
         """Test with zero returns."""
         # 0% doesn't change the total
-        percentages = [10, 0, 5]
+        percentages = [0.10, 0, 0.05]
 
         result = _compound_percentage_returns(percentages)
 
-        # (1.1) * (1.0) * (1.05) - 1 = 1.155 - 1 = 15.5%
-        self.assertAlmostEqual(result, 15.5, places=5)
+        # (1.1) * (1.0) * (1.05) - 1 = 0.155
+        self.assertAlmostEqual(result, 0.155, places=5)
 
     def test_large_loss_recovery(self):
         """Test recovery from large loss."""
         # -50% followed by +100% = back to even
-        # (1 - 0.5) * (1 + 1.0) - 1 = 0.5 * 2 - 1 = 0%
-        percentages = [-50, 100]
+        # (1 - 0.5) * (1 + 1.0) - 1 = 0.5 * 2 - 1 = 0
+        percentages = [-0.5, 1.0]
 
         result = _compound_percentage_returns(percentages)
 
@@ -358,24 +367,28 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
 
     def test_percentage_returns_compounded(self):
         """Test that percentage returns are compounded, not summed."""
-        # Period 1: 10%, Period 2: 10%
-        # Compounded: (1.1 * 1.1) - 1 = 21%, NOT 20%
-        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=10)
-        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=10)
+        # Period 1: 10%, Period 2: 10% (decimals: 0.10)
+        # Compounded: (1.1 * 1.1) - 1 = 0.21 (21%), NOT 0.20
+        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
+        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
 
         result = generate_backtest_summary_metrics([metrics1, metrics2])
 
-        self.assertAlmostEqual(result.total_net_gain_percentage, 21.0, places=3)
+        self.assertAlmostEqual(
+            result.total_net_gain_percentage, 0.21, places=4
+        )
 
     def test_growth_percentage_compounded(self):
         """Test that growth percentage is compounded."""
-        metrics1 = create_mock_backtest_metrics(total_growth_percentage=20)
-        metrics2 = create_mock_backtest_metrics(total_growth_percentage=10)
+        metrics1 = create_mock_backtest_metrics(total_growth_percentage=0.20)
+        metrics2 = create_mock_backtest_metrics(total_growth_percentage=0.10)
 
         result = generate_backtest_summary_metrics([metrics1, metrics2])
 
-        # (1.2 * 1.1) - 1 = 32%
-        self.assertAlmostEqual(result.total_growth_percentage, 32.0, places=3)
+        # (1.2 * 1.1) - 1 = 0.32
+        self.assertAlmostEqual(
+            result.total_growth_percentage, 0.32, places=4
+        )
 
     # ==========================================================
     # Risk-Adjusted Ratios (Weighted by Time)
@@ -562,7 +575,7 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
         """Test combining two equal-length periods."""
         metrics1 = create_mock_backtest_metrics(
             total_net_gain=1000,
-            total_net_gain_percentage=10,
+            total_net_gain_percentage=0.10,
             sharpe_ratio=1.5,
             max_drawdown=-0.15,
             number_of_trades=20,
@@ -572,7 +585,7 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
         )
         metrics2 = create_mock_backtest_metrics(
             total_net_gain=500,
-            total_net_gain_percentage=5,
+            total_net_gain_percentage=0.05,
             sharpe_ratio=1.0,
             max_drawdown=-0.10,
             number_of_trades=10,
@@ -589,8 +602,10 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
         self.assertEqual(result.number_of_trades_closed, 26)
 
         # Verify compounded percentage
-        # (1.10 * 1.05) - 1 = 15.5%
-        self.assertAlmostEqual(result.total_net_gain_percentage, 15.5, places=3)
+        # (1.10 * 1.05) - 1 = 0.155
+        self.assertAlmostEqual(
+            result.total_net_gain_percentage, 0.155, places=4
+        )
 
         # Verify weighted Sharpe (equal time weights)
         self.assertAlmostEqual(result.sharpe_ratio, 1.25, places=5)
@@ -636,15 +651,17 @@ class TestGenerateBacktestSummaryMetricsCalculationValidity(unittest.TestCase):
         Example: Start with $1000
         - Period 1: +10% -> $1100
         - Period 2: +10% -> $1210
-        Total return: ($1210 - $1000) / $1000 = 21%, NOT 20%
+        Total return: ($1210 - $1000) / $1000 = 0.21 (21%), NOT 0.20
         """
-        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=10)
-        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=10)
+        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
+        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
 
         result = generate_backtest_summary_metrics([metrics1, metrics2])
 
-        # Compound return should be 21%
-        self.assertAlmostEqual(result.total_net_gain_percentage, 21.0, places=3)
+        # Compound return should be 0.21 (21%)
+        self.assertAlmostEqual(
+            result.total_net_gain_percentage, 0.21, places=4
+        )
 
     def test_weighted_average_makes_sense_for_ratios(self):
         """
@@ -746,4 +763,3 @@ class TestGenerateBacktestSummaryMetricsCalculationValidity(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231201_20231202/metrics.json
+++ b/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231201_20231202/metrics.json
@@ -2,8 +2,8 @@
     "backtest_start_date": "2023-12-01T00:00:00+00:00",
     "backtest_end_date": "2023-12-02T00:00:00+00:00",
     "backtest_date_range_name": "",
-    "trading_symbol": "",
-    "initial_unallocated": 0.0,
+    "trading_symbol": "EUR",
+    "initial_unallocated": 1000.0,
     "equity_curve": [
         [
             1000.0,

--- a/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231202_20231203/metrics.json
+++ b/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231202_20231203/metrics.json
@@ -2,8 +2,8 @@
     "backtest_start_date": "2023-12-02T00:00:00+00:00",
     "backtest_end_date": "2023-12-03T00:00:00+00:00",
     "backtest_date_range_name": "",
-    "trading_symbol": "",
-    "initial_unallocated": 0.0,
+    "trading_symbol": "EUR",
+    "initial_unallocated": 1000.0,
     "equity_curve": [
         [
             1000.0,

--- a/tests/services/metrics/test_generate_metrics.py
+++ b/tests/services/metrics/test_generate_metrics.py
@@ -24,3 +24,38 @@ class TestGenerateMetrics(TestCase):
         backtest_metrics = create_backtest_metrics(
             backtest_run, risk_free_rate=0.024
         )
+
+    def test_total_loss_is_gross_loss_magnitude(self):
+        """Regression test for issue #511 (B1).
+
+        Per-run ``BacktestMetrics.total_loss`` must equal the gross
+        loss magnitude (``sum(abs(net_gain))`` over losing trades),
+        not the snapshot net-return clamped at zero. In particular,
+        ``total_loss`` must equal the ``gross_loss`` field, and
+        ``total_loss_percentage`` must be ``total_loss /
+        initial_unallocated`` (a non-negative decimal).
+        """
+        backtest_run = BacktestRun.open(
+            os.path.join(self.backtest_run_directory, 'backtest_run_one')
+        )
+        metrics = create_backtest_metrics(
+            backtest_run, risk_free_rate=0.024
+        )
+
+        # total_loss is a non-negative magnitude.
+        self.assertIsNotNone(metrics.total_loss)
+        self.assertGreaterEqual(metrics.total_loss, 0.0)
+
+        # total_loss equals gross_loss (same definition).
+        self.assertAlmostEqual(
+            metrics.total_loss, metrics.gross_loss or 0.0, places=6
+        )
+
+        # total_loss_percentage is non-negative and consistent with
+        # total_loss / initial_unallocated.
+        if backtest_run.initial_unallocated:
+            expected_pct = metrics.total_loss / backtest_run.initial_unallocated
+            self.assertAlmostEqual(
+                metrics.total_loss_percentage, expected_pct, places=6
+            )
+            self.assertGreaterEqual(metrics.total_loss_percentage, 0.0)


### PR DESCRIPTION
Closes #511.

## Primary fix — `summary.json` for walk-forward backtests

`backtest_summary` (written to `summary.json`) was supposed to be the aggregate of the per-run `BacktestMetrics`, but for multi-window walk-forward backtests it silently held the metrics of a single window: every aggregate field (`number_of_windows`, `total_net_gain`, `number_of_trades_closed`, `win_rate`, drawdown, …) was wrong.

Two upstream root causes:

1. `Backtest.save()` wrote `self.backtest_summary` straight to disk without checking it matched the current `backtest_runs`.
2. `Backtest.merge()` called the non-existent `BacktestSummaryMetrics.add()` method, which raised `AttributeError` and (depending on caller try/except) left whatever single-window summary had last been assigned in place.

This PR:

- **`Backtest.save()`** always rebuilds `backtest_summary` from the current set of `backtest_runs` (via `generate_backtest_summary_metrics`) right before writing `summary.json`. The on-disk summary is now always self-consistent with the per-run `metrics.json` files regardless of how the in-memory `Backtest` was assembled.
- **`Backtest.merge()`** rebuilds the summary from the combined runs using `generate_backtest_summary_metrics`, propagates `algorithm_id`, and no longer calls the non-existent `add()`.

## Secondary fixes (B1–B5 from the issue)

- **B1** — `BacktestMetrics.total_loss` is now the **gross loss magnitude** (`sum(abs(net_gain))` over losing trades) and `total_loss_percentage = total_loss / initial_unallocated` (decimal, non-negative). It no longer mirrors `total_net_gain` for unprofitable periods. The snapshot-based `get_total_loss()` is kept and marked deprecated in its docstring.
- **B2** — aggregate `total_loss = sum(per-run total_loss)` and aggregate `total_loss_percentage = sum(total_loss) / sum(initial_unallocated)`. Both now describe the same quantity with consistent units.
- **B3 / B4** — documented `total_growth*` as a legacy alias for `total_net_gain*` and `average_*` as time-weighted means **across windows** (which collapse to `total_*` for single-window backtests). No API breakage.
- **B5** — `_compound_percentage_returns` now expects and returns decimals (`0.10` for 10%) consistent with the rest of the framework. The earlier whole-number-percentage assumption silently produced results off by ~100× once multi-window aggregation actually started running.
- `create_backtest_metrics` now populates `trading_symbol`, `initial_unallocated`, and `backtest_date_range_name` on the returned `BacktestMetrics`, so per-run metrics carry the context needed for downstream aggregation (in particular B2 needs `initial_unallocated`).

## Tests

- New regression test **`test_save_multi_window_summary_aggregates_all_runs`** — builds a 3-window `Backtest`, deliberately seeds a stale single-window summary, calls `save()`, and asserts that the persisted `summary.json` reports `number_of_windows == 3`, correct sums of `total_net_gain` / `number_of_trades_closed`, and correct profitable-window count.
- New regression test **`test_merge_rebuilds_summary_from_all_runs`** — verifies `Backtest.merge()` no longer raises and aggregates across both backtests.
- New regression test **`test_total_loss_is_gross_loss_magnitude`** for B1.
- Existing aggregation tests updated for the new gross-loss semantics and decimal-percentage convention.

Full suite: **1441 passed, 3 skipped**.

## Recalculating existing on-disk results

Anyone with backtest folders produced by previous versions of the framework can rebuild correct `summary.json` files in-place using the existing public `recalculate_backtests()` API — see the comment below.
