### PR TITLE
release: v8.6.1 (dev → main)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,15 +58,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------
-      #  -----  install distutils if needed  -----
-      #----------------------------------------------
-      - name: Install distutils on Ubuntu
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get update
-          sudo apt install python${{ matrix.python-version }}-distutils
-      #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry

--- a/docs/design/pipeline-api.md
+++ b/docs/design/pipeline-api.md
@@ -1,0 +1,188 @@
+# Pipeline API — Design Doc
+
+> Status: **DRAFT for review**.  
+> Tracking issue: [#438](https://github.com/coding-kitties/investing-algorithm-framework/issues/438).  
+> Phase issues: [#501](https://github.com/coding-kitties/investing-algorithm-framework/issues/501) (event), [#502](https://github.com/coding-kitties/investing-algorithm-framework/issues/502) (vector), [#503](https://github.com/coding-kitties/investing-algorithm-framework/issues/503) (live).
+
+## 1. Goals & non-goals
+
+### Goals
+
+1. Declarative cross-sectional factor / filter / classifier computation across an asset universe at each bar.
+2. Look-ahead-safe by construction: a factor evaluated at bar `t` sees only data with timestamp `≤ t`.
+3. Strict opt-in: strategies without `pipelines = [...]` see **zero** behavioural or performance change.
+4. Three execution backends (event backtest, vector backtest, live) sharing the same `Pipeline` definition.
+
+### Non-goals (v1)
+
+- Full Zipline-Pipeline parity (no classifier hierarchies, no winsorization, no OLS factors).
+- Live pipelines on sub-daily timeframes.
+- Universes outside the supported envelope (see §6).
+- Cross-market order routing (separate issue).
+
+## 2. Public API
+
+```python
+from investing_algorithm_framework import (
+    TradingStrategy, Pipeline, Returns, AverageDollarVolume, TimeUnit,
+)
+
+class MomentumScreener(Pipeline):
+    dollar_volume = AverageDollarVolume(window=30)
+    momentum = Returns(window=60)
+
+    universe = dollar_volume.top(100)
+    alpha = momentum.rank(mask=universe)
+
+
+class MyStrategy(TradingStrategy):
+    time_unit = TimeUnit.DAY
+    interval = 1
+    pipelines = [MomentumScreener]
+    universe = ["BTC/EUR", "ETH/EUR", ...]   # candidate symbols
+
+    def run_strategy(self, context, data):
+        out = data["MomentumScreener"]   # pl.DataFrame, one row per surviving symbol
+        ...
+```
+
+### Class attributes added to `TradingStrategy`
+
+| Attribute | Type | Default | Meaning |
+|---|---|---|---|
+| `pipelines` | `list[type[Pipeline]]` | `[]` | Pipelines to run before each `run_strategy` call. |
+| `universe` | `list[str] \| list[DataSource]` | `[]` | Candidate symbols. Folded into `data_sources` at app startup; pipelines filter down. |
+
+### `Pipeline` class
+
+- Class attributes that are `Factor` / `Filter` instances are introspected via `__init_subclass__`.
+- A class attribute named `universe` is treated as the **root mask**: if present, every other column is computed on the masked subset.
+- All other attributes become columns of the output frame.
+
+## 3. Panel shape
+
+The engine's internal representation is a **long-form Polars DataFrame**:
+
+```
+schema = {
+    "datetime": pl.Datetime,
+    "symbol":   pl.Utf8,
+    "open":     pl.Float32,
+    "high":     pl.Float32,
+    "low":      pl.Float32,
+    "close":    pl.Float32,
+    "volume":   pl.Float32,
+}
+```
+
+Long-form is chosen because:
+
+- Polars rolling/group-by is faster on long form than on wide.
+- Sparse symbols (delisted, late-listed) are natural — no NaN columns.
+- Cache files are smaller (no per-symbol column duplication).
+
+Per-bar pipeline output handed to the strategy is a **wide** frame keyed by symbol:
+
+```
+out = pl.DataFrame({
+    "symbol":        pl.Utf8,
+    "<factor name>": pl.Float64,    # one column per Factor/Filter on the Pipeline
+    ...
+})
+```
+
+## 4. Engine API (internal)
+
+```python
+class PipelineEngine(Protocol):
+    def evaluate_at(
+        self,
+        pipeline: type[Pipeline],
+        as_of: datetime,
+    ) -> pl.DataFrame: ...
+    """Event mode: return wide per-symbol frame for the given timestamp."""
+
+    def evaluate_range(
+        self,
+        pipeline: type[Pipeline],
+        start: datetime,
+        end: datetime,
+    ) -> pl.DataFrame: ...
+    """Vector mode: return long (date, symbol)-indexed frame for the range."""
+```
+
+Two implementations:
+
+- `LazyPolarsPipelineEngine` (event + vector). Compiles Factor expressions into a single `pl.LazyFrame` plan; `collect()` only at the boundary.
+- `LiveBatchedPipelineEngine` (Phase 3). Adds async batched fetch + universe-refresh.
+
+## 5. Cache key (Phase 2)
+
+Cache lives under `<resource_dir>/pipeline_cache/`. Key:
+
+```
+hash(
+    universe_hash:   sha1(sorted(symbol_list)),
+    daterange:       (start.isoformat(), end.isoformat()),
+    timeframe:       e.g. "1d",
+    expr_hash:       sha1(canonical_repr(factor_expression_tree)),
+    schema_version:  int,           # bump on any cache-incompatible change
+)
+```
+
+Hits return the cached panel/factor frame without recomputation.  
+Parameter sweeps over **non-pipeline** attributes (signal thresholds, position sizing) reuse the cache for free.
+
+## 6. Performance contract
+
+| Mode | Timeframe | Max universe | Tested in CI |
+|---|---|---|---|
+| Event BT | daily | 5,000 | ✅ |
+| Event BT | 4h / 1h | 1,000 / 500 | ✅ |
+| Event BT | < 1h | — | ❌ raises |
+| Vector BT | daily | 5,000 | ✅ |
+| Vector BT | 4h / 1h | 1,000 / 500 | ✅ |
+| Vector BT | < 1h | — | ❌ raises |
+| Live | daily | 50 | smoke only |
+| Live | < daily | — | ❌ raises |
+
+**Opt-in guarantee (CI-asserted):** vector backtest of the existing single-symbol example must run within ±10% of the pre-pipeline baseline wall-clock.
+
+## 7. Built-in factors (v1)
+
+| Factor | Formula |
+|---|---|
+| `Returns(window=N)` | `close.pct_change(N)` |
+| `AverageDollarVolume(window=N)` | `(close * volume).rolling_mean(N)` |
+| `SMA(window=N)` | `close.rolling_mean(N)` |
+| `RSI(window=N)` | standard Wilder RSI |
+| `Volatility(window=N)` | `log_returns.rolling_std(N) * sqrt(periods_per_year)` |
+
+All other factors mentioned in #438's original draft (`MACD`, `BollingerBands`, `EWMA`, `VWAP`, `MaxDrawdown`) are deferred. Users can subclass `CustomFactor`:
+
+```python
+class MACD(CustomFactor):
+    inputs = ["close"]
+    window = 26
+
+    def compute(self, close: pl.Series) -> pl.Series:
+        ...
+```
+
+## 8. Look-ahead safety
+
+Factors operate on a Polars `LazyFrame` filtered to `datetime <= as_of` *before* any rolling op. Rolling windows are right-aligned (closed on the right). Tests must assert that injecting a future bar does not change a past factor value.
+
+## 9. Open questions
+
+1. **Universe declaration ergonomics.** Do we accept a callable `universe = lambda ctx: top_500_by_market_cap()` or only a static list in v1? (Proposed: static list in v1, callable in v2.)
+2. **Pipeline scheduling.** Always run every bar, or honour a per-pipeline `time_unit`? (Proposed: same `time_unit` as the strategy in v1; per-pipeline scheduling in v2.)
+3. **Multiple pipelines on one strategy.** Independent (each gets its own cache key) or composable (one pipeline can reference another's column)? (Proposed: independent in v1.)
+4. **Float32 vs float64.** Default to float32 for memory; users opt into float64 per factor? (Proposed: yes, factor-level `dtype=` override.)
+
+## 10. Out of code, in the order of work
+
+1. ✅ This doc reviewed and merged.
+2. Phase 1 ([#501](https://github.com/coding-kitties/investing-algorithm-framework/issues/501)) — event backtest + 5 factors.
+3. Phase 2 ([#502](https://github.com/coding-kitties/investing-algorithm-framework/issues/502)) — vector + cache + benchmark.
+4. Phase 3 ([#503](https://github.com/coding-kitties/investing-algorithm-framework/issues/503)) — live, gated on async CCXT fetch.

--- a/docs/design/pipeline-api.md
+++ b/docs/design/pipeline-api.md
@@ -1,7 +1,7 @@
 # Pipeline API — Design Doc
 
-> Status: **DRAFT for review**.  
-> Tracking issue: [#438](https://github.com/coding-kitties/investing-algorithm-framework/issues/438).  
+> Status: **DRAFT for review**.
+> Tracking issue: [#438](https://github.com/coding-kitties/investing-algorithm-framework/issues/438).
 > Phase issues: [#501](https://github.com/coding-kitties/investing-algorithm-framework/issues/501) (event), [#502](https://github.com/coding-kitties/investing-algorithm-framework/issues/502) (vector), [#503](https://github.com/coding-kitties/investing-algorithm-framework/issues/503) (live).
 
 ## 1. Goals & non-goals
@@ -130,7 +130,7 @@ hash(
 )
 ```
 
-Hits return the cached panel/factor frame without recomputation.  
+Hits return the cached panel/factor frame without recomputation.
 Parameter sweeps over **non-pipeline** attributes (signal thresholds, position sizing) reuse the cache for free.
 
 ## 6. Performance contract

--- a/docusaurus/docs/Advanced Concepts/vector-backtesting.md
+++ b/docusaurus/docs/Advanced Concepts/vector-backtesting.md
@@ -532,25 +532,25 @@ def robust_strategies(backtests, date_range):
     filtered = []
     for backtest in backtests:
         metrics = backtest.get_backtest_metrics(date_range)
-        
+
         # Must be profitable
         if metrics.total_growth_percentage <= 0:
             continue
-            
+
         # Must have sufficient trades
         if metrics.number_of_trades_closed < 10:
             continue
-            
+
         # Must have good risk-adjusted returns
         if metrics.sharpe_ratio < 1.5:
             continue
-            
+
         # Must have reasonable drawdown
         if metrics.max_drawdown > 25.0:
             continue
-            
+
         filtered.append(backtest)
-    
+
     return filtered
 ```
 
@@ -597,7 +597,7 @@ def select_top_performers(backtests):
         key=lambda b: b.backtest_summary.total_growth_percentage,
         reverse=True
     )
-    
+
     # Return top 10
     return sorted_backtests[:10]
 
@@ -631,17 +631,17 @@ def best_risk_adjusted(backtests):
 def most_consistent(backtests):
     """Select strategies profitable in ALL periods."""
     consistent = []
-    
+
     for backtest in backtests:
         # Check if profitable in every run
         all_profitable = all(
             run.backtest_metrics.total_growth_percentage > 0
             for run in backtest.backtest_runs
         )
-        
+
         if all_profitable:
             consistent.append(backtest)
-    
+
     return consistent
 ```
 
@@ -650,10 +650,10 @@ def most_consistent(backtests):
 def score_and_select(backtests):
     """Score strategies and select top 50."""
     scored = []
-    
+
     for backtest in backtests:
         summary = backtest.backtest_summary
-        
+
         # Calculate composite score
         score = (
             summary.total_growth_percentage * 0.3 +
@@ -661,9 +661,9 @@ def score_and_select(backtests):
             (100 - summary.max_drawdown) * 0.2 +
             summary.win_rate * 0.2
         )
-        
+
         scored.append((score, backtest))
-    
+
     # Sort by score and return top 50
     scored.sort(reverse=True)
     return [backtest for score, backtest in scored[:50]]
@@ -1099,7 +1099,7 @@ def top_100(backtests):
             (100 - b.backtest_summary.max_drawdown) * 0.2
         )
         scored.append((score, b))
-    
+
     scored.sort(reverse=True)
     return [b for score, b in scored[:100]]
 
@@ -1323,4 +1323,3 @@ For maximum performance:
 5. Use `show_progress=True` to monitor execution
 
 Happy backtesting! 🎉
-

--- a/docusaurus/docs/Advanced Concepts/vector-backtesting.md
+++ b/docusaurus/docs/Advanced Concepts/vector-backtesting.md
@@ -171,6 +171,71 @@ backtest_storage/
 │   └── ...
 ```
 
+#### Content-aware checkpoints
+
+Checkpoints are **content-aware**. Each entry in `checkpoints.json`
+stores a `manifest_hash` next to the `algorithm_id`. The hash
+fingerprints:
+
+- the strategy class source code
+- the strategy's instance parameters
+- the data sources (symbols, timeframe, type, market)
+- the backtest date range
+
+When you edit a strategy or change a parameter, the hash changes, the
+stored checkpoint becomes *stale*, and that strategy is **rerun
+automatically** on the next call. No prompt, no flag.
+
+```json
+{
+    "2022-01-01T00:00:00+00:00_2023-01-01T00:00:00+00:00": {
+        "94cf4f10": "a1b2c3d4e5f6a7b8",
+        "bc0899f9": "9a8b7c6d5e4f3a2b"
+    }
+}
+```
+
+Old `checkpoints.json` files using the legacy list format keep working
+unchanged — entries without a stored hash fall back to the previous
+"match by `algorithm_id` only" behaviour, and are migrated to the new
+dict shape the next time they're written.
+
+#### Overriding checkpoint behaviour
+
+Two explicit, non-interactive knobs let you override the default
+skip-on-match behaviour. They are safe in CI, AWS Lambda, parallel
+workers, and headless notebooks.
+
+```python
+backtests = app.run_vector_backtests(
+    strategies=strategies,
+    backtest_date_ranges=date_ranges,
+    initial_amount=1000,
+    market="BITVAVO",
+    trading_symbol="EUR",
+    use_checkpoints=True,
+    backtest_storage_directory="./backtest_storage",
+
+    # Rerun only strategies whose code or params changed:
+    force_rerun="stale",
+
+    # Or rerun everything, ignoring checkpoints:
+    # force_rerun=True,
+
+    # Log a single line per matched-checkpoint batch:
+    on_checkpoint_match="warn",
+)
+```
+
+| Parameter             | Value      | Behaviour                                      |
+|-----------------------|------------|------------------------------------------------|
+| `force_rerun`         | `False` (default) | Skip on hash match (today's behaviour)  |
+| `force_rerun`         | `"stale"`  | Rerun only when stored hash mismatches         |
+| `force_rerun`         | `True`     | Ignore checkpoints; rerun everything           |
+| `on_checkpoint_match` | `"skip"` (default) | Silent skip                            |
+| `on_checkpoint_match` | `"warn"`   | Skip but emit one log line per match           |
+| `on_checkpoint_match` | `"rerun"`  | Rerun even on a hash match                     |
+
 #### Checkpoint Behavior
 
 | `use_checkpoints` | `backtest_storage_directory` | Creates Checkpoints? | Uses Checkpoints? |
@@ -1181,10 +1246,38 @@ use_checkpoints=True
 # Ensure storage directory is provided
 backtest_storage_directory="./storage"
 
-# Check that strategy algorithm_ids are consistent
-# (changing strategy parameters changes algorithm_id)
-
 # Don't delete the storage directory between runs
+```
+
+Note: checkpoints are **content-aware**. If you edit the strategy
+class or change any of its parameters, the manifest hash changes and
+the checkpoint is treated as stale, which triggers an automatic
+rerun. This is intentional — it prevents silently using stale
+results. To force-skip stale entries (not recommended), pass
+`force_rerun=False` together with `on_checkpoint_match="skip"` and
+delete the manifest hash from `checkpoints.json`.
+
+### Issue: Strategies Silently Skipped After Edits
+
+**Symptoms**: You edited a strategy but the rerun produces the same
+results as before.
+
+**Cause**: This was the behaviour in older versions where checkpoints
+keyed on `algorithm_id` only. The framework now uses content-aware
+checkpoints, so this should no longer happen with new runs.
+
+**Solution**: Run once to migrate any legacy `checkpoints.json`
+entries to the new format. From then on, edits to the strategy code or
+its parameters will trigger a rerun automatically. To force a rerun
+explicitly, use:
+
+```python
+backtests = app.run_vector_backtests(
+    ...,
+    use_checkpoints=True,
+    backtest_storage_directory="./storage",
+    force_rerun=True,  # rerun everything once
+)
 ```
 
 ### Issue: Filtered Backtests Still Present

--- a/docusaurus/docs/Getting Started/backtesting.md
+++ b/docusaurus/docs/Getting Started/backtesting.md
@@ -163,6 +163,13 @@ backtests = app.run_vector_backtests(
 )
 ```
 
+Checkpoints are **content-aware**: when you edit a strategy or change
+a parameter, the stored checkpoint hash no longer matches and that
+strategy is rerun automatically. Use `force_rerun="stale"` to rerun
+*only* changed strategies, or `force_rerun=True` to ignore checkpoints
+entirely. See the [vector backtesting guide](../Advanced%20Concepts/vector-backtesting.md#content-aware-checkpoints)
+for details.
+
 ### Filtering Strategies
 
 Filter out underperforming strategies during backtesting:

--- a/docusaurus/docs/Getting Started/backtesting.md
+++ b/docusaurus/docs/Getting Started/backtesting.md
@@ -2,11 +2,34 @@
 sidebar_position: 8
 ---
 
-# Event-Driven Backtesting
+# Backtesting
 
-Event-driven backtesting simulates the market environment by processing each price update sequentially, just like live trading. It provides realistic order execution with full support for stop losses, take profits, and position sizing.
+Backtesting is the process of running a strategy against historical market
+data to estimate how it would have performed. The framework offers two
+complementary backtesting modes — pick the one that matches what you
+are trying to learn.
 
-## Quick Start
+## Choosing a backtesting mode
+
+| Aspect | [Event-Driven](event-backtesting) | [Vector](vector-backtesting) |
+|--------|-----------------------------------|------------------------------|
+| **Speed** | Slower, realistic simulation | 10-100x faster |
+| **Stop Loss / Take Profit** | Fully supported | Not supported |
+| **Signal Timing** | Executes at next strategy interval | Executes at exact signal timestamp |
+| **Position Sizing** | Based on portfolio at execution time | Based on portfolio at signal time |
+| **Data Loading** | Sliding window at each step | All data loaded at once |
+| **Best For** | Final validation, realistic results | Fast prototyping, parameter sweeps |
+
+A common workflow is to use **vector backtesting** for parameter sweeps
+and strategy filtering, and then validate the surviving strategies with
+**event-driven backtesting** for realistic execution.
+
+## Event-Driven Backtesting
+
+Event-driven backtesting steps through historical data tick-by-tick,
+mimicking the live trading loop. It is the right choice when realism
+matters: stop losses, take profits, intra-bar fills, and time-of-day
+position sizing all behave the same as in live trading.
 
 ```python
 from investing_algorithm_framework import create_app, BacktestDateRange
@@ -16,119 +39,27 @@ app = create_app()
 app.add_strategy(MyStrategy())
 app.add_market(market="bitvavo", trading_symbol="EUR")
 
-# Define the backtest period
 backtest_range = BacktestDateRange(
     start_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
     end_date=datetime(2024, 1, 1, tzinfo=timezone.utc)
 )
 
-# Run an event backtest
 backtest = app.run_backtest(
     backtest_date_range=backtest_range,
     initial_amount=1000
 )
 ```
 
-## Running an Event-Based Backtest
+See [Event-Driven Backtesting](event-backtesting) for the full guide,
+including multiple date ranges, accessing metrics and trades, and
+best practices.
 
-```python
-backtest = app.run_backtest(
-    backtest_date_range=backtest_range,
-    initial_amount=1000,
-    risk_free_rate=0.027,  # Optional: for metrics such as Sharpe ratio calculation
-)
-```
+## Vector Backtesting
 
-## Multiple Date Ranges
-
-Test your strategy across different market conditions:
-
-```python
-date_ranges = [
-    BacktestDateRange(
-        start_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
-        end_date=datetime(2022, 12, 31, tzinfo=timezone.utc),
-        name="Bear Market 2022"
-    ),
-    BacktestDateRange(
-        start_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-        end_date=datetime(2023, 12, 31, tzinfo=timezone.utc),
-        name="Recovery 2023"
-    ),
-]
-
-backtests = app.run_backtests(
-    backtest_date_ranges=date_ranges,
-    ... # other params
-)
-```
-
-## Event-Driven vs Vector Backtesting
-
-The framework supports two backtesting modes. This page covers event-driven backtesting. For vector backtesting, see [Vector Backtesting](vector-backtesting).
-
-| Aspect | Event-Driven | Vector |
-|--------|-------------|--------|
-| **Speed** | Slower, realistic simulation | 10-100x faster |
-| **Stop Loss / Take Profit** | Fully supported | Not supported |
-| **Signal Timing** | Executes at next strategy interval | Executes at exact signal timestamp |
-| **Position Sizing** | Based on portfolio at execution time | Based on portfolio at signal time |
-| **Data Loading** | Sliding window at each step | All data loaded at once |
-| **Best For** | Final validation, realistic results | Fast prototyping, parameter sweeps |
-
-## Analyzing Results
-
-### Backtest Report
-
-Generate a visual report of your backtest:
-
-```python
-from investing_algorithm_framework import BacktestReport
-
-# Single strategy
-report = BacktestReport(backtest)
-report.show(browser=True)  # Opens in your default browser
-
-# Multi-strategy comparison
-report = BacktestReport(backtests=[backtest_a, backtest_b])
-report.show()
-
-# Load from saved backtests on disk
-report = BacktestReport.open(directory_path="./my_backtests")
-report.show()
-
-# Save as a self-contained HTML file
-report.save("comparison_report.html")
-```
-
-See [Backtest Reports](/docs/Getting%20Started/backtest-reports) for full documentation on the dashboard features, compare mode, and API reference.
-
-### Accessing Metrics
-
-```python
-# Get performance metrics
-metrics = backtest.get_backtest_metrics()
-print(f"Total Return: {metrics.total_return}%")
-print(f"Sharpe Ratio: {metrics.sharpe_ratio}")
-print(f"Max Drawdown: {metrics.max_drawdown}%")
-print(f"Total Trades: {metrics.number_of_trades_closed}")
-```
-
-### Accessing Trades
-
-```python
-for run in backtest.get_all_backtest_runs():
-    trades = run.trades
-    for trade in trades:
-        print(f"Symbol: {trade.symbol}")
-        print(f"Entry: {trade.entry_price}")
-        print(f"Exit: {trade.exit_price}")
-        print(f"Return: {trade.return_percentage}%")
-```
-
-## Saving and Loading Backtests
-
-### Save to Directory
+Vector backtesting processes the entire price series in a single pass,
+which makes it dramatically faster but skips intra-bar simulation
+(no stop losses or take profits). It is ideal for parameter sweeps,
+running hundreds of strategy variants, and large-scale optimization.
 
 ```python
 backtests = app.run_vector_backtests(
@@ -139,7 +70,14 @@ backtests = app.run_vector_backtests(
 )
 ```
 
-### Load from Directory
+See [Vector Backtesting](vector-backtesting) for the full guide,
+including checkpointing, content-aware reruns (`force_rerun`),
+strategy filtering, and parallel processing.
+
+## Saving and Loading Backtests
+
+Both modes can persist their results to disk so you can analyse them
+later or share them across machines.
 
 ```python
 from investing_algorithm_framework import load_backtests_from_directory
@@ -147,76 +85,26 @@ from investing_algorithm_framework import load_backtests_from_directory
 backtests = load_backtests_from_directory("./my_backtests")
 ```
 
-## Advanced Features
+## Reporting
 
-### Checkpointing
-
-Resume interrupted backtests:
-
-```python
-backtests = app.run_vector_backtests(
-    strategies=strategies,
-    backtest_date_ranges=date_ranges,
-    backtest_storage_directory="./my_backtests",
-    use_checkpoints=True,  # Resume from last checkpoint
-    initial_amount=1000
-)
-```
-
-Checkpoints are **content-aware**: when you edit a strategy or change
-a parameter, the stored checkpoint hash no longer matches and that
-strategy is rerun automatically. Use `force_rerun="stale"` to rerun
-*only* changed strategies, or `force_rerun=True` to ignore checkpoints
-entirely. See the [vector backtesting guide](../Advanced%20Concepts/vector-backtesting.md#content-aware-checkpoints)
-for details.
-
-### Filtering Strategies
-
-Filter out underperforming strategies during backtesting:
+Use [Backtest Reports](/docs/Getting%20Started/backtest-reports) to turn
+backtest results — from either mode — into an interactive dashboard or
+a self-contained HTML file.
 
 ```python
-def window_filter(backtest_run):
-    """Filter after each date range"""
-    return backtest_run.backtest_metrics.total_return > 0
+from investing_algorithm_framework import BacktestReport
 
-def final_filter(backtest):
-    """Filter at the end"""
-    return backtest.backtest_summary.sharpe_ratio > 1.0
-
-backtests = app.run_vector_backtests(
-    strategies=strategies,
-    backtest_date_ranges=date_ranges,
-    window_filter_function=window_filter,
-    final_filter_function=final_filter,
-    initial_amount=1000
-)
+report = BacktestReport(backtest)
+report.show(browser=True)
 ```
-
-### Parallel Processing
-
-Utilize multiple CPU cores for faster backtesting:
-
-```python
-import os
-
-backtests = app.run_vector_backtests(
-    strategies=strategies,
-    backtest_date_ranges=date_ranges,
-    n_workers=os.cpu_count() - 1,  # Use all cores except one
-    initial_amount=1000
-)
-```
-
-## Best Practices
-
-1. **Use representative date ranges**: Include bull markets, bear markets, and sideways periods
-2. **Avoid overfitting**: Don't optimize too heavily on historical data
-3. **Account for costs**: Consider trading fees and slippage in your strategy
-4. **Use checkpointing**: For long-running backtests, enable checkpoints to avoid losing progress
-5. **Start with event-based**: Use event-based backtesting for realistic simulation, then scale with vector backtesting
 
 ## Next Steps
 
-- Learn about [Vector Backtesting](vector-backtesting) for fast parameter sweeps and optimization
-- Explore [Backtest Reports](/docs/Getting%20Started/backtest-reports) for the interactive dashboard
-- Check out [Performance Optimization](/docs/Advanced%20Concepts/OPTIMIZATION_GUIDE) for large-scale testing
+- [Event-Driven Backtesting](event-backtesting) — realistic simulation
+  with full order-execution semantics.
+- [Vector Backtesting](vector-backtesting) — fast parameter sweeps and
+  optimization, with content-aware checkpoints.
+- [Backtest Reports](/docs/Getting%20Started/backtest-reports) — explore
+  results in the interactive dashboard.
+- [Performance Optimization](/docs/Advanced%20Concepts/OPTIMIZATION_GUIDE)
+  — tips for large-scale testing.

--- a/docusaurus/docs/Getting Started/event-backtesting.md
+++ b/docusaurus/docs/Getting Started/event-backtesting.md
@@ -1,0 +1,130 @@
+---
+sidebar_position: 9
+---
+
+# Event-Driven Backtesting
+
+Event-driven backtesting simulates the market environment by processing each price update sequentially, just like live trading. It provides realistic order execution with full support for stop losses, take profits, and position sizing.
+
+> Looking for a high-level comparison of backtesting modes? See [Backtesting](backtesting). For batch-style high-throughput runs, see [Vector Backtesting](vector-backtesting).
+
+## Quick Start
+
+```python
+from investing_algorithm_framework import create_app, BacktestDateRange
+from datetime import datetime, timezone
+
+app = create_app()
+app.add_strategy(MyStrategy())
+app.add_market(market="bitvavo", trading_symbol="EUR")
+
+# Define the backtest period
+backtest_range = BacktestDateRange(
+    start_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+    end_date=datetime(2024, 1, 1, tzinfo=timezone.utc)
+)
+
+# Run an event backtest
+backtest = app.run_backtest(
+    backtest_date_range=backtest_range,
+    initial_amount=1000
+)
+```
+
+## Running an Event-Based Backtest
+
+```python
+backtest = app.run_backtest(
+    backtest_date_range=backtest_range,
+    initial_amount=1000,
+    risk_free_rate=0.027,  # Optional: for metrics such as Sharpe ratio calculation
+)
+```
+
+## Multiple Date Ranges
+
+Test your strategy across different market conditions:
+
+```python
+date_ranges = [
+    BacktestDateRange(
+        start_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        end_date=datetime(2022, 12, 31, tzinfo=timezone.utc),
+        name="Bear Market 2022"
+    ),
+    BacktestDateRange(
+        start_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        end_date=datetime(2023, 12, 31, tzinfo=timezone.utc),
+        name="Recovery 2023"
+    ),
+]
+
+backtests = app.run_backtests(
+    backtest_date_ranges=date_ranges,
+    ... # other params
+)
+```
+
+## Analyzing Results
+
+### Backtest Report
+
+Generate a visual report of your backtest:
+
+```python
+from investing_algorithm_framework import BacktestReport
+
+# Single strategy
+report = BacktestReport(backtest)
+report.show(browser=True)  # Opens in your default browser
+
+# Multi-strategy comparison
+report = BacktestReport(backtests=[backtest_a, backtest_b])
+report.show()
+
+# Load from saved backtests on disk
+report = BacktestReport.open(directory_path="./my_backtests")
+report.show()
+
+# Save as a self-contained HTML file
+report.save("comparison_report.html")
+```
+
+See [Backtest Reports](/docs/Getting%20Started/backtest-reports) for full documentation on the dashboard features, compare mode, and API reference.
+
+### Accessing Metrics
+
+```python
+# Get performance metrics
+metrics = backtest.get_backtest_metrics()
+print(f"Total Return: {metrics.total_return}%")
+print(f"Sharpe Ratio: {metrics.sharpe_ratio}")
+print(f"Max Drawdown: {metrics.max_drawdown}%")
+print(f"Total Trades: {metrics.number_of_trades_closed}")
+```
+
+### Accessing Trades
+
+```python
+for run in backtest.get_all_backtest_runs():
+    trades = run.trades
+    for trade in trades:
+        print(f"Symbol: {trade.symbol}")
+        print(f"Entry: {trade.entry_price}")
+        print(f"Exit: {trade.exit_price}")
+        print(f"Return: {trade.return_percentage}%")
+```
+
+## Best Practices
+
+1. **Use representative date ranges**: Include bull markets, bear markets, and sideways periods.
+2. **Avoid overfitting**: Don't optimize too heavily on historical data.
+3. **Account for costs**: Consider trading fees and slippage in your strategy.
+4. **Start with event-based**: Use event-based backtesting for realistic simulation, then scale out with [vector backtesting](vector-backtesting) for parameter sweeps.
+
+## Next Steps
+
+- Compare modes on the [Backtesting overview](backtesting).
+- Switch to [Vector Backtesting](vector-backtesting) for fast parameter sweeps and optimization.
+- Explore [Backtest Reports](/docs/Getting%20Started/backtest-reports) for the interactive dashboard.
+- Check out [Performance Optimization](/docs/Advanced%20Concepts/OPTIMIZATION_GUIDE) for large-scale testing.

--- a/docusaurus/docs/Getting Started/vector-backtesting.md
+++ b/docusaurus/docs/Getting Started/vector-backtesting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Vector Backtesting
@@ -13,7 +13,7 @@ Vector backtesting is a high-performance backtesting approach that processes mar
 - Large-scale strategy optimization (100+ strategies)
 - Fast prototyping and signal research
 
-> For realistic simulation with stop losses and take profits, use [Event-Driven Backtesting](backtesting) instead.
+> For realistic simulation with stop losses and take profits, use [Event-Driven Backtesting](event-backtesting) instead. For a high-level comparison of backtesting modes, see the [Backtesting overview](backtesting).
 
 ## Quick Start
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -47,6 +47,10 @@ const sidebars = {
                 },
                 {
                     type: 'doc',
+                    id: 'Getting Started/event-backtesting',
+                },
+                {
+                    type: 'doc',
                     id: 'Getting Started/vector-backtesting',
                 },
                 {

--- a/investing_algorithm_framework/app/app.py
+++ b/investing_algorithm_framework/app/app.py
@@ -4,7 +4,7 @@ import os
 import threading
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import List, Optional, Any, Dict, Tuple, Callable, Union
+from typing import List, Literal, Optional, Any, Dict, Tuple, Callable, Union
 
 from flask import Flask
 
@@ -985,6 +985,8 @@ class App:
         ] = None,
         backtest_storage_directory: Optional[Union[str, Path]] = None,
         use_checkpoints: bool = False,
+        force_rerun: Union[bool, Literal["stale"]] = False,
+        on_checkpoint_match: Literal["skip", "rerun", "warn"] = "skip",
         batch_size: int = 50,
         checkpoint_batch_size: int = 25,
         n_workers: Optional[int] = None,
@@ -1087,7 +1089,24 @@ class App:
                 instead of running a new backtest. This is useful for
                 long-running backtests that might take a while to complete.
                 When enabled, uses the optimized version with batching and
-                optional parallel processing.
+                optional parallel processing. Checkpoints are content-aware:
+                each entry stores a manifest hash that fingerprints the
+                strategy code, parameters, data sources, and date range.
+                Strategies whose hash differs from the stored hash are
+                rerun automatically.
+            force_rerun (Union[bool, Literal["stale"]]): Override checkpoint
+                skipping behaviour.
+
+                - False (default): Skip strategies with a matching checkpoint.
+                - "stale": Rerun only strategies whose stored checkpoint hash
+                  differs from the current manifest hash.
+                - True: Ignore checkpoints entirely and rerun all strategies.
+            on_checkpoint_match (Literal["skip", "rerun", "warn"]): Behaviour
+                when a strategy's checkpoint matches.
+
+                - "skip" (default): Silently skip the strategy.
+                - "warn": Skip but emit a single log line per match batch.
+                - "rerun": Rerun the strategy anyway.
             batch_size (int): Number of strategies to process in each batch
                 before memory cleanup. Only used when use_checkpoints=True.
                 Default: 100. Higher values use more memory but may be faster.
@@ -1204,6 +1223,8 @@ class App:
             checkpoint_batch_size=checkpoint_batch_size,
             n_workers=n_workers,
             use_checkpoints=use_checkpoints,
+            force_rerun=force_rerun,
+            on_checkpoint_match=on_checkpoint_match,
             dynamic_position_sizing=dynamic_position_sizing,
             fill_missing_data=fill_missing_data,
             iterative_summary_update=iterative_summary_update,
@@ -1381,6 +1402,8 @@ class App:
         metadata: Optional[Dict[str, str]] = None,
         backtest_storage_directory: Optional[Union[str, Path]] = None,
         use_checkpoints: bool = False,
+        force_rerun: Union[bool, Literal["stale"]] = False,
+        on_checkpoint_match: Literal["skip", "rerun", "warn"] = "skip",
         show_progress: bool = False,
         continue_on_error: bool = False,
         window_filter_function: Optional[Callable] = None,
@@ -1420,7 +1443,16 @@ class App:
             backtest_storage_directory (Union[str, Path]): Directory to save
                 backtests to.
             use_checkpoints (bool): Whether to use checkpointing to resume
-                interrupted backtests.
+                interrupted backtests. Checkpoints are content-aware:
+                strategies whose code or parameters have changed since the
+                last run are detected and rerun automatically.
+            force_rerun (Union[bool, Literal["stale"]]): Override checkpoint
+                skipping behaviour. ``False`` (default) skips matched
+                checkpoints, ``"stale"`` reruns only mismatched ones, and
+                ``True`` reruns everything.
+            on_checkpoint_match (Literal["skip", "rerun", "warn"]): Behaviour
+                on a matching checkpoint. ``"skip"`` (default) silently
+                skips, ``"warn"`` skips and logs, ``"rerun"`` reruns anyway.
             show_progress (bool): Whether to show progress bars.
             continue_on_error (bool): Whether to continue on errors.
             window_filter_function: Filter function applied after each
@@ -1533,6 +1565,8 @@ class App:
             final_filter_function=final_filter_function,
             backtest_storage_directory=backtest_storage_directory,
             use_checkpoints=use_checkpoints,
+            force_rerun=force_rerun,
+            on_checkpoint_match=on_checkpoint_match,
             batch_size=batch_size,
             checkpoint_batch_size=checkpoint_batch_size,
             fill_missing_data=fill_missing_data,

--- a/investing_algorithm_framework/domain/backtesting/backtest.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest.py
@@ -418,6 +418,23 @@ class Backtest:
                 os.makedirs(destination_run_path, exist_ok=True)
                 br.save(destination_run_path)
 
+        # Always rebuild the summary from the current set of backtest runs
+        # before writing it to disk. This guarantees that summary.json is
+        # self-consistent with the per-run metrics.json files (e.g.
+        # number_of_windows == number of runs, total_net_gain == sum of
+        # per-run total_net_gain, etc.) regardless of how the in-memory
+        # Backtest was constructed (single backtest, walk-forward,
+        # merge(), …). See issue #511.
+        if self.backtest_runs:
+            per_run_metrics = [
+                br.backtest_metrics for br in self.backtest_runs
+                if br.backtest_metrics is not None
+            ]
+            if per_run_metrics:
+                self.backtest_summary = generate_backtest_summary_metrics(
+                    per_run_metrics
+                )
+
         # Save combined backtest metrics if available
         if self.backtest_summary:
             summary_file = os.path.join(
@@ -517,15 +534,22 @@ class Backtest:
             Backtest: The merged Backtest instance.
         """
 
-        merged = Backtest()
+        merged = Backtest(algorithm_id=self.algorithm_id)
         merged.backtest_runs = self.backtest_runs + other.backtest_runs
 
-        summary = BacktestSummaryMetrics()
+        # Rebuild the summary from the full set of merged backtest runs.
+        # `BacktestSummaryMetrics` is a plain dataclass and does not expose
+        # an `add()` method, so the previous incremental approach raised
+        # AttributeError and silently produced a stale / single-window
+        # summary. See issue #511.
+        merged_metrics = merged.get_all_backtest_metrics()
+        if merged_metrics:
+            merged.backtest_summary = generate_backtest_summary_metrics(
+                merged_metrics
+            )
+        else:
+            merged.backtest_summary = BacktestSummaryMetrics()
 
-        for bt_run in merged.get_all_backtest_metrics():
-            summary.add(bt_run)
-
-        merged.backtest_summary = summary
         merged.backtest_permutation_tests = \
             self.backtest_permutation_tests + other.backtest_permutation_tests
 

--- a/investing_algorithm_framework/domain/backtesting/backtest_metrics.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest_metrics.py
@@ -20,6 +20,21 @@ class BacktestMetrics:
     total return, annualized return, volatility, Sharpe ratio,
     and maximum drawdown.
 
+    .. note:: Field semantics & known duplicates (issue #511)
+
+        - ``total_loss`` is the **gross loss magnitude** (a non-negative
+          number equal to ``sum(abs(net_gain))`` over losing trades).
+          ``total_loss_percentage`` is ``total_loss /
+          initial_unallocated`` (decimal, non-negative). These fields
+          no longer mirror ``total_net_gain`` / ``total_net_gain_pct``;
+          see B1 in issue #511.
+
+        - ``total_growth`` / ``total_growth_percentage`` are
+          numerically equivalent to ``total_net_gain`` /
+          ``total_net_gain_percentage`` for the standard
+          mark-to-market portfolio used in backtests. They are kept as
+          legacy aliases. See B3 in issue #511.
+
     Attributes:
         backtest_date_range_name (str): The name of the date range
             used for the backtest.

--- a/investing_algorithm_framework/domain/backtesting/backtest_summary_metrics.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest_summary_metrics.py
@@ -13,6 +13,30 @@ class BacktestSummaryMetrics:
     Represents the summarized results of a backtest,
     focusing on key headline performance and risk metrics.
 
+    .. note:: Field semantics & known duplicates (issue #511)
+
+        - ``total_loss`` / ``total_loss_percentage`` are gross-loss
+          based: ``total_loss`` is ``sum(per-run gross_loss)`` (a
+          non-negative magnitude in account currency) and
+          ``total_loss_percentage`` is ``total_loss /
+          sum(initial_unallocated)`` (decimal). They no longer mix
+          with net-return semantics. See B1/B2 in issue #511.
+
+        - ``total_growth`` / ``total_growth_percentage`` are
+          numerically equivalent to ``total_net_gain`` /
+          ``total_net_gain_percentage`` for closed-position backtests
+          because both are derived from the same start/end portfolio
+          values. They are kept for backwards compatibility but should
+          be considered legacy aliases. See B3 in issue #511.
+
+        - ``average_net_gain``, ``average_loss``, ``average_growth``
+          (and their ``*_percentage`` counterparts) are time-weighted
+          means **across windows**. For a single-window backtest they
+          collapse to the corresponding ``total_*`` value by
+          definition (weighted mean of one element equals that
+          element). See B4 in issue #511. For per-trade averages use
+          ``average_trade_*`` instead.
+
     Attributes:
         total_net_gain (float): Total net gain from the backtest.
         total_net_gain_percentage (float): Total net gain percentage

--- a/investing_algorithm_framework/domain/backtesting/combine_backtests.py
+++ b/investing_algorithm_framework/domain/backtesting/combine_backtests.py
@@ -39,28 +39,32 @@ def _compound_percentage_returns(percentages):
     Compound percentage returns across multiple periods.
 
     For example, if period 1 has 10% return and period 2 has 5% return,
-    the compounded return is: (1 + 0.10) * (1 + 0.05) - 1 = 15.5%
-    NOT simply 10% + 5% = 15%
+    the compounded return is: (1 + 0.10) * (1 + 0.05) - 1 = 0.155 = 15.5%
+    NOT simply 0.10 + 0.05 = 0.15.
+
+    The framework consistently represents percentages as **decimals**
+    (e.g. ``0.10`` for 10%), so this helper expects decimal inputs and
+    returns a decimal. See issue #511 (B5) — earlier versions assumed
+    whole-number percentages, which silently produced results off by a
+    factor of ~100 once multi-window aggregation was exercised.
 
     Args:
-        percentages (List[float | None]): List of percentage returns
-            (as whole numbers, e.g., 10 for 10%).
+        percentages (List[float | None]): List of period returns expressed
+            as decimals (e.g. ``0.10`` for 10%).
 
     Returns:
-        float | None: The compounded percentage return, or None if no
-            valid percentages.
+        float | None: The compounded return as a decimal, or ``None`` if
+            no valid percentages.
     """
     valid_percentages = [p for p in percentages if p is not None]
     if not valid_percentages:
         return None
 
-    # Convert percentages to decimals, compound, then convert back
     compounded = 1.0
     for pct in valid_percentages:
-        compounded *= (1 + pct / 100)
+        compounded *= (1 + pct)
 
-    # Convert back to percentage
-    return (compounded - 1) * 100
+    return compounded - 1
 
 
 def combine_backtests(backtests):
@@ -173,9 +177,13 @@ def generate_backtest_summary_metrics(
         b.total_net_gain for b in valid_metrics
         if b.total_net_gain is not None
     )
+    # B1/B2 fix (issue #511): per-run ``total_loss`` is now the gross
+    # loss magnitude, so the aggregate is simply the sum of per-run
+    # ``total_loss`` (equivalent to ``sum(gross_loss)``). Both per-run
+    # and aggregate use the same unit (positive currency).
     total_loss = sum(
-        b.gross_loss for b in valid_metrics
-        if b.gross_loss is not None
+        b.total_loss for b in valid_metrics
+        if b.total_loss is not None
     )
     total_growth = sum(
         b.total_growth for b in valid_metrics
@@ -184,13 +192,24 @@ def generate_backtest_summary_metrics(
 
     # === PERCENTAGE RETURNS (compounded, not summed) ===
     # Compound returns: (1 + r1) * (1 + r2) * ... - 1
-    # For percentages stored as whole numbers (e.g., 10 for 10%)
+    # All percentages are stored as decimals (e.g. 0.10 for 10%).
     total_net_gain_percentage = _compound_percentage_returns(
         [b.total_net_gain_percentage for b in valid_metrics]
     )
-    total_loss_percentage = _compound_percentage_returns(
-        [b.total_loss_percentage for b in valid_metrics]
-    )
+    # ``total_loss`` is a non-multiplicative magnitude (it does not
+    # compound across windows). Express the aggregate as the sum of
+    # gross losses divided by the sum of initial capital across
+    # windows, which keeps the unit (decimal fraction) consistent
+    # with the per-run definition. See issue #511 (B2).
+    total_initial_value = 0.0
+    for b in valid_metrics:
+        iv = getattr(b, "initial_unallocated", None)
+        if isinstance(iv, (int, float)) and iv > 0:
+            total_initial_value += iv
+    if total_initial_value > 0 and total_loss is not None:
+        total_loss_percentage = total_loss / total_initial_value
+    else:
+        total_loss_percentage = None
     total_growth_percentage = _compound_percentage_returns(
         [b.total_growth_percentage for b in valid_metrics]
     )

--- a/investing_algorithm_framework/domain/models/data/data_source.py
+++ b/investing_algorithm_framework/domain/models/data/data_source.py
@@ -69,9 +69,13 @@ class DataSource:
             if self.warmup_window is None:
                 object.__setattr__(self, 'warmup_window', self.window_size)
 
-        # Sync warmup_window back to window_size for backward compatibility
-        # so existing code reading .window_size still works
-        if self.warmup_window is not None and self.window_size is None:
+        # Keep warmup_window and window_size in sync. warmup_window is the
+        # canonical attribute; window_size is the deprecated alias kept for
+        # backward compatibility (see issue #379). Whenever warmup_window is
+        # set, mirror it onto window_size so consumers reading either
+        # attribute see the same value.
+        if self.warmup_window is not None \
+                and self.window_size != self.warmup_window:
             object.__setattr__(self, 'window_size', self.warmup_window)
 
         # Convert data_type and time_frame to their respective enums if needed

--- a/investing_algorithm_framework/infrastructure/services/backtesting/backtest_service.py
+++ b/investing_algorithm_framework/infrastructure/services/backtesting/backtest_service.py
@@ -1,4 +1,5 @@
 import gc
+import hashlib
 import json
 import logging
 import multiprocessing
@@ -8,7 +9,7 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -26,6 +27,10 @@ from investing_algorithm_framework.services.metrics import \
     create_backtest_metrics
 from investing_algorithm_framework.services.portfolios import \
     PortfolioConfigurationService
+from .checkpoint_manifest import (
+    compute_strategy_manifest_hash,
+    normalize_checkpoint_entry,
+)
 from .vector_backtest_service import VectorBacktestService
 
 
@@ -333,10 +338,17 @@ class BacktestService:
         algorithm_ids = [bt.algorithm_id for bt in backtests]
 
         if mode == "append" and backtest_range_key in checkpoints:
-            existing_ids = set(checkpoints[backtest_range_key])
-            new_ids = set(algorithm_ids)
-            combined_ids = list(existing_ids.union(new_ids))
-            checkpoints[backtest_range_key] = combined_ids
+            existing_entry = checkpoints[backtest_range_key]
+            if isinstance(existing_entry, dict):
+                # Preserve dict format; new ids get None hash
+                for algo_id in algorithm_ids:
+                    existing_entry.setdefault(algo_id, None)
+                checkpoints[backtest_range_key] = existing_entry
+            else:
+                existing_ids = set(existing_entry)
+                new_ids = set(algorithm_ids)
+                combined_ids = list(existing_ids.union(new_ids))
+                checkpoints[backtest_range_key] = combined_ids
         else:
             checkpoints[backtest_range_key] = algorithm_ids
 
@@ -402,7 +414,12 @@ class BacktestService:
             checkpoints = json.load(f)
 
         backtest_range_key = f"{start_date_key}_{end_date_key}"
-        checkpointed = checkpoints.get(backtest_range_key, [])
+        raw_entry = checkpoints.get(backtest_range_key, [])
+        # Support both legacy (list) and content-aware (dict) formats.
+        if isinstance(raw_entry, dict):
+            checkpointed = list(raw_entry.keys())
+        else:
+            checkpointed = list(raw_entry)
 
         # Determine which algorithms are missing, by comparing witch
         # algorithm id's are present in the checkpoints and which are not
@@ -734,6 +751,8 @@ class BacktestService:
         ] = None,
         backtest_storage_directory: Optional[Union[str, Path]] = None,
         use_checkpoints: bool = True,
+        force_rerun: Union[bool, Literal["stale"]] = False,
+        on_checkpoint_match: Literal["skip", "rerun", "warn"] = "skip",
         batch_size: int = 50,
         checkpoint_batch_size: int = 25,
         n_workers: Optional[int] = None,
@@ -891,43 +910,62 @@ class BacktestService:
             end_date = backtest_date_range.end_date.strftime('%Y-%m-%d')
             active_algorithm_ids = [s.algorithm_id for s in active_strategies]
 
+            # Compute content-aware manifest hashes for the active
+            # strategies. These fingerprint the strategy code, parameters,
+            # data sources and date range so checkpoints can detect when a
+            # strategy has actually changed since its last run.
+            manifest_hashes: Dict[str, str] = {}
+            if backtest_storage_directory is not None:
+                manifest_hashes = self._compute_manifest_hashes(
+                    active_strategies, backtest_date_range
+                )
+
             # Only check for checkpoints if use_checkpoints is True
-            if use_checkpoints:
+            if use_checkpoints and force_rerun is not True:
                 _print_progress(
                     "Using checkpoints to skip completed backtests ...",
                     show_progress
                 )
-                checkpointed_ids = self._get_checkpointed_from_cache(
-                    checkpoint_cache, backtest_date_range
-                )
-                missing_ids = set(active_algorithm_ids) - set(checkpointed_ids)
-                strategies_to_run = [
-                    s for s in active_strategies
-                    if s.algorithm_id in missing_ids
-                ]
+                strategies_to_run, matched_ids, stale_ids = \
+                    self._select_items_to_rerun(
+                        active_strategies,
+                        active_algorithm_ids,
+                        manifest_hashes,
+                        checkpoint_cache,
+                        backtest_date_range,
+                        force_rerun=force_rerun,
+                        on_checkpoint_match=on_checkpoint_match,
+                    )
 
-                # Add checkpointed IDs to session cache so they're included
-                # in final loading (they were run in a previous session but
-                # are part of the current batch)
+                # Add matched (skipped) ids to session cache so they end
+                # up in the final result set even though they weren't
+                # rerun in this session.
                 if session_cache is not None:
-                    for algo_id in checkpointed_ids:
-                        if algo_id in active_algorithm_ids:
-                            backtest_path = os.path.join(
-                                backtest_storage_directory, algo_id
-                            )
-                            session_cache["backtests"][algo_id] = backtest_path
+                    for algo_id in matched_ids:
+                        backtest_path = os.path.join(
+                            backtest_storage_directory, algo_id
+                        )
+                        session_cache["backtests"][algo_id] = backtest_path
 
-                # Count how many active strategies are in the checkpoint
-                matched_checkpoint_count = len(
-                    set(active_algorithm_ids) & set(checkpointed_ids)
-                )
+                if stale_ids and on_checkpoint_match != "skip":
+                    logger.info(
+                        "Detected %d stale checkpoint(s) for "
+                        "%s to %s; rerunning due to content change.",
+                        len(stale_ids), start_date, end_date,
+                    )
+                if matched_ids and on_checkpoint_match == "warn":
+                    logger.info(
+                        "Skipping %d strategies with matching checkpoint "
+                        "for %s to %s.",
+                        len(matched_ids), start_date, end_date,
+                    )
 
                 if show_progress:
                     _print_progress(
                         f"Active strategies: {len(active_algorithm_ids)}, "
-                        f"checkpoint file has: {len(checkpointed_ids)}, "
-                        f"matched: {matched_checkpoint_count}, "
-                        f"running {len(strategies_to_run)} new backtests",
+                        f"matched: {len(matched_ids)}, "
+                        f"stale: {len(stale_ids)}, "
+                        f"running {len(strategies_to_run)} backtests",
                         show_progress
                     )
             else:
@@ -1094,7 +1132,8 @@ class BacktestService:
                                             backtest_date_range,
                                             backtest_storage_directory,
                                             checkpoint_cache,
-                                            session_cache
+                                            session_cache,
+                                            manifest_hashes=manifest_hashes,
                                         )
 
                                 # Periodic garbage collection every 10 batches
@@ -1128,7 +1167,8 @@ class BacktestService:
                             backtest_date_range,
                             backtest_storage_directory,
                             checkpoint_cache,
-                            session_cache
+                            session_cache,
+                            manifest_hashes=manifest_hashes,
                         )
 
                 else:
@@ -1186,7 +1226,8 @@ class BacktestService:
                                         backtest_date_range,
                                         backtest_storage_directory,
                                         checkpoint_cache,
-                                        session_cache
+                                        session_cache,
+                                        manifest_hashes=manifest_hashes,
                                     )
 
                             # Periodic garbage collection every 5 batches
@@ -1211,7 +1252,8 @@ class BacktestService:
                             backtest_date_range,
                             backtest_storage_directory,
                             checkpoint_cache,
-                            session_cache
+                            session_cache,
+                            manifest_hashes=manifest_hashes,
                         )
 
             # Store backtests in memory when no storage directory provided
@@ -1482,10 +1524,132 @@ class BacktestService:
         cache: Dict,
         date_range: BacktestDateRange
     ) -> List[str]:
-        """Get checkpointed algorithm IDs from cache."""
+        """Get checkpointed algorithm IDs from cache.
+
+        Supports both legacy (list) and content-aware (dict) entries.
+        """
         key = (f"{date_range.start_date.isoformat()}_"
                f"{date_range.end_date.isoformat()}")
-        return cache.get(key, [])
+        entry = cache.get(key)
+        if entry is None:
+            return []
+        if isinstance(entry, dict):
+            return list(entry.keys())
+        return list(entry)
+
+    @staticmethod
+    def _checkpoint_key_for(date_range: BacktestDateRange) -> str:
+        return (f"{date_range.start_date.isoformat()}_"
+                f"{date_range.end_date.isoformat()}")
+
+    @staticmethod
+    def _compute_manifest_hashes(
+        items: List,
+        date_range: BacktestDateRange,
+    ) -> Dict[str, str]:
+        """
+        Compute content-aware manifest hashes for a list of strategies
+        or algorithms.
+
+        For an ``Algorithm``, the hash is computed over its underlying
+        strategies; this keeps the result deterministic regardless of
+        whether the caller passed strategies or algorithms.
+        """
+        hashes: Dict[str, str] = {}
+        for item in items:
+            algo_id = (
+                item.algorithm_id if hasattr(item, "algorithm_id")
+                else getattr(item, "id", None)
+            )
+            if algo_id is None:
+                continue
+
+            strategies = getattr(item, "strategies", None)
+            if strategies:
+                # Algorithm: aggregate hashes of contained strategies
+                parts = [
+                    compute_strategy_manifest_hash(s, date_range)
+                    for s in strategies
+                ]
+                payload = "|".join(parts)
+                hashes[algo_id] = hashlib.sha256(
+                    payload.encode("utf-8")
+                ).hexdigest()[:16]
+            else:
+                hashes[algo_id] = compute_strategy_manifest_hash(
+                    item, date_range
+                )
+        return hashes
+
+    @staticmethod
+    def _select_items_to_rerun(
+        active_items: List,
+        active_algorithm_ids: List[str],
+        manifest_hashes: Dict[str, str],
+        checkpoint_cache: Dict,
+        date_range: BacktestDateRange,
+        force_rerun: Union[bool, Literal["stale"]] = False,
+        on_checkpoint_match: Literal["skip", "rerun", "warn"] = "skip",
+    ) -> Tuple[List, List[str], List[str]]:
+        """
+        Decide which strategies/algorithms to (re)run for ``date_range``.
+
+        Returns a tuple ``(items_to_run, matched_ids, stale_ids)``:
+
+        - ``items_to_run`` is the filtered list of strategies/algorithms
+          the engine should actually execute.
+        - ``matched_ids`` are algorithm_ids whose checkpoint matches the
+          current manifest hash (or any checkpoint, when no hash is
+          stored).
+        - ``stale_ids`` are algorithm_ids that have a checkpoint with a
+          mismatching manifest hash. They will be rerun unless
+          ``force_rerun=False`` AND ``on_checkpoint_match='skip'`` AND
+          no stored hash exists (legacy behaviour).
+        """
+        if force_rerun is True:
+            return list(active_items), [], []
+
+        key = BacktestService._checkpoint_key_for(date_range)
+        entry = normalize_checkpoint_entry(checkpoint_cache.get(key))
+
+        matched_ids: List[str] = []
+        stale_ids: List[str] = []
+        items_to_run: List = []
+
+        # zip-by-id mapping
+        active_by_id = {
+            algo_id: item for algo_id, item
+            in zip(active_algorithm_ids, active_items)
+        }
+
+        for algo_id, item in active_by_id.items():
+            if algo_id not in entry:
+                items_to_run.append(item)
+                continue
+
+            stored_hash = entry[algo_id]
+            current_hash = manifest_hashes.get(algo_id)
+
+            # Determine whether the checkpoint matches the current run.
+            # - No stored hash (legacy): treat as a content-blind match.
+            # - Stored hash matches current hash: content match.
+            # - Stored hash differs: stale.
+            if stored_hash is None or stored_hash == current_hash:
+                # match
+                matched_ids.append(algo_id)
+                if on_checkpoint_match == "rerun":
+                    items_to_run.append(item)
+                # "skip" and "warn" both don't rerun on match
+            else:
+                stale_ids.append(algo_id)
+                # Stale checkpoints rerun unless caller explicitly
+                # opted out via force_rerun=False AND on_checkpoint_match
+                # behaviour is "skip" — the issue specifies that stale
+                # entries should rerun automatically (the whole point
+                # of the content-aware key), so we always rerun here.
+                items_to_run.append(item)
+
+        return items_to_run, matched_ids, stale_ids
 
     def _batch_save_and_checkpoint(
         self,
@@ -1494,9 +1658,16 @@ class BacktestService:
         storage_directory: str,
         checkpoint_cache: Dict,
         show_progress: bool = False,
-        session_cache: Dict = None
+        session_cache: Dict = None,
+        manifest_hashes: Optional[Dict[str, str]] = None,
     ):
-        """Save a batch of backtests and update checkpoint cache."""
+        """Save a batch of backtests and update checkpoint cache.
+
+        ``manifest_hashes`` maps ``algorithm_id`` to its content-aware
+        manifest hash for the current run. When provided, the on-disk
+        checkpoint entry for ``date_range`` is migrated from a list to
+        a dict so future runs can detect strategy/parameter changes.
+        """
         if len(backtests) == 0:
             return
 
@@ -1508,14 +1679,39 @@ class BacktestService:
         )
 
         # Update checkpoint cache
-        key = (f"{date_range.start_date.isoformat()}_"
-               f"{date_range.end_date.isoformat()}")
-        if key not in checkpoint_cache:
-            checkpoint_cache[key] = []
+        key = self._checkpoint_key_for(date_range)
+        existing = checkpoint_cache.get(key)
 
-        for backtest in backtests:
-            if backtest.algorithm_id not in checkpoint_cache[key]:
-                checkpoint_cache[key].append(backtest.algorithm_id)
+        # If we have manifest hashes, store as dict. Otherwise preserve
+        # the existing shape (legacy list) for backward compatibility.
+        if manifest_hashes:
+            if isinstance(existing, dict):
+                entry = existing
+            elif isinstance(existing, list):
+                # migrate: legacy entries have no hash
+                entry = {alg_id: None for alg_id in existing}
+            else:
+                entry = {}
+
+            for backtest in backtests:
+                algo_id = backtest.algorithm_id
+                entry[algo_id] = manifest_hashes.get(algo_id)
+            checkpoint_cache[key] = entry
+        else:
+            if isinstance(existing, dict):
+                # don't downgrade an existing dict to a list
+                entry = existing
+                for backtest in backtests:
+                    entry.setdefault(backtest.algorithm_id, None)
+                checkpoint_cache[key] = entry
+            else:
+                entry_list = list(existing) if isinstance(
+                    existing, list
+                ) else []
+                for backtest in backtests:
+                    if backtest.algorithm_id not in entry_list:
+                        entry_list.append(backtest.algorithm_id)
+                checkpoint_cache[key] = entry_list
 
         # Write checkpoint file with forced flush to disk
         checkpoint_file = os.path.join(storage_directory, "checkpoints.json")
@@ -1738,7 +1934,8 @@ class BacktestService:
         backtest_date_range: BacktestDateRange,
         backtest_storage_directory: str,
         checkpoint_cache: Dict,
-        session_cache: Dict = None
+        session_cache: Dict = None,
+        manifest_hashes: Optional[Dict[str, str]] = None,
     ) -> bool:
         """
         Save batch if buffer is full and clear memory.
@@ -1750,6 +1947,8 @@ class BacktestService:
             backtest_storage_directory: Directory to save to.
             checkpoint_cache: Checkpoint cache to update.
             session_cache: Session cache to track backtests from this run.
+            manifest_hashes: Optional mapping of algorithm_id -> hash to
+                persist content-aware checkpoints.
 
         Returns:
             True if batch was saved, False otherwise
@@ -1761,7 +1960,8 @@ class BacktestService:
                 backtest_storage_directory,
                 checkpoint_cache,
                 show_progress=False,
-                session_cache=session_cache
+                session_cache=session_cache,
+                manifest_hashes=manifest_hashes,
             )
             batch_buffer.clear()
             gc.collect()
@@ -1774,7 +1974,8 @@ class BacktestService:
         backtest_date_range: BacktestDateRange,
         backtest_storage_directory: str,
         checkpoint_cache: Dict,
-        session_cache: Dict = None
+        session_cache: Dict = None,
+        manifest_hashes: Optional[Dict[str, str]] = None,
     ):
         """
         Save any remaining backtests in the buffer.
@@ -1785,6 +1986,8 @@ class BacktestService:
             backtest_storage_directory: Directory to save to.
             checkpoint_cache: Checkpoint cache to update.
             session_cache: Session cache to track backtests from this run.
+            manifest_hashes: Optional mapping of algorithm_id -> hash to
+                persist content-aware checkpoints.
         """
         if len(batch_buffer) > 0:
             self._batch_save_and_checkpoint(
@@ -1793,7 +1996,8 @@ class BacktestService:
                 backtest_storage_directory,
                 checkpoint_cache,
                 show_progress=False,
-                session_cache=session_cache
+                session_cache=session_cache,
+                manifest_hashes=manifest_hashes,
             )
             batch_buffer.clear()
             gc.collect()
@@ -2121,6 +2325,8 @@ class BacktestService:
         ] = None,
         backtest_storage_directory: Optional[Union[str, Path]] = None,
         use_checkpoints: bool = False,
+        force_rerun: Union[bool, Literal["stale"]] = False,
+        on_checkpoint_match: Literal["skip", "rerun", "warn"] = "skip",
         batch_size: int = 50,
         checkpoint_batch_size: int = 25,
         fill_missing_data: bool = True,
@@ -2267,44 +2473,61 @@ class BacktestService:
                 ) else alg.id
                 active_algorithm_ids.append(alg_id)
 
+            # Compute content-aware manifest hashes for active algorithms.
+            manifest_hashes: Dict[str, str] = {}
+            if backtest_storage_directory is not None:
+                manifest_hashes = self._compute_manifest_hashes(
+                    active_algorithms, backtest_date_range
+                )
+
+            start_date = backtest_date_range.start_date.strftime('%Y-%m-%d')
+            end_date = backtest_date_range.end_date.strftime('%Y-%m-%d')
+
             # Only check for checkpoints if use_checkpoints is True
-            if use_checkpoints:
+            if use_checkpoints and force_rerun is not True:
                 _print_progress(
                     "Using checkpoints to "
                     "skip completed backtests ...",
                     show_progress
                 )
-                checkpointed_ids = self._get_checkpointed_from_cache(
-                    checkpoint_cache, backtest_date_range
-                )
-                missing_ids = set(active_algorithm_ids) - set(checkpointed_ids)
-                algorithms_to_run = [
-                    alg for alg in active_algorithms
-                    if (alg.algorithm_id if hasattr(
-                        alg, 'algorithm_id'
-                    ) else alg.id) in missing_ids
-                ]
+                algorithms_to_run, matched_ids, stale_ids = \
+                    self._select_items_to_rerun(
+                        active_algorithms,
+                        active_algorithm_ids,
+                        manifest_hashes,
+                        checkpoint_cache,
+                        backtest_date_range,
+                        force_rerun=force_rerun,
+                        on_checkpoint_match=on_checkpoint_match,
+                    )
 
-                # Add checkpointed IDs to session cache
+                # Add matched (skipped) ids to session cache
                 if session_cache is not None:
-                    for algo_id in checkpointed_ids:
-                        if algo_id in active_algorithm_ids:
-                            backtest_path = os.path.join(
-                                backtest_storage_directory, algo_id
-                            )
-                            session_cache["backtests"][algo_id] = backtest_path
+                    for algo_id in matched_ids:
+                        backtest_path = os.path.join(
+                            backtest_storage_directory, algo_id
+                        )
+                        session_cache["backtests"][algo_id] = backtest_path
 
-                # Count how many active algorithms are in the checkpoint
-                matched_checkpoint_count = len(
-                    set(active_algorithm_ids) & set(checkpointed_ids)
-                )
+                if stale_ids and on_checkpoint_match != "skip":
+                    logger.info(
+                        "Detected %d stale checkpoint(s) for "
+                        "%s to %s; rerunning due to content change.",
+                        len(stale_ids), start_date, end_date,
+                    )
+                if matched_ids and on_checkpoint_match == "warn":
+                    logger.info(
+                        "Skipping %d algorithms with matching checkpoint "
+                        "for %s to %s.",
+                        len(matched_ids), start_date, end_date,
+                    )
 
                 if show_progress:
                     _print_progress(
                         f"Active algorithms: {len(active_algorithm_ids)}, "
-                        f"checkpoint file has: {len(checkpointed_ids)}, "
-                        f"matched: {matched_checkpoint_count}, "
-                        f"running {len(algorithms_to_run)} new backtests",
+                        f"matched: {len(matched_ids)}, "
+                        f"stale: {len(stale_ids)}, "
+                        f"running {len(algorithms_to_run)} backtests",
                         show_progress
                     )
             else:
@@ -2469,7 +2692,8 @@ class BacktestService:
                                     backtest_date_range,
                                     backtest_storage_directory,
                                     checkpoint_cache,
-                                    session_cache
+                                    session_cache,
+                                    manifest_hashes=manifest_hashes,
                                 )
 
                         except Exception as e:
@@ -2493,7 +2717,8 @@ class BacktestService:
                         backtest_date_range,
                         backtest_storage_directory,
                         checkpoint_cache,
-                        session_cache
+                        session_cache,
+                        manifest_hashes=manifest_hashes,
                     )
 
             # Store backtests in memory when no storage directory provided

--- a/investing_algorithm_framework/infrastructure/services/backtesting/checkpoint_manifest.py
+++ b/investing_algorithm_framework/infrastructure/services/backtesting/checkpoint_manifest.py
@@ -1,0 +1,240 @@
+"""
+Content-aware checkpoint manifest hashing.
+
+The checkpoint system identifies a completed backtest by its
+``algorithm_id`` plus the backtest date range. That key cannot
+distinguish between "the same experiment ran" and "the strategy
+code or its parameters changed since the last run".
+
+This module computes a ``manifest_hash`` for a strategy + date range
+combination. Storing the hash next to each ``algorithm_id`` in
+``checkpoints.json`` lets the backtest engine automatically rerun a
+strategy whose code or parameters changed, without any user prompt.
+
+The hash fingerprints:
+
+- the strategy's instance attributes (parameters)
+- the source code of the strategy's class
+- the data sources (symbols, timeframe, type, market)
+- the backtest date range
+
+Optionally (off by default), the framework version can be mixed in.
+This is opt-in because a framework upgrade does not always invalidate
+prior backtest results.
+"""
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Attributes ignored when fingerprinting a strategy instance. These are
+# either internal state, transient runtime objects, or the algorithm_id
+# itself (which is the lookup key, not the content being hashed).
+_IGNORED_STRATEGY_ATTRS = frozenset(
+    {
+        "algorithm_id",
+        "strategy_id",
+        "decorated",
+        "context",
+        "traces",
+        "_orders",
+        "_trades",
+    }
+)
+
+
+def _safe_repr(value: Any) -> str:
+    """
+    Return a stable, JSON-friendly representation of ``value``.
+
+    Falls back to ``repr`` for objects that are not natively JSON
+    serialisable. ``repr`` is used because it is deterministic for
+    primitive types and exposes class identity for objects that don't
+    implement ``__eq__`` / ``__hash__``.
+    """
+    try:
+        return json.dumps(value, sort_keys=True, default=repr)
+    except Exception:
+        return repr(value)
+
+
+def _strategy_params_fingerprint(strategy: Any) -> Dict[str, str]:
+    """
+    Build a sorted dict of (attr_name -> stable repr) for a strategy.
+
+    Public, non-callable attributes set on the instance are included.
+    Class-level type annotations and ``_IGNORED_STRATEGY_ATTRS`` are
+    skipped.
+    """
+    fingerprint: Dict[str, str] = {}
+
+    raw_dict = getattr(strategy, "__dict__", {}) or {}
+    for name, value in raw_dict.items():
+        if name.startswith("__"):
+            continue
+        if name in _IGNORED_STRATEGY_ATTRS:
+            continue
+        if callable(value):
+            continue
+        fingerprint[name] = _safe_repr(value)
+
+    return dict(sorted(fingerprint.items()))
+
+
+def _strategy_source_fingerprint(strategy: Any) -> str:
+    """
+    Return a hash of the strategy's class source code.
+
+    Uses ``inspect.getsource`` on the class. If the source is not
+    available (e.g. classes defined in the REPL or notebooks where
+    the source can't be located), returns the qualified class name as
+    a fallback so the hash stays stable but no longer reacts to code
+    edits. A debug log is emitted in that case.
+    """
+    cls = strategy.__class__
+    try:
+        source = inspect.getsource(cls)
+    except (OSError, TypeError):
+        logger.debug(
+            "Could not read source for %s; falling back to class name "
+            "for manifest hash",
+            cls,
+        )
+        return f"<no-source>:{cls.__module__}.{cls.__qualname__}"
+
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def _data_sources_fingerprint(strategy: Any) -> List[str]:
+    """
+    Return a stable, sorted list of data-source identifiers used by
+    the strategy.
+    """
+    data_sources = getattr(strategy, "data_sources", None) or []
+    rendered = []
+    for ds in data_sources:
+        # DataSource objects are fully described by their identifier; we
+        # also include the repr in case identifier is not implemented.
+        ident = getattr(ds, "identifier", None)
+        if callable(ident):
+            try:
+                ident = ident()
+            except Exception:
+                ident = None
+        rendered.append(str(ident) if ident is not None else repr(ds))
+    return sorted(rendered)
+
+
+def _date_range_fingerprint(backtest_date_range: Any) -> str:
+    """Return a stable string for a BacktestDateRange."""
+    start = backtest_date_range.start_date.isoformat()
+    end = backtest_date_range.end_date.isoformat()
+    return f"{start}_{end}"
+
+
+def compute_strategy_manifest_hash(
+    strategy: Any,
+    backtest_date_range: Any,
+    framework_version: Optional[str] = None,
+) -> str:
+    """
+    Compute a deterministic content-aware manifest hash for a single
+    (strategy, date_range) pair.
+
+    Args:
+        strategy: A ``TradingStrategy`` instance (or anything exposing
+            ``__dict__`` and ``data_sources``).
+        backtest_date_range: A ``BacktestDateRange`` exposing
+            ``start_date`` and ``end_date``.
+        framework_version: Optional framework version to mix into the
+            hash. When ``None`` (default) the framework version is
+            excluded so framework upgrades do not invalidate
+            checkpoints.
+
+    Returns:
+        A short (16-char) hex digest. Short because checkpoints.json is
+        human-inspectable; collisions across the relevant scope (a
+        single batch of backtests for one date range) are negligible.
+    """
+    payload: Dict[str, Any] = {
+        "params": _strategy_params_fingerprint(strategy),
+        "source": _strategy_source_fingerprint(strategy),
+        "data_sources": _data_sources_fingerprint(strategy),
+        "date_range": _date_range_fingerprint(backtest_date_range),
+    }
+    if framework_version is not None:
+        payload["framework_version"] = framework_version
+
+    serialized = json.dumps(payload, sort_keys=True, default=repr)
+    digest = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def get_checkpoint_hash_for_id(
+    checkpoint_entry: Any,
+    algorithm_id: str,
+) -> Optional[str]:
+    """
+    Look up the stored manifest hash for ``algorithm_id`` in a single
+    checkpoint entry (the value stored under one date-range key).
+
+    The on-disk format for a checkpoint entry can be either:
+
+    - a list of algorithm ids (legacy format), or
+    - a dict mapping algorithm_id -> manifest_hash, or
+    - a dict mapping algorithm_id -> {"manifest_hash": "..."}
+
+    Returns:
+        - The stored hash string if present.
+        - ``None`` if the algorithm_id is checkpointed but no hash is
+          recorded (legacy entry).
+        - ``None`` if the algorithm_id is not in the entry. Callers
+          should also use ``algorithm_id_in_entry`` to disambiguate.
+    """
+    if isinstance(checkpoint_entry, dict):
+        value = checkpoint_entry.get(algorithm_id)
+        if isinstance(value, dict):
+            return value.get("manifest_hash")
+        if isinstance(value, str):
+            return value
+        return None
+    return None
+
+
+def algorithm_id_in_entry(
+    checkpoint_entry: Any,
+    algorithm_id: str,
+) -> bool:
+    """Whether ``algorithm_id`` is checkpointed in this entry."""
+    if isinstance(checkpoint_entry, dict):
+        return algorithm_id in checkpoint_entry
+    if isinstance(checkpoint_entry, list):
+        return algorithm_id in checkpoint_entry
+    return False
+
+
+def normalize_checkpoint_entry(
+    checkpoint_entry: Any,
+) -> Dict[str, Optional[str]]:
+    """
+    Convert a checkpoint entry to the canonical
+    ``{algorithm_id: manifest_hash | None}`` form.
+    """
+    if isinstance(checkpoint_entry, dict):
+        result: Dict[str, Optional[str]] = {}
+        for algo_id, value in checkpoint_entry.items():
+            if isinstance(value, dict):
+                result[algo_id] = value.get("manifest_hash")
+            elif isinstance(value, str):
+                result[algo_id] = value
+            else:
+                result[algo_id] = None
+        return result
+    if isinstance(checkpoint_entry, list):
+        return {algo_id: None for algo_id in checkpoint_entry}
+    return {}

--- a/investing_algorithm_framework/services/metrics/generate.py
+++ b/investing_algorithm_framework/services/metrics/generate.py
@@ -21,7 +21,7 @@ from .returns import get_monthly_returns, get_yearly_returns, \
     get_average_monthly_return, get_average_monthly_return_winning_months, \
     get_average_monthly_return_losing_months, get_cumulative_return, \
     get_cumulative_return_series
-from .returns import get_total_return, get_final_value, get_total_loss, \
+from .returns import get_total_return, get_final_value, \
     get_total_growth
 from .sharpe_ratio import get_sharpe_ratio, get_rolling_sharpe_ratio
 from .sortino_ratio import get_sortino_ratio
@@ -232,6 +232,11 @@ def create_backtest_metrics(
     backtest_metrics = BacktestMetrics(
         backtest_start_date=backtest_run.backtest_start_date,
         backtest_end_date=backtest_run.backtest_end_date,
+        backtest_date_range_name=(
+            backtest_run.backtest_date_range_name or ""
+        ),
+        trading_symbol=backtest_run.trading_symbol or "",
+        initial_unallocated=backtest_run.initial_unallocated or 0.0,
     )
 
     def safe_set(metric_name, func, *args, index=None):
@@ -268,11 +273,26 @@ def create_backtest_metrics(
 
     if "total_loss" in metrics or "total_loss_percentage" in metrics:
         try:
-            total_loss = get_total_loss(backtest_run.portfolio_snapshots)
+            # B1 fix (issue #511): "total_loss" is now the **gross loss**
+            # (sum of P&L of all losing trades, expressed as a non-negative
+            # magnitude) rather than the snapshot net-return clamped at
+            # zero. The latter was indistinguishable from
+            # ``total_net_gain`` whenever the period was unprofitable and
+            # always 0 otherwise. ``total_loss_percentage`` is the gross
+            # loss expressed as a fraction of the initial unallocated
+            # capital (decimal, e.g. ``0.05`` for a 5% loss magnitude).
+            gross_loss_value = get_gross_loss(backtest_run.trades)
+            initial_value = backtest_run.initial_unallocated or 0.0
+
             if "total_loss" in metrics:
-                backtest_metrics.total_loss = total_loss[0]
+                backtest_metrics.total_loss = gross_loss_value
             if "total_loss_percentage" in metrics:
-                backtest_metrics.total_loss_percentage = total_loss[1]
+                if initial_value > 0:
+                    backtest_metrics.total_loss_percentage = (
+                        gross_loss_value / initial_value
+                    )
+                else:
+                    backtest_metrics.total_loss_percentage = 0.0
         except OperationalException as e:
             logger.warning(f"total_loss failed: {e}")
 

--- a/investing_algorithm_framework/services/metrics/returns.py
+++ b/investing_algorithm_framework/services/metrics/returns.py
@@ -302,10 +302,19 @@ def get_total_loss(
     snapshots: List[PortfolioSnapshot]
 ) -> Tuple[float, float]:
     """
-    Calculate the total loss from portfolio snapshots.
+    Legacy helper — net portfolio change clamped at zero when positive.
 
-    The total loss is calculated as the percentage change in portfolio value
-    from the first snapshot to the last snapshot, only if there is a loss.
+    .. deprecated::
+        This is **not** a real loss metric. It is the net portfolio
+        return clamped to zero whenever the period was profitable, which
+        means it is identical to ``total_net_gain`` whenever the period
+        is unprofitable and ``0.0`` otherwise. It is no longer used to
+        populate ``BacktestMetrics.total_loss`` — that field now holds
+        the **gross loss** (sum of P&L of all losing trades). See issue
+        #511 (B1). This function is kept for backwards compatibility and
+        will be removed in a future release; prefer
+        :func:`get_gross_loss` from
+        ``investing_algorithm_framework.services.metrics.profit_factor``.
 
     Args:
         snapshots (List[PortfolioSnapshot]): List of portfolio snapshots.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "investing-algorithm-framework"
-version = "v8.5.0"
+version = "v8.6.0"
 description = "A framework for creating trading bots"
 authors = ["MDUYN"]
 readme = "README.md"

--- a/tests/domain/backtests/test_backtest_save.py
+++ b/tests/domain/backtests/test_backtest_save.py
@@ -6,6 +6,7 @@ save method produces the expected directory structure and files.
 
 Moved from: tests/app/reporting/test_backtest_report.py
 """
+import json
 import os
 import shutil
 from datetime import datetime, timezone
@@ -152,4 +153,158 @@ class TestBacktestSave(TestCase):
         )
         self.assertTrue(
             os.path.exists(os.path.join(backtest_run_dir, "metrics.json"))
+        )
+
+    def _make_run(self, start, end, name, total_net_gain, trades_closed,
+                  win_rate, gross_profit, gross_loss):
+        """Helper: build a BacktestRun with pre-computed metrics."""
+        date_range = BacktestDateRange(
+            start_date=start, end_date=end, name=name
+        )
+        return BacktestRun(
+            backtest_start_date=date_range.start_date,
+            backtest_end_date=date_range.end_date,
+            backtest_date_range_name=date_range.name,
+            created_at=datetime.now(tz=timezone.utc),
+            orders=[],
+            trades=[],
+            positions=[],
+            portfolio_snapshots=self._create_snapshots(),
+            trading_symbol="EUR",
+            number_of_runs=1000,
+            initial_unallocated=1000,
+            backtest_metrics=BacktestMetrics(
+                backtest_start_date=start.replace(tzinfo=None),
+                backtest_end_date=end.replace(tzinfo=None),
+                total_net_gain=total_net_gain,
+                total_net_gain_percentage=total_net_gain / 1000.0,
+                number_of_trades=trades_closed,
+                number_of_trades_closed=trades_closed,
+                win_rate=win_rate,
+                gross_profit=gross_profit,
+                gross_loss=gross_loss,
+                total_number_of_days=365,
+            ),
+        )
+
+    def test_save_multi_window_summary_aggregates_all_runs(self):
+        """Regression test for issue #511.
+
+        When saving a Backtest containing multiple BacktestRun instances
+        (e.g. a walk-forward run), `summary.json` must reflect the
+        aggregate of all runs — not just one of them. Specifically:
+        - number_of_windows == len(runs)
+        - total_net_gain == sum(per-run total_net_gain)
+        - number_of_trades_closed == sum(per-run number_of_trades_closed)
+        """
+        runs = [
+            self._make_run(
+                start=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2023, 12, 31, tzinfo=timezone.utc),
+                name="window-1",
+                total_net_gain=499.21,
+                trades_closed=56,
+                win_rate=0.393,
+                gross_profit=900.0,
+                gross_loss=-400.79,
+            ),
+            self._make_run(
+                start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 12, 31, tzinfo=timezone.utc),
+                name="window-2",
+                total_net_gain=222.75,
+                trades_closed=63,
+                win_rate=0.333,
+                gross_profit=600.0,
+                gross_loss=-377.25,
+            ),
+            self._make_run(
+                start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2025, 12, 31, tzinfo=timezone.utc),
+                name="window-3",
+                total_net_gain=-24.75,
+                trades_closed=57,
+                win_rate=0.316,
+                gross_profit=300.0,
+                gross_loss=-324.75,
+            ),
+        ]
+
+        # Simulate the buggy upstream pre-condition: backtest_summary
+        # was set from a single window only.
+        from investing_algorithm_framework.domain.backtesting \
+            .combine_backtests import generate_backtest_summary_metrics
+
+        stale_summary = generate_backtest_summary_metrics(
+            [runs[-1].backtest_metrics]
+        )
+
+        backtest = Backtest(
+            algorithm_id="alg-511",
+            backtest_runs=runs,
+            backtest_summary=stale_summary,
+            risk_free_rate=0.0,
+        )
+        backtest.save(self.output_path)
+
+        summary_path = os.path.join(self.output_path, "summary.json")
+        self.assertTrue(os.path.exists(summary_path))
+
+        with open(summary_path, "r") as f:
+            summary = json.load(f)
+
+        self.assertEqual(summary["number_of_windows"], 3)
+        self.assertAlmostEqual(
+            summary["total_net_gain"],
+            499.21 + 222.75 + -24.75,
+            places=4,
+        )
+        self.assertEqual(
+            summary["number_of_trades_closed"], 56 + 63 + 57
+        )
+        self.assertEqual(summary["number_of_profitable_windows"], 2)
+        self.assertEqual(summary["number_of_windows_with_trades"], 3)
+
+    def test_merge_rebuilds_summary_from_all_runs(self):
+        """Regression test for issue #511.
+
+        `Backtest.merge()` previously called the non-existent
+        `BacktestSummaryMetrics.add()` method, which silently produced
+        a wrong / stale summary. After merging, the summary must
+        aggregate the runs from both backtests.
+        """
+        run_a = self._make_run(
+            start=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2023, 12, 31, tzinfo=timezone.utc),
+            name="window-a",
+            total_net_gain=100.0,
+            trades_closed=10,
+            win_rate=0.5,
+            gross_profit=200.0,
+            gross_loss=-100.0,
+        )
+        run_b = self._make_run(
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 12, 31, tzinfo=timezone.utc),
+            name="window-b",
+            total_net_gain=50.0,
+            trades_closed=20,
+            win_rate=0.4,
+            gross_profit=150.0,
+            gross_loss=-100.0,
+        )
+
+        bt_a = Backtest(algorithm_id="alg-511", backtest_runs=[run_a])
+        bt_b = Backtest(algorithm_id="alg-511", backtest_runs=[run_b])
+
+        merged = bt_a.merge(bt_b)
+
+        self.assertEqual(len(merged.backtest_runs), 2)
+        self.assertIsNotNone(merged.backtest_summary)
+        self.assertEqual(merged.backtest_summary.number_of_windows, 2)
+        self.assertAlmostEqual(
+            merged.backtest_summary.total_net_gain, 150.0, places=4
+        )
+        self.assertEqual(
+            merged.backtest_summary.number_of_trades_closed, 30
         )

--- a/tests/domain/models/backtesting/test_combine.py
+++ b/tests/domain/models/backtesting/test_combine.py
@@ -27,10 +27,13 @@ class TestCombine(TestCase):
             backtest_end_date=datetime(2020, 12, 31),
             equity_curve=[(1000, datetime(2020, 1, 1)),
                           (1500, datetime(2020, 12, 31))],
+            initial_unallocated=1000,
             total_growth=500,
             total_growth_percentage=50.0,
             total_net_gain=500,
             total_net_gain_percentage=50.0,
+            total_loss=200,
+            total_loss_percentage=0.2,
             final_value=1500.0,
             cagr=0.1,
             sharpe_ratio=1.2,
@@ -39,7 +42,7 @@ class TestCombine(TestCase):
             calmar_ratio=0.8,
             profit_factor=1.5,
             gross_profit=700,
-            gross_loss=-200,
+            gross_loss=200,
             annual_volatility=0.15,
             monthly_returns=[],
             yearly_returns=[],
@@ -89,10 +92,13 @@ class TestCombine(TestCase):
             backtest_end_date=datetime(2021, 12, 31),
             equity_curve=[(2000, datetime(2021, 1, 1)),
                           (1800, datetime(2021, 12, 31))],
+            initial_unallocated=2000,
             total_growth=-200,
             total_growth_percentage=-10.0,
             total_net_gain=-200,
             total_net_gain_percentage=-10.0,
+            total_loss=500,
+            total_loss_percentage=0.25,
             final_value=1800.0,
             cagr=-0.05,
             sharpe_ratio=-0.5,
@@ -101,7 +107,7 @@ class TestCombine(TestCase):
             calmar_ratio=-0.3,
             profit_factor=0.7,
             gross_profit=300,
-            gross_loss=-500,
+            gross_loss=500,
             annual_volatility=0.25,
             monthly_returns=[],
             yearly_returns=[],
@@ -151,7 +157,13 @@ class TestCombine(TestCase):
         # --- Assertions ---
         # Sum metrics
         self.assertEqual(summary.total_net_gain, 300)  # 500 + (-200)
-        self.assertEqual(summary.total_loss, -700)  # -200 + -500
+        # B1/B2 fix (#511): total_loss is the gross loss magnitude
+        # summed across windows.
+        self.assertEqual(summary.total_loss, 700)  # 200 + 500
+        # total_loss_percentage = sum(gross_loss) / sum(initial)
+        self.assertAlmostEqual(
+            summary.total_loss_percentage, 700 / 3000, places=4
+        )
         self.assertEqual(summary.number_of_trades, 30)  # 10 + 20
 
         # Mean metrics

--- a/tests/domain/models/backtesting/test_generate_backtest_summary_metrics.py
+++ b/tests/domain/models/backtesting/test_generate_backtest_summary_metrics.py
@@ -20,12 +20,14 @@ from investing_algorithm_framework.domain.backtesting.combine_backtests import (
 
 def create_mock_backtest_metrics(
     total_net_gain=100.0,
-    total_net_gain_percentage=10.0,
-    gross_loss=-50.0,
-    total_loss_percentage=-5.0,
+    total_net_gain_percentage=0.10,
+    total_loss=50.0,
+    gross_loss=50.0,
+    total_loss_percentage=0.05,
     total_growth=100.0,
-    total_growth_percentage=10.0,
+    total_growth_percentage=0.10,
     gross_profit=150.0,
+    initial_unallocated=1000.0,
     cagr=0.12,
     sharpe_ratio=1.5,
     sortino_ratio=2.0,
@@ -55,11 +57,13 @@ def create_mock_backtest_metrics(
     metrics = MagicMock()
     metrics.total_net_gain = total_net_gain
     metrics.total_net_gain_percentage = total_net_gain_percentage
+    metrics.total_loss = total_loss
     metrics.gross_loss = gross_loss
     metrics.total_loss_percentage = total_loss_percentage
     metrics.total_growth = total_growth
     metrics.total_growth_percentage = total_growth_percentage
     metrics.gross_profit = gross_profit
+    metrics.initial_unallocated = initial_unallocated
     metrics.cagr = cagr
     metrics.sharpe_ratio = sharpe_ratio
     metrics.sortino_ratio = sortino_ratio
@@ -184,57 +188,62 @@ class TestSafeWeightedMean(unittest.TestCase):
 
 
 class TestCompoundPercentageReturns(unittest.TestCase):
-    """Tests for _compound_percentage_returns helper function."""
+    """Tests for _compound_percentage_returns helper function.
+
+    The framework uses **decimal** percentages (e.g. ``0.10`` for 10%),
+    so all inputs and outputs of this helper are decimals. See issue
+    #511 (B5).
+    """
 
     def test_basic_compounding(self):
         """Test basic percentage compounding."""
         # 10% followed by 5%
         # (1 + 0.10) * (1 + 0.05) - 1 = 1.155 - 1 = 0.155 = 15.5%
-        percentages = [10, 5]
+        percentages = [0.10, 0.05]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, 15.5, places=5)
+        self.assertAlmostEqual(result, 0.155, places=5)
 
     def test_simple_compounding_not_addition(self):
         """Verify compounding is used, not simple addition."""
-        # If using addition: 10 + 10 = 20%
-        # If using compounding: (1.1) * (1.1) - 1 = 0.21 = 21%
-        percentages = [10, 10]
+        # If using addition: 0.10 + 0.10 = 0.20
+        # If using compounding: (1.1) * (1.1) - 1 = 0.21
+        percentages = [0.10, 0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        # Should be 21%, not 20%
-        self.assertAlmostEqual(result, 21.0, places=5)
+        # Should be 0.21, not 0.20
+        self.assertAlmostEqual(result, 0.21, places=5)
 
     def test_negative_returns(self):
         """Test compounding with negative returns."""
         # -10% followed by -10%
-        # (1 - 0.10) * (1 - 0.10) - 1 = 0.81 - 1 = -0.19 = -19%
-        percentages = [-10, -10]
+        # (1 - 0.10) * (1 - 0.10) - 1 = 0.81 - 1 = -0.19
+        percentages = [-0.10, -0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, -19.0, places=5)
+        self.assertAlmostEqual(result, -0.19, places=5)
 
     def test_mixed_positive_negative(self):
         """Test compounding with mixed positive and negative returns."""
         # +20% followed by -10%
-        # (1 + 0.20) * (1 - 0.10) - 1 = 1.2 * 0.9 - 1 = 1.08 - 1 = 0.08 = 8%
-        percentages = [20, -10]
+        # (1 + 0.20) * (1 - 0.10) - 1 = 1.2 * 0.9 - 1 = 0.08
+        percentages = [0.20, -0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, 8.0, places=5)
+        self.assertAlmostEqual(result, 0.08, places=5)
 
     def test_ignores_none(self):
         """Test that None values are ignored."""
-        percentages = [10, None, 10]
+        percentages = [0.10, None, 0.10]
 
         result = _compound_percentage_returns(percentages)
 
-        # Only 10% and 10%: 21%
-        self.assertAlmostEqual(result, 21.0, places=5)
+        # Only 0.10 and 0.10: 0.21
+        self.assertAlmostEqual(result, 0.21, places=5)
 
     def test_empty_list(self):
         """Test with empty list."""
@@ -249,27 +258,27 @@ class TestCompoundPercentageReturns(unittest.TestCase):
 
     def test_single_return(self):
         """Test with single return."""
-        percentages = [15]
+        percentages = [0.15]
 
         result = _compound_percentage_returns(percentages)
 
-        self.assertAlmostEqual(result, 15.0, places=5)
+        self.assertAlmostEqual(result, 0.15, places=5)
 
     def test_zero_returns(self):
         """Test with zero returns."""
         # 0% doesn't change the total
-        percentages = [10, 0, 5]
+        percentages = [0.10, 0, 0.05]
 
         result = _compound_percentage_returns(percentages)
 
-        # (1.1) * (1.0) * (1.05) - 1 = 1.155 - 1 = 15.5%
-        self.assertAlmostEqual(result, 15.5, places=5)
+        # (1.1) * (1.0) * (1.05) - 1 = 0.155
+        self.assertAlmostEqual(result, 0.155, places=5)
 
     def test_large_loss_recovery(self):
         """Test recovery from large loss."""
         # -50% followed by +100% = back to even
-        # (1 - 0.5) * (1 + 1.0) - 1 = 0.5 * 2 - 1 = 0%
-        percentages = [-50, 100]
+        # (1 - 0.5) * (1 + 1.0) - 1 = 0.5 * 2 - 1 = 0
+        percentages = [-0.5, 1.0]
 
         result = _compound_percentage_returns(percentages)
 
@@ -358,24 +367,28 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
 
     def test_percentage_returns_compounded(self):
         """Test that percentage returns are compounded, not summed."""
-        # Period 1: 10%, Period 2: 10%
-        # Compounded: (1.1 * 1.1) - 1 = 21%, NOT 20%
-        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=10)
-        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=10)
+        # Period 1: 10%, Period 2: 10% (decimals: 0.10)
+        # Compounded: (1.1 * 1.1) - 1 = 0.21 (21%), NOT 0.20
+        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
+        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
 
         result = generate_backtest_summary_metrics([metrics1, metrics2])
 
-        self.assertAlmostEqual(result.total_net_gain_percentage, 21.0, places=3)
+        self.assertAlmostEqual(
+            result.total_net_gain_percentage, 0.21, places=4
+        )
 
     def test_growth_percentage_compounded(self):
         """Test that growth percentage is compounded."""
-        metrics1 = create_mock_backtest_metrics(total_growth_percentage=20)
-        metrics2 = create_mock_backtest_metrics(total_growth_percentage=10)
+        metrics1 = create_mock_backtest_metrics(total_growth_percentage=0.20)
+        metrics2 = create_mock_backtest_metrics(total_growth_percentage=0.10)
 
         result = generate_backtest_summary_metrics([metrics1, metrics2])
 
-        # (1.2 * 1.1) - 1 = 32%
-        self.assertAlmostEqual(result.total_growth_percentage, 32.0, places=3)
+        # (1.2 * 1.1) - 1 = 0.32
+        self.assertAlmostEqual(
+            result.total_growth_percentage, 0.32, places=4
+        )
 
     # ==========================================================
     # Risk-Adjusted Ratios (Weighted by Time)
@@ -562,7 +575,7 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
         """Test combining two equal-length periods."""
         metrics1 = create_mock_backtest_metrics(
             total_net_gain=1000,
-            total_net_gain_percentage=10,
+            total_net_gain_percentage=0.10,
             sharpe_ratio=1.5,
             max_drawdown=-0.15,
             number_of_trades=20,
@@ -572,7 +585,7 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
         )
         metrics2 = create_mock_backtest_metrics(
             total_net_gain=500,
-            total_net_gain_percentage=5,
+            total_net_gain_percentage=0.05,
             sharpe_ratio=1.0,
             max_drawdown=-0.10,
             number_of_trades=10,
@@ -589,8 +602,10 @@ class TestGenerateBacktestSummaryMetrics(unittest.TestCase):
         self.assertEqual(result.number_of_trades_closed, 26)
 
         # Verify compounded percentage
-        # (1.10 * 1.05) - 1 = 15.5%
-        self.assertAlmostEqual(result.total_net_gain_percentage, 15.5, places=3)
+        # (1.10 * 1.05) - 1 = 0.155
+        self.assertAlmostEqual(
+            result.total_net_gain_percentage, 0.155, places=4
+        )
 
         # Verify weighted Sharpe (equal time weights)
         self.assertAlmostEqual(result.sharpe_ratio, 1.25, places=5)
@@ -636,15 +651,17 @@ class TestGenerateBacktestSummaryMetricsCalculationValidity(unittest.TestCase):
         Example: Start with $1000
         - Period 1: +10% -> $1100
         - Period 2: +10% -> $1210
-        Total return: ($1210 - $1000) / $1000 = 21%, NOT 20%
+        Total return: ($1210 - $1000) / $1000 = 0.21 (21%), NOT 0.20
         """
-        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=10)
-        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=10)
+        metrics1 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
+        metrics2 = create_mock_backtest_metrics(total_net_gain_percentage=0.10)
 
         result = generate_backtest_summary_metrics([metrics1, metrics2])
 
-        # Compound return should be 21%
-        self.assertAlmostEqual(result.total_net_gain_percentage, 21.0, places=3)
+        # Compound return should be 0.21 (21%)
+        self.assertAlmostEqual(
+            result.total_net_gain_percentage, 0.21, places=4
+        )
 
     def test_weighted_average_makes_sense_for_ratios(self):
         """
@@ -746,4 +763,3 @@ class TestGenerateBacktestSummaryMetricsCalculationValidity(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/infrastructure/data_providers/test_warmup_window_propagation.py
+++ b/tests/infrastructure/data_providers/test_warmup_window_propagation.py
@@ -1,0 +1,88 @@
+"""Regression tests for issue #379.
+
+Ensures `DataSource.warmup_window` propagates to the CCXT
+(and other OHLCV) data providers as `window_size`, including
+backward-compatibility with the deprecated `window_size=` alias on
+``DataSource``.
+"""
+import warnings
+from unittest import TestCase
+
+from investing_algorithm_framework.domain.models.data.data_source import \
+    DataSource
+from investing_algorithm_framework.infrastructure.data_providers.ccxt import (
+    CCXTOHLCVDataProvider,
+)
+
+
+class TestWarmupWindowPropagation(TestCase):
+    """Regression tests for #379."""
+
+    def _data_source(self, **kwargs) -> DataSource:
+        defaults = dict(
+            symbol="BTC/EUR",
+            data_type="ohlcv",
+            market="BITVAVO",
+            time_frame="1h",
+        )
+        defaults.update(kwargs)
+        return DataSource(**defaults)
+
+    def test_warmup_window_propagates_to_ccxt_provider(self):
+        """warmup_window on the DataSource ends up as window_size on
+        the copied CCXT data provider (#379)."""
+        data_source = self._data_source(warmup_window=200)
+
+        provider = CCXTOHLCVDataProvider().copy(data_source)
+
+        self.assertEqual(provider.window_size, 200)
+
+    def test_legacy_window_size_alias_still_propagates(self):
+        """The deprecated DataSource(window_size=...) alias still
+        propagates to the CCXT provider, while emitting a
+        DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            data_source = self._data_source(window_size=150)
+
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning) for w in caught),
+            "Using DataSource(window_size=...) should emit "
+            "a DeprecationWarning",
+        )
+
+        provider = CCXTOHLCVDataProvider().copy(data_source)
+
+        self.assertEqual(provider.window_size, 150)
+
+    def test_warmup_window_takes_precedence_over_legacy_alias(self):
+        """If both warmup_window and the deprecated window_size are set,
+        warmup_window wins on both the DataSource and the provider."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            data_source = self._data_source(
+                warmup_window=300, window_size=100
+            )
+
+        self.assertEqual(data_source.warmup_window, 300)
+        self.assertEqual(data_source.window_size, 300)
+
+        provider = CCXTOHLCVDataProvider().copy(data_source)
+        self.assertEqual(provider.window_size, 300)
+
+    def test_no_warmup_window_set_yields_none(self):
+        """When neither warmup_window nor window_size is set on the
+        DataSource, the provider's window_size is None."""
+        data_source = self._data_source()
+
+        provider = CCXTOHLCVDataProvider().copy(data_source)
+
+        self.assertIsNone(provider.window_size)
+
+    def test_data_source_post_init_syncs_warmup_to_window_size(self):
+        """DataSource exposes both attributes in sync for backward
+        compatibility (consumers reading either still work)."""
+        data_source = self._data_source(warmup_window=250)
+
+        self.assertEqual(data_source.warmup_window, 250)
+        self.assertEqual(data_source.window_size, 250)

--- a/tests/infrastructure/services/test_content_aware_checkpoints.py
+++ b/tests/infrastructure/services/test_content_aware_checkpoints.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for content-aware checkpoint manifest hashing and the
+checkpoint helpers on BacktestService (issue #276).
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from investing_algorithm_framework import BacktestDateRange
+from investing_algorithm_framework.infrastructure import BacktestService
+from investing_algorithm_framework.infrastructure.services.backtesting\
+    .checkpoint_manifest import (
+    algorithm_id_in_entry,
+    compute_strategy_manifest_hash,
+    get_checkpoint_hash_for_id,
+    normalize_checkpoint_entry,
+)
+
+
+class _FakeStrategy:
+    """Minimal stand-in for a TradingStrategy used by the manifest hasher."""
+
+    def __init__(self, algorithm_id, params=None, data_sources=None):
+        self.algorithm_id = algorithm_id
+        self.data_sources = list(data_sources or [])
+        if params:
+            for k, v in params.items():
+                setattr(self, k, v)
+
+
+def _make_service():
+    return BacktestService(
+        data_provider_service=MagicMock(),
+        order_service=MagicMock(),
+        portfolio_service=MagicMock(),
+        portfolio_snapshot_service=MagicMock(),
+        position_repository=MagicMock(),
+        trade_service=MagicMock(),
+        configuration_service=MagicMock(),
+        portfolio_configuration_service=MagicMock(),
+    )
+
+
+def _date_range():
+    end = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    start = end - timedelta(days=30)
+    return BacktestDateRange(start_date=start, end_date=end)
+
+
+class TestManifestHash(unittest.TestCase):
+
+    def test_hash_is_deterministic(self):
+        s = _FakeStrategy("abc", params={"rsi_period": 14, "ema": 200})
+        dr = _date_range()
+        h1 = compute_strategy_manifest_hash(s, dr)
+        h2 = compute_strategy_manifest_hash(s, dr)
+        self.assertEqual(h1, h2)
+        self.assertEqual(len(h1), 16)
+
+    def test_hash_changes_when_param_changes(self):
+        dr = _date_range()
+        s1 = _FakeStrategy("abc", params={"rsi_period": 14})
+        s2 = _FakeStrategy("abc", params={"rsi_period": 21})
+        self.assertNotEqual(
+            compute_strategy_manifest_hash(s1, dr),
+            compute_strategy_manifest_hash(s2, dr),
+        )
+
+    def test_hash_changes_when_date_range_changes(self):
+        s = _FakeStrategy("abc", params={"rsi_period": 14})
+        end = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        dr1 = BacktestDateRange(
+            start_date=end - timedelta(days=30), end_date=end
+        )
+        dr2 = BacktestDateRange(
+            start_date=end - timedelta(days=60), end_date=end
+        )
+        self.assertNotEqual(
+            compute_strategy_manifest_hash(s, dr1),
+            compute_strategy_manifest_hash(s, dr2),
+        )
+
+    def test_hash_ignores_algorithm_id(self):
+        dr = _date_range()
+        s1 = _FakeStrategy("abc", params={"rsi_period": 14})
+        s2 = _FakeStrategy("xyz", params={"rsi_period": 14})
+        # Same code (same class), same params, same date range,
+        # different algorithm_id -> hash must match (algorithm_id is
+        # the lookup key, not part of the content fingerprint).
+        self.assertEqual(
+            compute_strategy_manifest_hash(s1, dr),
+            compute_strategy_manifest_hash(s2, dr),
+        )
+
+
+class TestNormalizeCheckpointEntry(unittest.TestCase):
+
+    def test_legacy_list_entry(self):
+        result = normalize_checkpoint_entry(["a", "b"])
+        self.assertEqual(result, {"a": None, "b": None})
+
+    def test_dict_entry_with_string_hash(self):
+        result = normalize_checkpoint_entry({"a": "deadbeef", "b": None})
+        self.assertEqual(result, {"a": "deadbeef", "b": None})
+
+    def test_dict_entry_with_nested_dict(self):
+        result = normalize_checkpoint_entry(
+            {"a": {"manifest_hash": "deadbeef"}}
+        )
+        self.assertEqual(result, {"a": "deadbeef"})
+
+    def test_unknown_shape_returns_empty(self):
+        self.assertEqual(normalize_checkpoint_entry(None), {})
+        self.assertEqual(normalize_checkpoint_entry("oops"), {})
+
+
+class TestEntryHelpers(unittest.TestCase):
+
+    def test_get_checkpoint_hash_for_id_legacy(self):
+        self.assertIsNone(get_checkpoint_hash_for_id(["a"], "a"))
+
+    def test_get_checkpoint_hash_for_id_dict(self):
+        self.assertEqual(
+            get_checkpoint_hash_for_id({"a": "h1"}, "a"), "h1"
+        )
+
+    def test_algorithm_id_in_entry(self):
+        self.assertTrue(algorithm_id_in_entry(["a", "b"], "a"))
+        self.assertTrue(algorithm_id_in_entry({"a": "h"}, "a"))
+        self.assertFalse(algorithm_id_in_entry(["a"], "b"))
+
+
+class TestSelectItemsToRerun(unittest.TestCase):
+
+    def setUp(self):
+        self.dr = _date_range()
+        self.key = BacktestService._checkpoint_key_for(self.dr)
+        self.s_a = _FakeStrategy("a")
+        self.s_b = _FakeStrategy("b")
+        self.s_c = _FakeStrategy("c")
+
+    def test_no_checkpoints_runs_everything(self):
+        items, matched, stale = BacktestService._select_items_to_rerun(
+            [self.s_a, self.s_b],
+            ["a", "b"],
+            {"a": "h_a", "b": "h_b"},
+            checkpoint_cache={},
+            date_range=self.dr,
+        )
+        self.assertEqual(len(items), 2)
+        self.assertEqual(matched, [])
+        self.assertEqual(stale, [])
+
+    def test_matching_hash_skips(self):
+        cache = {self.key: {"a": "h_a"}}
+        items, matched, stale = BacktestService._select_items_to_rerun(
+            [self.s_a, self.s_b],
+            ["a", "b"],
+            {"a": "h_a", "b": "h_b"},
+            checkpoint_cache=cache,
+            date_range=self.dr,
+        )
+        # 'a' is matched and skipped; 'b' has no checkpoint, runs
+        self.assertEqual([s.algorithm_id for s in items], ["b"])
+        self.assertEqual(matched, ["a"])
+        self.assertEqual(stale, [])
+
+    def test_stale_hash_reruns(self):
+        cache = {self.key: {"a": "stale_hash"}}
+        items, matched, stale = BacktestService._select_items_to_rerun(
+            [self.s_a],
+            ["a"],
+            {"a": "h_a"},
+            checkpoint_cache=cache,
+            date_range=self.dr,
+        )
+        self.assertEqual([s.algorithm_id for s in items], ["a"])
+        self.assertEqual(matched, [])
+        self.assertEqual(stale, ["a"])
+
+    def test_legacy_list_treated_as_match(self):
+        # Legacy entries (no hash recorded) preserve the old "skip on
+        # algorithm_id match" behaviour.
+        cache = {self.key: ["a"]}
+        items, matched, stale = BacktestService._select_items_to_rerun(
+            [self.s_a, self.s_b],
+            ["a", "b"],
+            {"a": "h_a", "b": "h_b"},
+            checkpoint_cache=cache,
+            date_range=self.dr,
+        )
+        self.assertEqual([s.algorithm_id for s in items], ["b"])
+        self.assertEqual(matched, ["a"])
+        self.assertEqual(stale, [])
+
+    def test_force_rerun_true_runs_everything(self):
+        cache = {self.key: {"a": "h_a"}}
+        items, matched, stale = BacktestService._select_items_to_rerun(
+            [self.s_a, self.s_b],
+            ["a", "b"],
+            {"a": "h_a", "b": "h_b"},
+            checkpoint_cache=cache,
+            date_range=self.dr,
+            force_rerun=True,
+        )
+        self.assertEqual(len(items), 2)
+        self.assertEqual(matched, [])
+        self.assertEqual(stale, [])
+
+    def test_on_checkpoint_match_rerun(self):
+        cache = {self.key: {"a": "h_a"}}
+        items, matched, stale = BacktestService._select_items_to_rerun(
+            [self.s_a],
+            ["a"],
+            {"a": "h_a"},
+            checkpoint_cache=cache,
+            date_range=self.dr,
+            on_checkpoint_match="rerun",
+        )
+        self.assertEqual([s.algorithm_id for s in items], ["a"])
+        self.assertEqual(matched, ["a"])
+
+    def test_get_checkpointed_from_cache_supports_dict(self):
+        service = _make_service()
+        cache = {self.key: {"a": "h_a", "b": None}}
+        ids = service._get_checkpointed_from_cache(cache, self.dr)
+        self.assertEqual(sorted(ids), ["a", "b"])
+
+    def test_get_checkpointed_from_cache_supports_list(self):
+        service = _make_service()
+        cache = {self.key: ["a", "b"]}
+        ids = service._get_checkpointed_from_cache(cache, self.dr)
+        self.assertEqual(ids, ["a", "b"])
+
+
+class TestBatchSaveCheckpointFormat(unittest.TestCase):
+    """
+    Verify that _batch_save_and_checkpoint persists the new dict-format
+    when manifest_hashes are provided, and preserves legacy list format
+    when they are not.
+    """
+
+    def setUp(self):
+        self.dr = _date_range()
+        self.key = BacktestService._checkpoint_key_for(self.dr)
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _service(self):
+        return _make_service()
+
+    def _backtest(self, algo_id):
+        b = MagicMock()
+        b.algorithm_id = algo_id
+        return b
+
+    def test_writes_dict_format_with_hashes(self):
+        service = self._service()
+        # patch save_backtests_to_directory to a no-op so we don't
+        # need to materialize backtests on disk
+        import investing_algorithm_framework.infrastructure.services\
+            .backtesting.backtest_service as bt_mod
+        original = bt_mod.save_backtests_to_directory
+        bt_mod.save_backtests_to_directory = lambda **kw: None
+        try:
+            cache = {}
+            backtests = [self._backtest("a"), self._backtest("b")]
+            service._batch_save_and_checkpoint(
+                backtests=backtests,
+                date_range=self.dr,
+                storage_directory=self.tmp,
+                checkpoint_cache=cache,
+                manifest_hashes={"a": "h_a", "b": "h_b"},
+            )
+        finally:
+            bt_mod.save_backtests_to_directory = original
+
+        with open(os.path.join(self.tmp, "checkpoints.json")) as f:
+            persisted = json.load(f)
+        self.assertEqual(
+            persisted[self.key], {"a": "h_a", "b": "h_b"}
+        )
+
+    def test_migrates_legacy_list_to_dict_when_hashes_given(self):
+        service = self._service()
+        import investing_algorithm_framework.infrastructure.services\
+            .backtesting.backtest_service as bt_mod
+        original = bt_mod.save_backtests_to_directory
+        bt_mod.save_backtests_to_directory = lambda **kw: None
+        try:
+            cache = {self.key: ["a"]}  # legacy entry
+            service._batch_save_and_checkpoint(
+                backtests=[self._backtest("b")],
+                date_range=self.dr,
+                storage_directory=self.tmp,
+                checkpoint_cache=cache,
+                manifest_hashes={"b": "h_b"},
+            )
+        finally:
+            bt_mod.save_backtests_to_directory = original
+
+        self.assertEqual(
+            cache[self.key], {"a": None, "b": "h_b"}
+        )
+
+    def test_preserves_legacy_list_when_no_hashes_given(self):
+        service = self._service()
+        import investing_algorithm_framework.infrastructure.services\
+            .backtesting.backtest_service as bt_mod
+        original = bt_mod.save_backtests_to_directory
+        bt_mod.save_backtests_to_directory = lambda **kw: None
+        try:
+            cache = {}
+            service._batch_save_and_checkpoint(
+                backtests=[self._backtest("a")],
+                date_range=self.dr,
+                storage_directory=self.tmp,
+                checkpoint_cache=cache,
+            )
+        finally:
+            bt_mod.save_backtests_to_directory = original
+
+        self.assertEqual(cache[self.key], ["a"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231201_20231202/metrics.json
+++ b/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231201_20231202/metrics.json
@@ -2,8 +2,8 @@
     "backtest_start_date": "2023-12-01T00:00:00+00:00",
     "backtest_end_date": "2023-12-02T00:00:00+00:00",
     "backtest_date_range_name": "",
-    "trading_symbol": "",
-    "initial_unallocated": 0.0,
+    "trading_symbol": "EUR",
+    "initial_unallocated": 1000.0,
     "equity_curve": [
         [
             1000.0,

--- a/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231202_20231203/metrics.json
+++ b/tests/resources/backtest_reports_for_testing/test_algorithm_backtest/runs/backtest_EUR_20231202_20231203/metrics.json
@@ -2,8 +2,8 @@
     "backtest_start_date": "2023-12-02T00:00:00+00:00",
     "backtest_end_date": "2023-12-03T00:00:00+00:00",
     "backtest_date_range_name": "",
-    "trading_symbol": "",
-    "initial_unallocated": 0.0,
+    "trading_symbol": "EUR",
+    "initial_unallocated": 1000.0,
     "equity_curve": [
         [
             1000.0,

--- a/tests/services/metrics/test_generate_metrics.py
+++ b/tests/services/metrics/test_generate_metrics.py
@@ -24,3 +24,38 @@ class TestGenerateMetrics(TestCase):
         backtest_metrics = create_backtest_metrics(
             backtest_run, risk_free_rate=0.024
         )
+
+    def test_total_loss_is_gross_loss_magnitude(self):
+        """Regression test for issue #511 (B1).
+
+        Per-run ``BacktestMetrics.total_loss`` must equal the gross
+        loss magnitude (``sum(abs(net_gain))`` over losing trades),
+        not the snapshot net-return clamped at zero. In particular,
+        ``total_loss`` must equal the ``gross_loss`` field, and
+        ``total_loss_percentage`` must be ``total_loss /
+        initial_unallocated`` (a non-negative decimal).
+        """
+        backtest_run = BacktestRun.open(
+            os.path.join(self.backtest_run_directory, 'backtest_run_one')
+        )
+        metrics = create_backtest_metrics(
+            backtest_run, risk_free_rate=0.024
+        )
+
+        # total_loss is a non-negative magnitude.
+        self.assertIsNotNone(metrics.total_loss)
+        self.assertGreaterEqual(metrics.total_loss, 0.0)
+
+        # total_loss equals gross_loss (same definition).
+        self.assertAlmostEqual(
+            metrics.total_loss, metrics.gross_loss or 0.0, places=6
+        )
+
+        # total_loss_percentage is non-negative and consistent with
+        # total_loss / initial_unallocated.
+        if backtest_run.initial_unallocated:
+            expected_pct = metrics.total_loss / backtest_run.initial_unallocated
+            self.assertAlmostEqual(
+                metrics.total_loss_percentage, expected_pct, places=6
+            )
+            self.assertGreaterEqual(metrics.total_loss_percentage, 0.0)


### PR DESCRIPTION
Release `dev` → `main`.

Changes since the previous `main` release:

### Bug fixes
- **fix(backtesting): aggregate `summary.json` across all walk-forward runs (#511, #512)** — `Backtest.save()` and `Backtest.merge()` now always rebuild `backtest_summary` from the current `backtest_runs` instead of writing whatever single-window summary happened to be assigned. Also fixes B1–B5 in the issue: gross-loss semantics for `total_loss` / `total_loss_percentage`, decimal-percentage convention in `_compound_percentage_returns`, and propagation of `trading_symbol` / `initial_unallocated` / `backtest_date_range_name` through `create_backtest_metrics`.
- **fix(#379): make `warmup_window` canonical and add regression tests (#500)**.

### Features
- **feat(backtest): make checkpoints content-aware + add `force_rerun` (#276, #498)**.

### Docs
- **docs(#438): add Pipeline API design doc (#504)**, including a split of the backtesting page into overview + event-driven subpage and content-aware checkpoint / `force_rerun` documentation.

### Chores / CI
- chore: bump version to v8.6.0.
- ci: drop redundant deadsnakes distutils step.
