### PR TITLE
Docs: metrics reference + CLI scaffold + Azure deploy fixes + dependabot patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,23 @@ This framework is built around the full loop: **create strategies → vector bac
  Features
 </summary> <br>
 
-- 📊 **30+ Metrics** — CAGR, Sharpe, Sortino, Calmar, VaR, CVaR, Max DD, Recovery & more
+- 📊 **[30+ Metrics](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/metrics)** — CAGR, Sharpe, Sortino, Calmar, VaR, CVaR, Max DD, Recovery & more
 - 🧮 **[Cross-Sectional Pipelines](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/pipelines)** — Rank, filter and score entire universes of symbols every iteration with a tidy factor table
-- ⚡ **Vector Backtesting for Signal Analysis** — Quickly test your strategy logic on historical data to see how signals would have behaved before committing to full event-driven backtests
-- 🏃 **Event-Driven Backtesting** — Once promising strategies are identified via vector backtests, run full event-driven backtests to simulate realistic execution and portfolio management
-- 🔀 **Permutation Testing / Monte Carlo Simulations** — Assess the statistical robustness of your strategies by running them across randomized market scenarios to see how often your results could occur by chance
-- 🚀 **Deployment** — Once the best strategy is identified through backtesting and comparison, deploy it to production locally or in the cloud (AWS Lambda / Azure Functions) to start live trading
-- ⚔️ **Multi-Strategy Comparison** — Rank, filter & compare strategies in a single interactive report
-- 🪟 **Multi-Window Robustness** — Test across different time periods with window coverage analysis
-- 📈 **Equity & Drawdown Charts** — Overlay equity curves, rolling Sharpe, drawdown & return distributions
-- 🗓️ **Monthly Heatmaps & Yearly Returns** — Calendar heatmap per strategy with return/growth toggles
-- 🎯 **Return Scenario Projections** — Good, average, bad & very bad year projections from backtest data
-- 📉 **Benchmark Comparison** — Beat-rate analysis vs Buy & Hold, DCA, risk-free & custom benchmarks
-- 📄 **One-Click HTML Report** — Self-contained file, no server, dark & light theme, shareable
-- 📦 **Custom `.iafbt` Backtest Bundle Format** — An explicit, versioned, compressed, language-portable container (zstd + msgpack with magic-byte header) plus a separate parquet index for fast filtering without loading. ~21× smaller and ~27× fewer files than standard filebased directory layouts, with parallel I/O for fast load/save of large amounts of backtests.
-- 🌐 **Load External Data** — Fetch CSV, JSON, or Parquet from any URL with caching and auto-refresh
-- � **[Record Custom Variables](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/recording-variables)** — Track any indicator or metric during backtests with `context.record()`
-- �🚀 **Build → Backtest → Deploy** — Local dev, cloud deploy (AWS / Azure), or monetize on Finterion
+- ⚡ **[Vector Backtesting for Signal Analysis](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/vector-backtesting)** — Quickly test your strategy logic on historical data to see how signals would have behaved before committing to full event-driven backtests
+- 🏃 **[Event-Driven Backtesting](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/event-backtesting)** — Once promising strategies are identified via vector backtests, run full event-driven backtests to simulate realistic execution and portfolio management
+- 🔀 **[Permutation Testing / Monte Carlo Simulations](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Assess the statistical robustness of your strategies by running them across randomized market scenarios to see how often your results could occur by chance
+- 🚀 **[Deployment](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/deployment)** — Once the best strategy is identified through backtesting and comparison, deploy it to production locally or in the cloud (AWS Lambda / Azure Functions) to start live trading
+- ⚔️ **[Multi-Strategy Comparison](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Rank, filter & compare strategies in a single interactive report
+- 🪟 **[Multi-Window Robustness](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Test across different time periods with window coverage analysis
+- 📈 **[Equity & Drawdown Charts](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Overlay equity curves, rolling Sharpe, drawdown & return distributions
+- 🗓️ **[Monthly Heatmaps & Yearly Returns](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Calendar heatmap per strategy with return/growth toggles
+- 🎯 **[Return Scenario Projections](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Good, average, bad & very bad year projections from backtest data
+- 📉 **[Benchmark Comparison](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Beat-rate analysis vs Buy & Hold, DCA, risk-free & custom benchmarks
+- 📄 **[One-Click HTML Report](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Self-contained file, no server, dark & light theme, shareable
+- 📦 **[Custom `.iafbt` Backtest Bundle Format](https://coding-kitties.github.io/investing-algorithm-framework/Data/backtest_data)** — An explicit, versioned, compressed, language-portable container (zstd + msgpack with magic-byte header) plus a separate parquet index for fast filtering without loading. ~21× smaller and ~27× fewer files than standard filebased directory layouts, with parallel I/O for fast load/save of large amounts of backtests.
+- 🌐 **[Load External Data](https://coding-kitties.github.io/investing-algorithm-framework/Data/external-data)** — Fetch CSV, JSON, or Parquet from any URL with caching and auto-refresh
+- 📝 **[Record Custom Variables](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/recording-variables)** — Track any indicator or metric during backtests with `context.record()`
+- 🚀 **[Build → Backtest → Deploy](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/application-setup)** — Local dev, cloud deploy (AWS / Azure), or monetize on Finterion
 
 </details>
 

--- a/docusaurus/docs/Getting Started/application-setup.md
+++ b/docusaurus/docs/Getting Started/application-setup.md
@@ -4,125 +4,256 @@ sidebar_position: 2
 
 # Application Setup
 
-Learn how to set up your first trading application using the Investing Algorithm Framework.
+A real trading project usually has three concerns that pull in different
+directions:
 
-## Creating Your First App
+1. **Research**: exploring data, designing strategies and tuning parameters
+   in Jupyter notebooks.
+2. **Backtesting**: running reproducible historical simulations from a
+   script.
+3. **Production**: running the strategy live, deployed somewhere stable, with
+   secrets, logging and a single entry point.
 
-The framework provides a simple `create_app()` function to initialize your trading application:
+The Investing Algorithm Framework is designed to support all three from the
+**same** strategy code. To make that work, we recommend the following
+project layout for any non-trivial bot.
 
-```python
-from investing_algorithm_framework import create_app
+## Recommended Project Structure
 
-app = create_app()
+```text
+my_trading_bot/
+├── app.py                  # Production entry point (live trading)
+├── strategies/             # Strategy implementations (importable package)
+│   ├── __init__.py
+│   └── my_strategy.py
+├── data_providers.py       # Custom data providers for your dataSource definitions in your strategies (OPTIONAL)
+├── notebooks/              # Research notebooks and backtest analyses
+│   ├── 01_data_exploration.ipynb
+│   ├── 02_backtest_baseline.ipynb
+│   ├── 03_in_sample_param_grid_search.ipynb
+│   ├── 04_out_of_sample_param_grid_search.ipynb
+│   ├── 05_overfitting_analysis.ipynb
+│   └── 06_event_backtests.ipynb
+├── data/                   # Downloaded market data (OHLCV, etc.)
+├── backtest_results/       # Saved backtest bundles (.iafbt)
+├── reports/                # Generated reports (HTML, CSV, etc.)
+├── resources/              # Misc assets (databases, configs)
+├── requirements.txt
+├── .env.example
+└── README.md
 ```
 
-## Adding a Market
+A working example of this layout lives in
+[`examples/tutorial`](https://github.com/coding-kitties/investing-algorithm-framework/tree/main/examples/tutorial).
 
-Before you can trade, you need to add a market configuration:
+You can scaffold this structure with the framework's CLI:
+
+```bash
+investing-algorithm-framework init --path ./my_trading_bot
+```
+
+This creates the above files and folders, with `app.py` and a sample strategy
+that you can modify. The `notebooks/` folder is left empty for you to fill with your research work.
+
+### Why this layout?
+
+- **`strategies/` is a package, not a script.** Both `app.py` (production)
+  and `notebooks` import the same strategy class, so
+  what you backtest is *exactly* what you deploy.
+- **`notebooks/` is for exploration and backtesting only.** Notebooks should `import`
+  from `strategies/` and `data_providers.py` — never copy-paste strategy
+  code into a cell. This keeps research and production in sync.
+- **`data/` and `backtest_results/` are caches.** They should usually
+  be in `.gitignore`. The framework writes data downloads to `data/`
+  and backtest bundles to `backtest_results/`.
+- **`app.py` does only what production needs** — load config, register
+  the market and strategy, call `app.run()`. Nothing else.
+
+## The Strategy (`strategies/my_strategy.py`)
+
+This is the only file that contains your trading logic. It is imported
+by `app.py`, `run_backtest.py` and your notebooks alike.
+
+A strategy is **declarative**: you describe *what data you need* and *when
+to buy or sell*, and the framework takes care of order routing, position
+sizing, stop-losses and take-profits. The two functions you implement are
+`generate_buy_signals` and `generate_sell_signals` — both return a
+boolean `pd.Series` per symbol.
 
 ```python
-app.add_market(
-    market="bitvavo",
-    trading_symbol="EUR",
+from typing import Any, Dict
+
+import pandas as pd
+from pyindicators import sma, crossover, crossunder
+
+from investing_algorithm_framework import (
+    TradingStrategy,
+    DataSource,
+    DataType,
+    TimeUnit,
 )
-```
 
-## Adding a Strategy
-
-Register your trading strategy with the application:
-
-```python
-from investing_algorithm_framework import TradingStrategy, TimeUnit
 
 class MyStrategy(TradingStrategy):
     time_unit = TimeUnit.HOUR
     interval = 2
     symbols = ["BTC"]
-    
-    def run(self, algorithm):
-        # Your trading logic here
-        pass
 
-app.add_strategy(MyStrategy())
+    data_sources = [
+        DataSource(
+            identifier="btc_ohlcv_1h",
+            data_type=DataType.OHLCV,
+            symbol="BTC/EUR",
+            time_frame="1h",
+            market="BITVAVO",
+            window_size=200,
+            pandas=True,
+        ),
+    ]
+
+    def generate_buy_signals(
+        self, data: Dict[str, Any]
+    ) -> Dict[str, pd.Series]:
+        df = data["btc_ohlcv_1h"]
+        df = sma(df, period=20, source_column="Close", result_column="sma_fast")
+        df = sma(df, period=50, source_column="Close", result_column="sma_slow")
+        df = crossover(df, "sma_fast", "sma_slow", result_column="cross_up")
+
+        return {"BTC": df["cross_up"].fillna(False).astype(bool)}
+
+    def generate_sell_signals(
+        self, data: Dict[str, Any]
+    ) -> Dict[str, pd.Series]:
+        df = data["btc_ohlcv_1h"]
+        df = sma(df, period=20, source_column="Close", result_column="sma_fast")
+        df = sma(df, period=50, source_column="Close", result_column="sma_slow")
+        df = crossunder(df, "sma_fast", "sma_slow", result_column="cross_down")
+
+        return {"BTC": df["cross_down"].fillna(False).astype(bool)}
 ```
+
+> The framework instantiates the class for you, so pass the **class**
+> (not an instance) to `app.add_strategy(...)`.
+
+The same `generate_buy_signals` / `generate_sell_signals` functions are
+used by **both** the vector backtest engine and the event-driven engine,
+which is what guarantees that what you backtest is what you deploy. For
+custom entry/exit logic that doesn't fit signals (e.g. rebalancing across
+symbols), override `run_strategy` instead see [Strategies](./strategies)
+for advanced patterns including position sizing, stop-loss, take-profit
+and scale-in rules.
+
+## The Production Entry Point (`app.py`)
+
+`app.py` is the file you run in production (locally, in a container, or as
+a serverless function). It should be small, declarative, and free of any
+research code.
+
+```python
+import logging.config
+
+from dotenv import load_dotenv
+
+from investing_algorithm_framework import create_app, DEFAULT_LOGGING_CONFIG
+
+from strategies.my_strategy import MyStrategy
+
+load_dotenv()
+logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+
+app = create_app()
+app.add_market(
+    market="bitvavo",
+    trading_symbol="EUR",
+    initial_balance=1000,
+)
+app.add_strategy(MyStrategy)
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+API keys belong in environment variables (`.env`), not in source. Use
+`.env.example` to document which variables are required.
+
+## The Backtest Entry Point (`run_backtest.py`)
+
+`run_backtest.py` mirrors `app.py` but calls `run_backtest(...)` instead
+of `run()`. Because both files import the same `MyStrategy`, the strategy
+under test is identical to the one that will run live.
+
+```python
+from datetime import datetime, timezone
+
+from investing_algorithm_framework import create_app, BacktestDateRange
+
+from strategies.my_strategy import MyStrategy
+
+app = create_app()
+app.add_market(market="bitvavo", trading_symbol="EUR")
+app.add_strategy(MyStrategy)
+
+
+if __name__ == "__main__":
+    backtest_date_range = BacktestDateRange(
+        start_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        end_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    backtest = app.run_backtest(
+        backtest_date_range=backtest_date_range,
+        initial_amount=1000,
+    )
+
+    summary = backtest.backtest_summary
+    print(f"Total return: {summary.total_growth_percentage:.2f}%")
+    print(f"Sharpe ratio: {summary.sharpe_ratio:.2f}")
+```
+
+## The Notebooks (`notebooks/`)
+
+Notebooks are for research, backtesting, data exploration, signal visualisation,
+parameter sweeps, robustness checks, final reporting. They should
+**import** strategies from your `strategies/` package rather than
+redefining them.
+
+A typical progression (mirroring `examples/tutorial/notebooks/`):
+
+| Notebook | Purpose |
+| --- | --- |
+| `01_data_exploration.ipynb` | Download OHLCV, inspect coverage, detect and fill gaps |
+| `02_backtest_baseline.ipynb` | Single vector backtest of the strategy with default parameters + HTML report |
+| `03_in_sample_param_grid_search.ipynb` | Grid search across thousands of parameter combinations on the in-sample window |
+| `04_out_of_sample_param_grid_search.ipynb` | Re-run top in-sample candidates on the held-out out-of-sample window |
+| `05_overfitting_analysis.ipynb` | Compare in-sample vs out-of-sample performance, walk-forward / permutation checks |
+| `06_event_backtests.ipynb` | Validate the final picks with the event-driven engine (fees, slippage, fills) |
+
+See the [tutorial README](https://github.com/coding-kitties/investing-algorithm-framework/tree/main/examples/tutorial)
+for fully worked-out versions.
 
 ## Running the Application
 
-### Live Trading
+### Live trading
 
-To start live trading:
-
-```python
-app.run()
+```bash
+python app.py
 ```
 
-### Backtesting
+### Research and backtesting
 
-To run a backtest:
-
-```python
-from datetime import datetime, timezone
-from investing_algorithm_framework import BacktestDateRange
-
-backtest_range = BacktestDateRange(
-    start_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-    end_date=datetime(2024, 1, 1, tzinfo=timezone.utc)
-)
-
-backtest = app.run_backtest(
-    backtest_date_range=backtest_range,
-    initial_amount=1000
-)
-```
-
-## Complete Example
-
-Here's a complete example bringing it all together:
-
-```python
-from investing_algorithm_framework import (
-    create_app, 
-    TradingStrategy, 
-    TimeUnit,
-    BacktestDateRange
-)
-from datetime import datetime, timezone
-
-# Create the application
-app = create_app()
-
-# Define your strategy
-class SimpleStrategy(TradingStrategy):
-    time_unit = TimeUnit.HOUR
-    interval = 4
-    symbols = ["BTC", "ETH"]
-    
-    def run(self, algorithm):
-        for symbol in self.symbols:
-            # Your trading logic
-            pass
-
-# Add market and strategy
-app.add_market(market="bitvavo", trading_symbol="EUR")
-app.add_strategy(SimpleStrategy())
-
-# Run backtest
-backtest_range = BacktestDateRange(
-    start_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-    end_date=datetime(2024, 1, 1, tzinfo=timezone.utc)
-)
-
-backtest = app.run_backtest(
-    backtest_date_range=backtest_range,
-    initial_amount=1000
-)
-
-print(f"Total return: {backtest.get_total_return()}%")
+```bash
+jupyter lab notebooks/
 ```
 
 ## Next Steps
 
-- Learn about [Portfolio Configuration](./portfolio-configuration) to manage your assets
-- Explore [Strategies](./strategies) for advanced strategy development
-- Check out [Backtesting](./backtesting) for comprehensive testing
-
+- [Strategies](./strategies) — designing the `run_strategy` body, declaring
+  data sources, position sizing, stop-losses and take-profits.
+- [Portfolio Configuration](./portfolio-configuration) — fees, slippage,
+  multi-market portfolios.
+- [Event Backtesting](./event-backtesting) and
+  [Vector Backtesting](./vector-backtesting) — the two backtest engines
+  and when to use which.
+- [Deployment](./deployment) — packaging `app.py` for AWS Lambda, Azure
+  Functions or a long-running container.

--- a/docusaurus/docs/Getting Started/backtest-reports.md
+++ b/docusaurus/docs/Getting Started/backtest-reports.md
@@ -84,46 +84,51 @@ report.show()
 
 ## Recalculating Metrics
 
-When metric calculations are updated in a newer framework version, previously saved backtests may have stale metrics. Use `recalculate_backtests` to recompute all per-run and summary metrics from the raw portfolio snapshots and trades:
+When metric calculations are updated in a newer framework version, previously saved backtests may have stale metrics. Use `recalculate_backtests_in_directory` to recompute all per-run and summary metrics from the raw portfolio snapshots and trades — **directly on disk**, without ever loading the full set of backtests into memory:
 
 ```python
-from investing_algorithm_framework import BacktestReport, recalculate_backtests
+from investing_algorithm_framework import recalculate_backtests_in_directory
 
-report = BacktestReport.open(directory_path="./my_backtests")
-
-# Recalculate all metrics for all backtests
-recalculate_backtests(report.backtests)
-
-report.show()
+# Rewrites every bundle in ./my_backtests in place
+recalculate_backtests_in_directory("./my_backtests")
 ```
 
-You can specify a custom risk-free rate (otherwise each backtest's stored rate is used):
+Each backtest is loaded, recalculated, and written back **inside a worker process**, so the parent process's memory footprint stays flat regardless of how many backtests are processed. This is the recommended approach for any non-trivial batch (hundreds to thousands of backtests with portfolio snapshots and trades can otherwise consume tens of GB).
+
+Write to a different directory instead of in place:
 
 ```python
-recalculate_backtests(report.backtests, risk_free_rate=0.04)
-```
-
-Or limit which metrics are recomputed:
-
-```python
-recalculate_backtests(
-    report.backtests,
-    metrics=["cagr", "sharpe_ratio", "max_drawdown", "win_rate"]
+recalculate_backtests_in_directory(
+    src_dir="./my_backtests",
+    dst_dir="./my_backtests_v2",
 )
 ```
 
-`recalculate_backtests` works on any list of `Backtest` objects, not just those loaded from disk:
+Use a custom risk-free rate (otherwise each backtest's stored rate is used):
 
 ```python
-from investing_algorithm_framework import recalculate_backtests
+recalculate_backtests_in_directory("./my_backtests", risk_free_rate=0.04)
+```
 
-backtests = [backtest_a, backtest_b, backtest_c]
-recalculate_backtests(backtests, risk_free_rate=0.027)
+Limit which metrics are recomputed, or tune parallelism:
+
+```python
+recalculate_backtests_in_directory(
+    "./my_backtests",
+    metrics=["cagr", "sharpe_ratio", "max_drawdown", "win_rate"],
+    workers=4,
+    show_progress=True,
+)
 ```
 
 For each backtest, the function:
 1. Recomputes per-run `BacktestMetrics` from raw `portfolio_snapshots` and `trades`
 2. Regenerates `BacktestSummaryMetrics` by aggregating the updated per-run metrics
+3. Writes the updated bundle back to disk and (by default) refreshes `index.parquet`
+
+:::warning Deprecated: `recalculate_backtests(List[Backtest])`
+The in-memory variant `recalculate_backtests(backtests)` is **deprecated since 8.7.2** and will be removed in a future major release. Holding many backtests in the parent process is memory-unsafe — each `Backtest` carries portfolio snapshots, trades and timeseries, so a list of a few thousand backtests can easily consume tens of GB before any work starts. Use `recalculate_backtests_in_directory(src_dir, ...)` instead.
+:::
 
 ## Saving Reports
 
@@ -191,7 +196,8 @@ Toggle between dark and light mode using the sun icon in the top-right corner.
 ```python
 from datetime import datetime, timezone
 from investing_algorithm_framework import (
-    create_app, BacktestDateRange, BacktestReport, recalculate_backtests
+    create_app, BacktestDateRange, BacktestReport,
+    recalculate_backtests_in_directory,
 )
 
 app = create_app()
@@ -211,18 +217,18 @@ date_ranges = [
     ),
 ]
 
-backtests = app.run_vector_backtests(
+app.run_vector_backtests(
     strategies=my_strategies,
     backtest_date_ranges=date_ranges,
     initial_amount=1000,
     backtest_storage_directory="./backtests"
 )
 
-# Optional: recalculate metrics with updated calculations
-recalculate_backtests(backtests, risk_free_rate=0.04)
+# Optional: recalculate metrics with updated calculations (memory-safe, on disk)
+recalculate_backtests_in_directory("./backtests", risk_free_rate=0.04)
 
 # Generate and save the comparison report
-report = BacktestReport(backtests=backtests)
+report = BacktestReport.open(directory_path="./backtests")
 report.save("comparison_report.html")
 report.show(browser=True)
 ```
@@ -239,7 +245,29 @@ report.show(browser=True)
 | `report.show(browser=False)` | Display the report. In Jupyter: renders inline. Otherwise: opens browser. Set `browser=True` to force browser. |
 | `report.save(path)` | Save the report as a self-contained HTML file |
 
-### `recalculate_backtests`
+### `recalculate_backtests_in_directory`
+
+Stream-recalculates every backtest bundle on disk inside worker processes. The full `Backtest` never crosses the process boundary, so parent memory stays flat.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `src_dir` | `str \| Path` | Directory containing `.iafbt` bundles (and/or legacy backtest directories) |
+| `dst_dir` | `str \| Path`, optional | Output directory. If `None`, bundles are rewritten in place inside `src_dir` |
+| `risk_free_rate` | `float`, optional | Override risk-free rate. If `None`, uses each backtest's stored rate |
+| `metrics` | `List[str]`, optional | Specific metrics to compute. If `None`, computes all default metrics |
+| `workers` | `int`, optional | Number of parallel worker processes. Defaults to `min(8, cpu_count)`. Pass `1` for serial |
+| `show_progress` | `bool` | Display a tqdm progress bar (default `False`) |
+| `include_ohlcv` | `bool` | Re-emit attached OHLCV data with the bundle (default `False`) |
+| `max_tasks_per_child` | `int`, optional | Recycle each worker after this many tasks so RSS stays bounded (default `16`) |
+| `update_index` | `bool` | Rewrite `index.parquet` in the destination directory (default `True`) |
+
+**Returns:** `int` — the number of backtests recalculated.
+
+### `recalculate_backtests` *(deprecated)*
+
+:::warning Deprecated since 8.7.2
+Use [`recalculate_backtests_in_directory`](#recalculate_backtests_in_directory) instead. This in-memory variant will be removed in a future major release.
+:::
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -248,5 +276,3 @@ report.show(browser=True)
 | `metrics` | `List[str]`, optional | Specific metrics to compute. If `None`, computes all default metrics |
 
 **Returns:** `List[Backtest]` — the same backtest objects with updated metrics.
-
-Recalculates all per-run `BacktestMetrics` from raw portfolio snapshots and trades, then regenerates `BacktestSummaryMetrics` for each backtest.

--- a/docusaurus/docs/Getting Started/installation.md
+++ b/docusaurus/docs/Getting Started/installation.md
@@ -24,7 +24,7 @@ Install the latest stable version from PyPI:
 pip install investing-algorithm-framework
 ```
 
-This installs the core framework with CCXT support for crypto exchanges.
+This installs the core framework with [CCXT](https://github.com/ccxt/ccxt) support.
 
 ### Optional Data Provider Extras
 

--- a/docusaurus/docs/Getting Started/metrics.md
+++ b/docusaurus/docs/Getting Started/metrics.md
@@ -1,0 +1,334 @@
+---
+sidebar_position: 13
+---
+
+# Metrics Reference
+
+The framework computes metrics at **two levels**:
+
+1. **Per-run metrics** (`BacktestMetrics`): one set per individual
+   backtest run / window. Includes everything specific to that run:
+   the equity curve, drawdown series, monthly/yearly return tables,
+   best/worst trade, exposure, etc.
+2. **Summary metrics** (`BacktestSummaryMetrics`): a single roll-up
+   across **all runs/windows** in a backtest. Used for ranking and
+   robustness analysis in the [HTML report](./backtest-reports).
+
+Both objects expose roughly the same headline stats (CAGR, Sharpe,
+max drawdown, win rate…), but the per-run object is richer (it has
+time-series like `equity_curve` and `drawdown_series`) while the
+summary adds **multi-window** measures (`consistency_score`,
+`stability_score`, `number_of_profitable_windows`).
+
+Prefer the getters over direct attribute access — they handle missing
+runs / metrics safely and work the same way whether the backtest was
+just produced or loaded from an `.iafbt` bundle.
+
+```python
+from investing_algorithm_framework import BacktestDateRange
+
+backtest = app.run_backtest(...)  # or app.run_vector_backtest(...)
+
+# Cross-window roll-up
+summary = backtest.get_backtest_summary()
+print(f"CAGR:          {summary.cagr:.2%}")
+print(f"Max drawdown:  {summary.max_drawdown:.2%}")
+
+# Per-run details — one BacktestMetrics per run/window
+for metrics in backtest.get_all_backtest_metrics():
+    print(
+        f"{metrics.backtest_date_range_name}: "
+        f"return={metrics.total_net_gain_percentage:.2%}, "
+        f"sharpe={metrics.sharpe_ratio:.2f}"
+    )
+
+# Or fetch a specific window by date range
+date_range = BacktestDateRange(
+    start_date="2022-01-01", end_date="2022-12-31", name="2022"
+)
+metrics = backtest.get_backtest_metrics(date_range)
+run = backtest.get_backtest_run(date_range)
+```
+
+All metrics are persisted inside the `.iafbt` bundle, so reports
+loaded from disk have identical values without recomputation.
+
+## Conventions
+
+- **Decimal vs percentage.** Fields ending in `_percentage` are decimals
+  (e.g. `0.42` means 42%). Fields without a `_percentage` suffix are in
+  account currency, except for ratios (Sharpe, Sortino, Calmar,
+  win/loss, profit factor) which are dimensionless.
+- **Currency**. All currency-denominated metrics are expressed in the
+  portfolio's `trading_symbol` (typically EUR/USD/USDT).
+- **Per-run vs per-trade**. On `BacktestMetrics`, `total_*` is over the
+  whole run, `average_trade_*` is over closed trades within that run.
+  On `BacktestSummaryMetrics`, `average_*` (without `trade_`) is the
+  time-weighted mean **across windows**.
+- **Single window**. If the backtest has only one window, summary
+  `total_*` and `average_*` collapse to the corresponding per-run
+  values by definition.
+- **Annualization**. Sharpe, Sortino, CAGR, and annual volatility are
+  annualized using the backtest's bar frequency (252 trading days for
+  daily, scaled accordingly for intraday).
+
+---
+
+## Per-run metrics — `BacktestMetrics`
+
+One `BacktestMetrics` instance is produced for every backtest run /
+window. Retrieve them via `backtest.get_all_backtest_metrics()` or a
+specific one via `backtest.get_backtest_metrics(date_range)`.
+
+### Run identity
+
+| Metric | Type | Description |
+|---|---|---|
+| `backtest_date_range_name` | str | Human-readable name of the date range (e.g. `"2022_bear"`). |
+| `backtest_start_date` | datetime | First bar timestamp of the run. |
+| `backtest_end_date` | datetime | Last bar timestamp of the run. |
+| `total_number_of_days` | int | Calendar days covered by the run. |
+| `trading_symbol` | str | Quote currency of the portfolio (e.g. `"EUR"`). |
+| `initial_unallocated` | currency | Starting cash for the run. |
+| `final_value` | currency | Portfolio value at the last bar. |
+| `metadata` | dict | Free-form metadata attached to the run. |
+
+### Returns and growth (per-run)
+
+| Metric | Type | Description |
+|---|---|---|
+| `total_net_gain` | currency | `final_value − initial_unallocated`. |
+| `total_net_gain_percentage` | decimal | `total_net_gain / initial_unallocated`. |
+| `total_growth` / `total_growth_percentage` | currency / decimal | Legacy aliases of `total_net_gain*`. |
+| `total_loss` | currency | Gross loss magnitude (sum of `abs(net_gain)` over losing trades). |
+| `total_loss_percentage` | decimal | `total_loss / initial_unallocated`. |
+| `gross_profit` | currency | Sum of P&L of winning trades. |
+| `gross_loss` | currency | Sum of P&L of losing trades (negative). |
+| `cumulative_return` | decimal | Cumulative return over the run. |
+| `cagr` | decimal | Compound annual growth rate. |
+| `annual_volatility` | decimal | Annualized stdev of periodic returns. |
+
+### Time series (per-run only)
+
+These are lists of `(value, datetime)` tuples used to render the charts
+in the HTML dashboard.
+
+| Metric | Type | Description |
+|---|---|---|
+| `equity_curve` | list[(float, datetime)] | Portfolio value over time. |
+| `cumulative_return_series` | list[(float, datetime)] | Cumulative return over time. |
+| `rolling_sharpe_ratio` | list[(float, datetime)] | Rolling Sharpe ratio over a fixed lookback. |
+| `drawdown_series` | list[(float, datetime)] | Drawdown from running peak over time. |
+| `monthly_returns` | list[(float, datetime)] | Monthly return per month. Powers the heatmap. |
+| `yearly_returns` | list[(float, date)] | Yearly return per year. |
+
+### Risk-adjusted performance (per-run)
+
+| Metric | Type | Description |
+|---|---|---|
+| `sharpe_ratio` | ratio | Annualized excess return / annualized volatility. |
+| `sortino_ratio` | ratio | Annualized excess return / downside deviation. |
+| `calmar_ratio` | ratio | `cagr / max_drawdown`. |
+| `profit_factor` | ratio | `gross_profit / abs(gross_loss)`. |
+
+### Drawdown and tail risk (per-run)
+
+| Metric | Type | Description |
+|---|---|---|
+| `max_drawdown` | decimal | Largest peak-to-trough drop, as a fraction of peak. |
+| `max_drawdown_absolute` | currency | Same drop in account currency. |
+| `max_daily_drawdown` | decimal | Largest single-day equity drop. |
+| `max_drawdown_duration` | int (days) | Days from drawdown peak to recovery. |
+| `var_95` | decimal | Value at Risk at 95% confidence. |
+| `cvar_95` | decimal | Conditional VaR — average loss in the worst 5% of cases. |
+
+### Trade statistics (per-run)
+
+| Metric | Type | Description |
+|---|---|---|
+| `number_of_trades` | int | All trades touched during the run. |
+| `number_of_trades_opened` | int | Trades opened during the run. |
+| `number_of_trades_closed` | int | Trades closed during the run. |
+| `number_of_trades_open_at_end` | int | Trades still open at last bar. |
+| `number_of_positive_trades` | int | Profitable closed trades. |
+| `number_of_negative_trades` | int | Losing closed trades. |
+| `percentage_positive_trades` | decimal | `n_positive / n_closed`. |
+| `percentage_negative_trades` | decimal | `n_negative / n_closed`. |
+| `average_trade_size` | currency | Mean notional per trade. |
+| `average_trade_return` / `_percentage` | currency / decimal | Mean P&L of all closed trades. |
+| `median_trade_return` / `_percentage` | currency / decimal | Median P&L. |
+| `average_trade_gain` / `_percentage` | currency / decimal | Mean P&L of winning trades. |
+| `average_trade_loss` / `_percentage` | currency / decimal | Mean loss of losing trades. |
+| `average_trade_duration` | hours | Mean time a trade is open. |
+| `average_win_duration` | hours | Mean duration of winning trades. |
+| `average_loss_duration` | hours | Mean duration of losing trades. |
+| `best_trade` | Trade | Highest-P&L trade in the run. |
+| `worst_trade` | Trade | Lowest-P&L trade in the run. |
+| `current_average_trade_*` | various | Same as above but rolling over the most recent trades. |
+
+### Win/loss (per-run)
+
+| Metric | Type | Description |
+|---|---|---|
+| `win_rate` | decimal | `n_positive / n_closed`. |
+| `current_win_rate` | decimal | Rolling win rate over recent trades. |
+| `win_loss_ratio` | ratio | `average_trade_gain / average_trade_loss`. |
+| `current_win_loss_ratio` | ratio | Rolling version. |
+| `max_consecutive_wins` | int | Longest winning streak. |
+| `max_consecutive_losses` | int | Longest losing streak. |
+
+### Calendar performance (per-run)
+
+| Metric | Type | Description |
+|---|---|---|
+| `percentage_winning_months` | decimal | Months with positive return / total months. |
+| `percentage_winning_years` | decimal | Years with positive return / total years. |
+| `average_monthly_return` | decimal | Mean monthly return. |
+| `average_monthly_return_winning_months` | decimal | Mean return over positive months. |
+| `average_monthly_return_losing_months` | decimal | Mean return over negative months. |
+| `best_month` | (float, datetime) | Best monthly return. |
+| `worst_month` | (float, datetime) | Worst monthly return. |
+| `best_year` | (float, date) | Best yearly return. |
+| `worst_year` | (float, date) | Worst yearly return. |
+
+### Exposure and activity (per-run)
+
+| Metric | Type | Description |
+|---|---|---|
+| `cumulative_exposure` | currency × time | Integral of capital deployed. |
+| `exposure_ratio` | decimal | Fraction of time with at least one open position. |
+| `trades_per_year` | float | Annualized trade frequency. |
+| `trades_per_month` | float | Monthly trade frequency. |
+| `trades_per_week` | float | Weekly trade frequency. |
+| `trade_per_day` | float | Daily trade frequency. |
+
+---
+
+## Summary metrics — `BacktestSummaryMetrics`
+
+A single roll-up across **all runs/windows** in a backtest. Available
+via `backtest.get_backtest_summary()`. Used by `BacktestReport` for
+ranking, filtering, and KPI cards.
+
+For single-window backtests these collapse to the per-run values; for
+multi-window backtests (e.g. walk-forward, permutation tests, see
+[Vector Backtesting](./vector-backtesting)) they aggregate across
+windows and add robustness measures.
+
+### Returns and growth (aggregate)
+
+| Metric | Type | Description |
+|---|---|---|
+| `total_net_gain` | currency | Sum of per-window net gains. |
+| `total_net_gain_percentage` | decimal | `total_net_gain` / total initial capital. |
+| `total_growth` / `total_growth_percentage` | currency / decimal | Legacy aliases of `total_net_gain*`. |
+| `cagr` | decimal | Compound annual growth rate of the combined equity curve. |
+| `annual_volatility` | decimal | Annualized return volatility across windows. |
+| `average_net_gain` / `_percentage` | currency / decimal | Time-weighted mean per-window net gain. |
+| `average_growth` / `_percentage` | currency / decimal | Legacy aliases. |
+
+### Risk-adjusted performance (aggregate)
+
+| Metric | Type | Description |
+|---|---|---|
+| `sharpe_ratio` | ratio | Annualized excess return / annualized volatility. |
+| `sortino_ratio` | ratio | Downside-risk adjusted return. |
+| `calmar_ratio` | ratio | `cagr / max_drawdown`. |
+| `profit_factor` | ratio | Gross profit / gross loss across all closed trades. |
+
+### Drawdown and tail risk (aggregate)
+
+| Metric | Type | Description |
+|---|---|---|
+| `max_drawdown` | decimal | Worst peak-to-trough drop seen across all windows. |
+| `max_drawdown_duration` | int (bars) | Bars between the worst drawdown peak and recovery. |
+| `var_95` | decimal | Value at Risk at 95% confidence across all returns. |
+| `cvar_95` | decimal | Conditional VaR. |
+
+### Loss metrics (aggregate)
+
+| Metric | Type | Description |
+|---|---|---|
+| `total_loss` | currency | Sum of per-window gross losses (non-negative magnitude). |
+| `total_loss_percentage` | decimal | `total_loss` / total initial capital. |
+| `average_loss` / `_percentage` | currency / decimal | Time-weighted mean loss across windows. |
+
+### Per-trade metrics (aggregate)
+
+| Metric | Type | Description |
+|---|---|---|
+| `number_of_trades` | int | Trades opened across all windows. |
+| `number_of_trades_closed` | int | Trades closed across all windows. |
+| `average_trade_return` / `_percentage` | currency / decimal | Mean P&L per closed trade. |
+| `average_trade_gain` / `_percentage` | currency / decimal | Mean P&L of winners. |
+| `average_trade_loss` / `_percentage` | currency / decimal | Mean loss of losers. |
+| `average_trade_duration` | seconds | Mean trade open time. |
+| `average_win_duration` | seconds | Mean winning trade duration. |
+| `average_loss_duration` | seconds | Mean losing trade duration. |
+
+### Win/loss statistics (aggregate)
+
+| Metric | Type | Description |
+|---|---|---|
+| `win_rate` | decimal | Profitable trades / closed trades across all windows. |
+| `current_win_rate` | decimal | Rolling win rate over recent trades. |
+| `win_loss_ratio` | ratio | `average_trade_gain` / `average_trade_loss`. |
+| `current_win_loss_ratio` | ratio | Rolling version. |
+| `max_consecutive_wins` | int | Longest winning streak across all windows. |
+| `max_consecutive_losses` | int | Longest losing streak across all windows. |
+
+### Exposure and activity (aggregate)
+
+| Metric | Type | Description |
+|---|---|---|
+| `cumulative_exposure` | currency × time | Total capital deployed across all windows. |
+| `exposure_ratio` | decimal | Fraction of time with at least one open position. |
+| `trades_per_year` / `trades_per_month` / `trades_per_week` | float | Annualized / monthly / weekly trade frequency. |
+
+### Multi-window robustness (summary-only)
+
+These metrics only exist on `BacktestSummaryMetrics` — they describe
+how performance varies *across* windows and have no per-run analog.
+
+| Metric | Type | Description |
+|---|---|---|
+| `number_of_windows` | int | Total backtest windows executed. |
+| `number_of_windows_with_trades` | int | Windows in which at least one trade closed. |
+| `number_of_profitable_windows` | int | Windows with positive net gain. |
+| `return_consistency` | decimal | Coefficient of variation of per-window returns (lower = more consistent). |
+| `win_rate_consistency` | decimal | Coefficient of variation of per-window win rates. |
+| `sharpe_consistency` | decimal | Coefficient of variation of per-window Sharpe ratios. |
+| `consistency_score` | decimal | Composite of the three `*_consistency` measures, scaled to `[0, 1]` (higher = better). |
+| `return_stability` | decimal | Per-window return autocorrelation — how stable returns are over time. |
+| `win_rate_stability` | decimal | Same, for win rate. |
+| `sharpe_stability` | decimal | Same, for Sharpe ratio. |
+| `stability_score` | decimal | Composite stability score, scaled to `[0, 1]` (higher = better). |
+
+---
+
+## Using metrics in code
+
+Every summary metric is also available as a ranking key in
+[`BacktestReport`](./backtest-reports):
+
+```python
+from investing_algorithm_framework import BacktestReport
+
+report = BacktestReport.open(directory_path="backtest_results/")
+
+# Top 10 strategies by Sharpe ratio
+top_sharpe = report.rank(by="sharpe_ratio", ascending=False, limit=10)
+
+# Filter to robust strategies only
+robust = report.filter(
+    lambda b: b.backtest_summary.consistency_score > 0.7
+    and b.backtest_summary.max_drawdown < 0.2
+)
+
+# Drill into per-run detail for a specific backtest
+for metrics in robust[0].get_all_backtest_metrics():
+    print(f"{metrics.backtest_date_range_name}: {metrics.total_net_gain_percentage:.2%}")
+```
+
+For multi-strategy comparison and visualization, see
+[Backtest Reports](./backtest-reports).

--- a/docusaurus/docs/Getting Started/simple-example.md
+++ b/docusaurus/docs/Getting Started/simple-example.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Simple Example
 
-Get started with a complete working example of a trading bot 
+Get started with a complete working example of a trading bot
 using the Investing Algorithm Framework.
 
 ## Overview
@@ -15,7 +15,7 @@ This example demonstrates how to create a sophisticated trading bot that uses te
 
 Here's a complete working example that you can run right after installation:
 
-> This example uses the `pyindicators` library for technical indicators. 
+> This example uses the `pyindicators` library for technical indicators.
 > Make sure to install it via pip:```pip install pyindicators```
 
 ```python
@@ -32,7 +32,7 @@ from investing_algorithm_framework import TradingStrategy, DataSource, \
     DEFAULT_LOGGING_CONFIG
 
 
-# Use the framework provided logging configuration
+# Use the framework provided logging configuration for better debugging and monitoring
 logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
 
 
@@ -142,7 +142,7 @@ class RSIEMACrossoverStrategy(TradingStrategy):
         ema_data
     ):
         """
-        Helper function to prepare the indicators 
+        Helper function to prepare the indicators
         for the strategy. The indicators are calculated
         using the pyindicators library: https://github.com/coding-kitties/PyIndicators
         """
@@ -308,7 +308,7 @@ import pandas as pd
 from pyindicators import ema, rsi, crossover, crossunder
 
 from investing_algorithm_framework import TradingStrategy, DataSource, \
-    TimeUnit, DataType, PositionSize, create_app, RESOURCE_DIRECTORY, \
+    TimeUnit, DataType, PositionSize, create_app, \
     BacktestDateRange, BacktestReport, TakeProfitRule, StopLossRule, \
     DEFAULT_LOGGING_CONFIG
 ```
@@ -330,17 +330,18 @@ logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
 ```python
 class RSIEMACrossoverStrategy(TradingStrategy):
     algorithm_id = "RSI-EMA-Crossover-Strategy"
-    time_unit = TimeUnit.HOUR
-    interval = 2
-    symbols = ["BTC"]
+    symbols = ["BTC", "ETH"]
     # ...
 ```
 
 **Key Properties:**
 - **algorithm_id**: Unique identifier for your strategy
-- **time_unit**: The time unit for strategy execution (HOUR in this case)
-- **interval**: How often to run the strategy (every 2 hours)
-- **symbols**: List of trading symbols to monitor
+- **symbols**: List of trading symbols the strategy trades. The
+  per-symbol `position_sizes`, `take_profits`, and `stop_losses` rules
+  below are matched against this list.
+- **time_unit** / **interval**: Passed to `super().__init__` from the
+  constructor — controls how often the strategy runs (every 2 hours
+  here).
 
 ### 4. Position Sizing and Risk Management
 
@@ -403,7 +404,7 @@ for symbol in self.symbols:
 
 **Data Sources for Technical Analysis:**
 - **RSI Data Source**: OHLCV data for RSI indicator calculation
-- **EMA Data Source**: OHLCV data for moving average calculations  
+- **EMA Data Source**: OHLCV data for moving average calculations
 - **warmup_window**: 800 candles for sufficient historical data
 - **pandas**: Returns data as pandas DataFrame for easy analysis
 
@@ -412,16 +413,16 @@ for symbol in self.symbols:
 ```python
 def _prepare_indicators(self, rsi_data, ema_data):
     # Calculate short and long EMAs
-    ema_data = ema(ema_data, period=self.ema_short_period, 
+    ema_data = ema(ema_data, period=self.ema_short_period,
                    source_column="Close", result_column=self.ema_short_result_column)
     ema_data = ema(ema_data, period=self.ema_long_period,
                    source_column="Close", result_column=self.ema_long_result_column)
-    
+
     # Detect EMA crossovers
     ema_data = crossover(ema_data, first_column=self.ema_short_result_column,
                         second_column=self.ema_long_result_column,
                         result_column=self.ema_crossover_result_column)
-    
+
     # Calculate RSI
     rsi_data = rsi(rsi_data, period=self.rsi_period,
                    source_column="Close", result_column=self.rsi_result_column)
@@ -440,16 +441,16 @@ def generate_buy_signals(self, data: Dict[str, Any]) -> Dict[str, pd.Series]:
     rsi_oversold = rsi_data[self.rsi_result_column] < self.rsi_oversold_threshold
     ema_crossover_lookback = ema_data[self.ema_crossover_result_column].rolling(
         window=self.ema_cross_lookback_window).max().astype(bool)
-    
+
     buy_signal = rsi_oversold & ema_crossover_lookback
     return buy_signal
 
 def generate_sell_signals(self, data: Dict[str, Any]) -> Dict[str, pd.Series]:
-    # Sell when RSI is overbought AND EMA crossunder occurred recently  
+    # Sell when RSI is overbought AND EMA crossunder occurred recently
     rsi_overbought = rsi_data[self.rsi_result_column] >= self.rsi_overbought_threshold
     ema_crossunder_lookback = ema_data[self.ema_crossunder_result_column].rolling(
         window=self.ema_cross_lookback_window).max().astype(bool)
-        
+
     sell_signal = rsi_overbought & ema_crossunder_lookback
     return sell_signal
 ```
@@ -593,13 +594,22 @@ This example showcases:
 Now that you have a working advanced strategy example, you can:
 
 1. **Experiment with parameters** - Modify RSI periods, EMA periods, and thresholds
-2. **Add more symbols** - Extend to trade ETH, ADA, and other cryptocurrencies  
+2. **Add more symbols** - Extend to trade ETH, ADA, and other cryptocurrencies
 3. **Implement live trading** - Add API credentials for live trading on Bitvavo
 4. **Create custom indicators** - Develop your own technical analysis indicators
 5. **Optimize strategy parameters** - Use the framework's optimization tools
 6. **Add more sophisticated risk management** - Implement dynamic position sizing
 
 Continue to [Application Setup](application-setup) to learn how to structure more complex trading applications, or jump to [Strategies](strategies) to learn about implementing more trading logic.
+
+## See also
+
+The strategy above generates buy/sell signals one symbol at a time. For
+**cross-sectional** strategies — where you score and rank a universe of
+symbols against each other (e.g. "long the top-10 by momentum, short
+the bottom-10") — see the [Pipelines](../Advanced%20Concepts/pipelines)
+guide. Pipelines also enable vectorised backtesting, which is
+significantly faster for large universes.
 
 ## Troubleshooting
 
@@ -620,7 +630,7 @@ Continue to [Application Setup](application-setup) to learn how to structure mor
 
 If you encounter issues:
 1. Check the logs for detailed error messages
-2. Verify your Python version (3.8+ required)
+2. Verify your Python version (3.10+ required)
 3. Ensure all dependencies are installed
 
 This example provides a solid foundation for building more sophisticated trading bots. Once you're comfortable with this advanced structure, you can explore the more advanced features covered in the rest of this documentation.

--- a/docusaurus/docs/introduction.md
+++ b/docusaurus/docs/introduction.md
@@ -12,7 +12,7 @@ Welcome to the Investing Algorithm Framework documentation! This framework provi
 The Investing Algorithm Framework is a Python-based library designed to help developers and traders build sophisticated algorithmic trading systems. It provides:
 
 - **Strategy Development**: Tools for creating and implementing trading strategies
-- **Backtesting**: Comprehensive backtesting capabilities with both event-based and vector-based approaches  
+- **Backtesting**: Comprehensive backtesting capabilities with both event-based and vector-based approaches
 - **Data Management**: Integration with multiple data sources and providers
 - **Order Management**: Advanced order execution and portfolio management
 - **Performance Analysis**: Detailed analytics and metrics for strategy evaluation
@@ -20,20 +20,23 @@ The Investing Algorithm Framework is a Python-based library designed to help dev
 
 ## Key Features
 
-### 📈 Strategy Framework
-Build trading strategies using our flexible strategy framework that supports various trading approaches.
-
-### 🔄 Backtesting Engine
-Test your strategies against historical data using our powerful backtesting engine with realistic market simulation.
-
-### 📊 Data Integration
-Connect to multiple data sources including cryptocurrencies, stocks, and other financial instruments.
-
-### ⚡ Performance Optimized
-Built for performance with efficient data processing and strategy execution.
-
-### 🛠 Production Ready
-Deploy your strategies in production environments with confidence.
+- 📊 **30+ Metrics** — CAGR, Sharpe, Sortino, Calmar, VaR, CVaR, Max DD, Recovery & more
+- 🧮 [Cross-Sectional Pipelines](./Advanced%20Concepts/pipelines)** — Rank, filter and score entire universes of symbols every iteration with a tidy factor table
+- ⚡ [Vector Backtesting for Signal Analysis](./Advanced%20Concepts/vector-backtesting)** — Quickly test your strategy logic on historical data to see how signals would have behaved before committing to full event-driven backtests
+- 🏃 [Event-Driven Backtesting](./Advanced%20Concepts/event-driven-backtesting)** — Once promising strategies are identified via vector backtests, run full event-driven backtests to simulate realistic execution and portfolio management
+- 🔀 [Permutation Testing / Monte Carlo Simulations](./Advanced%20Concepts/permutation-testing)** — Assess the statistical robustness of your strategies by running them across randomized market scenarios to see how often your results could occur by chance
+- 🚀 [Deployment](./Getting%20Started/deployment) — Once the best strategy is identified through backtesting and comparison, deploy it to production locally or in the cloud (AWS Lambda / Azure Functions) to start live trading
+- ⚔️ **Multi-Strategy Comparison** — Rank, filter & compare strategies in a single interactive report
+- 🪟 **Multi-Window Robustness** — Test across different time periods with window coverage analysis
+- 📈 **Equity & Drawdown Charts** — Overlay equity curves, rolling Sharpe, drawdown & return distributions
+- 🗓️ **Monthly Heatmaps & Yearly Returns** — Calendar heatmap per strategy with return/growth toggles
+- 🎯 **Return Scenario Projections** — Good, average, bad & very bad year projections from backtest data
+- 📉 **Benchmark Comparison** — Beat-rate analysis vs Buy & Hold, DCA, risk-free & custom benchmarks
+- 📄 [One-Click HTML Report](./Getting%20Started/backtest-reports) — Self-contained file, no server, dark & light theme, shareable
+- 📦 **Custom `.iafbt` Backtest Bundle Format** — An explicit, versioned, compressed, language-portable container (zstd + msgpack with magic-byte header) plus a separate parquet index for fast filtering without loading. ~21× smaller and ~27× fewer files than standard filebased directory layouts, with parallel I/O for fast load/save of large amounts of backtests.
+- 🌐 **Load External Data** — Fetch CSV, JSON, or Parquet from any URL with caching and auto-refresh
+- 📝 **[Record Custom Variables](./Advanced%20Concepts/recording-variables)** — Track any indicator or metric during backtests with `context.record()`
+- 🚀 **Build → Backtest → Deploy** — Local dev, cloud deploy (AWS / Azure), or monetize on Finterion
 
 ## Getting Started
 

--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -14110,9 +14110,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15776,15 +15776,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16807,12 +16798,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -17560,15 +17551,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -29,6 +29,10 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5",
+    "postcss": "^8.5.10"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -59,6 +59,10 @@ const sidebars = {
                 },
                 {
                     type: 'doc',
+                    id: 'Getting Started/metrics',
+                },
+                {
+                    type: 'doc',
                     id: 'Getting Started/deployment',
                 },
             ],

--- a/examples/tutorial/README.md
+++ b/examples/tutorial/README.md
@@ -1,10 +1,12 @@
 # Investing Algorithm Framework Tutorial
 
-This tutorial demonstrates the full capabilities of the **Investing Algorithm Framework** 
-through a series of Jupyter notebooks. Each notebook focuses on a specific aspect of 
+This tutorial demonstrates main capabilities of the **Investing Algorithm Framework**
+through a series of Jupyter notebooks. Each notebook focuses on a specific aspect of
 the framework, from data handling to advanced backtesting and analysis.
 
-> **Note**: This tutorial uses the Bitvavo exchange with EUR as the trading symbol. 
+> **Note**: This tutorial only showcases a subset of the framework's capabilities. Advanced features like cross-sectional pipelines can be explored in the [advanced tutorials](../advanced_tutorial/README.md).
+>
+> **Note**: This tutorial uses the Bitvavo exchange with EUR as the trading symbol.
 > You can adapt the examples to other exchanges and symbols supported by the framework.
 
 ## 📋 Table of Contents
@@ -19,16 +21,15 @@ the framework, from data handling to advanced backtesting and analysis.
 
 ## 🎯 Overview
 
-The Investing Algorithm Framework is a comprehensive Python library for building, 
+The Investing Algorithm Framework is a comprehensive Python library for building,
 testing, and deploying algorithmic trading strategies. This tutorial showcases:
 
 - **Data Management** - Download, validate, and fill missing market data
-- **Strategy Development** - Create and visualize trading strategies
-- **Vectorized Backtesting** - High-performance backtesting (10-100x faster)
-- **Event-Based Backtesting** - Realistic trade simulation
-- **Parameter Optimization** - Grid search across thousands of variations
-- **Performance Analysis** - Ranking, filtering, and robustness testing
-- **Checkpointing & Storage** - Save and resume long-running experiments
+- **Strategy Visualization** - Visualize trading strategies
+- **In sample Parameter Sweeping** - Test thousands of parameter combinations with ease through a grid search and vector backtesting.
+- **Out sample Vector Backtesting** - Test thousand of strategies out-of-sample with a fast vectorized backtester.
+- **Out sample event based Backtesting** - Simulate realistic trade execution with an event-based backtester to validate top strategies from the vector backtest.
+- **Final analysis** - Generate reports, rank strategies, and export results for further analysis.
 
 ## 📁 Tutorial Structure
 
@@ -38,12 +39,11 @@ tutorial/
 ├── notebooks/                         # Tutorial notebooks (start here!)
 │   ├── 01_data_exploration.ipynb      # Data download and validation
 │   ├── 02_strategy_visualization.ipynb # Strategy logic visualization
-│   ├── 03_backtest_baseline.ipynb     # Basic backtesting
-│   ├── 04_param_grid_search.ipynb     # Parameter optimization
-│   ├── 05_backtest_optimized.ipynb    # Optimized strategy testing
-│   ├── 06_event_backtest.ipynb        # Event-based backtesting
-│   ├── 07_robustness_analysis.ipynb   # Robustness and validation
-│   └── 08_final_analysis.ipynb        # Final results and reporting
+│   ├── 03_param_sweep.ipynb           # Parameter optimization
+│   ├── 04_backtest_optimized.ipynb    # Optimized strategy testing
+│   ├── 05_event_backtest.ipynb        # Event-based backtesting
+│   ├── 06_robustness_analysis.ipynb   # Robustness and validation
+│   └── 07_final_analysis.ipynb        # Final results and reporting
 ├── strategies/                        # Strategy implementations
 │   └── ema_crossover_rsi_filter/      # Example strategy
 ├── data/                              # Downloaded market data
@@ -151,8 +151,8 @@ report.show(browser=True)
 
 ---
 
-### 04 - Parameter Grid Search
-**File**: `notebooks/04_param_grid_search.ipynb`
+### 04 - Parameter Sweep
+**File**: `notebooks/04_param_sweep.ipynb`
 
 Test thousands of parameter combinations:
 - **`run_vector_backtests()`** - Batch vectorized backtesting
@@ -337,7 +337,7 @@ After completing this tutorial:
 
 - **Documentation**: See `docusaurus/docs/` for full documentation
 - **Example Strategies**: See `examples/example_strategies/`
-- **Advanced Topics**: 
+- **Advanced Topics**:
   - `docs/Advanced Concepts/vector-backtesting.md`
   - `docs/Advanced Concepts/PARALLEL_PROCESSING_GUIDE.md`
 
@@ -352,4 +352,3 @@ After completing this tutorial:
 **Happy Trading! 🚀📈**
 
 *Remember: Past performance does not guarantee future results. Always test thoroughly and use proper risk management.*
-

--- a/investing_algorithm_framework/cli/deploy_to_azure_function.py
+++ b/investing_algorithm_framework/cli/deploy_to_azure_function.py
@@ -30,6 +30,51 @@ def generate_unique_resource_name(base_name):
     return f"{base_name}{unique_suffix}".lower()
 
 
+async def _wait_until_function_app_ready(
+    function_app_name,
+    resource_group_name,
+    timeout_seconds=300,
+    poll_interval_seconds=10,
+):
+    """
+    Poll `az functionapp show --query state` until the Function App
+    reports 'Running', or raise once `timeout_seconds` is exceeded.
+
+    This replaces the old hard-coded `time.sleep(60)` which both blocked
+    the event loop and frequently published before the host was ready
+    (causing silent SCM 503s).
+    """
+    deadline = time.monotonic() + timeout_seconds
+    last_state = None
+
+    while time.monotonic() < deadline:
+        process = await asyncio.create_subprocess_exec(
+            "az", "functionapp", "show",
+            "--name", function_app_name,
+            "--resource-group", resource_group_name,
+            "--query", "state",
+            "-o", "tsv",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await process.communicate()
+        state = stdout.decode().strip()
+
+        if state and state != last_state:
+            print(f"Function App state: {state}")
+            last_state = state
+
+        if state == "Running":
+            return
+
+        await asyncio.sleep(poll_interval_seconds)
+
+    raise TimeoutError(
+        f"Function App '{function_app_name}' did not reach 'Running' "
+        f"state within {timeout_seconds}s (last seen: {last_state!r})."
+    )
+
+
 def ensure_azure_functools():
     """
     Function to ensure that the Azure Functions Core Tools are installed.
@@ -128,77 +173,93 @@ async def publish_function_app(
     """
     print(f"Publishing Function App {function_app_name}")
 
-    # Wait for 60 seconds to ensure the Function App is ready
-    time.sleep(60)
+    # Wait for the Function App to report a 'Running' state instead of
+    # blindly sleeping. The first deployment can take a while because the
+    # Linux Consumption host is provisioned lazily.
+    await _wait_until_function_app_ready(
+        function_app_name=function_app_name,
+        resource_group_name=resource_group_name,
+        timeout_seconds=300,
+    )
 
     try:
-        # Step 1: Publish the Azure Function App
-        process = await asyncio.create_subprocess_exec(
-            "func", "azure", "functionapp", "publish", function_app_name
-        )
-
-        # Wait for the subprocess to finish
-        _, stderr = await process.communicate()
-
-        # Check the return code
-        if process.returncode != 0:
-
-            if stderr is not None:
-                raise Exception(
-                    f"Error publishing Function App: {stderr.decode().strip()}"
-                )
-            else:
-                raise Exception("Error publishing Function App")
-
-        print(f"Function App {function_app_name} published successfully.")
-
-        # Step 2: Add app settings
+        # Step 1: Push app settings BEFORE publishing so the worker has
+        # the storage credentials available on first cold start.
+        print("Setting AZURE_STORAGE_* app settings...")
         add_settings_process = await asyncio.create_subprocess_exec(
             "az", "functionapp", "config", "appsettings", "set",
             "--name", function_app_name,
+            "--resource-group", resource_group_name,
             "--settings",
             f"AZURE_STORAGE_CONNECTION_STRING={storage_connection_string}",
             f"AZURE_STORAGE_CONTAINER_NAME={storage_container_name}",
-            "--resource-group", resource_group_name
+            "SCM_DO_BUILD_DURING_DEPLOYMENT=true",
+            "ENABLE_ORYX_BUILD=true",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
         _, stderr1 = await add_settings_process.communicate()
 
         if add_settings_process.returncode != 0:
+            raise Exception(
+                "Error adding app settings: " +
+                (stderr1.decode().strip() if stderr1 else "")
+            )
+        print("App settings configured successfully.")
 
-            if stderr1 is not None:
-                raise Exception(
-                    f"Error adding App settings: {stderr1.decode().strip()}"
-                )
-            else:
-                raise Exception("Error adding App settings")
-
+        # Step 2: Publish the Azure Function App. `--build remote --python`
+        # is *required* on Linux Consumption: native wheels (pandas, numpy,
+        # msgpack, polars, ...) must be built on the function host's libc/
+        # arch, otherwise the host crashes silently on import at cold start.
         print(
-            "Added app settings to the Function App successfully"
+            "Running 'func azure functionapp publish' "
+            f"(remote build) for {function_app_name}..."
         )
+        publish_process = await asyncio.create_subprocess_exec(
+            "func", "azure", "functionapp", "publish", function_app_name,
+            "--build", "remote",
+            "--python",
+        )
+        await publish_process.communicate()
 
-        # Step 3: Update the cors settings
+        if publish_process.returncode != 0:
+            raise Exception(
+                "Error publishing Function App. Re-run with the Azure "
+                "CLI directly to see full output:\n  "
+                f"func azure functionapp publish {function_app_name} "
+                "--build remote --python"
+            )
+        print(f"Function App {function_app_name} published successfully.")
+
+        # Step 3: Update the CORS settings.
         cors_process = await asyncio.create_subprocess_exec(
             "az", "functionapp", "cors", "add",
             "--name", function_app_name,
             "--allowed-origins", "*",
-            "--resource-group", resource_group_name
+            "--resource-group", resource_group_name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-
-        _, stderr1 = await add_settings_process.communicate()
+        _, cors_stderr = await cors_process.communicate()
 
         if cors_process.returncode != 0:
+            # CORS already configured is not fatal.
+            print(
+                "Warning: could not add CORS rule: " +
+                (cors_stderr.decode().strip() if cors_stderr else "")
+            )
+        else:
+            print("CORS rule '*' added.")
 
-            if stderr1 is not None:
-                raise Exception(
-                    f"Error adding cors settings: {stderr1.decode().strip()}"
-                )
-            else:
-                raise Exception("Error adding cors settings")
-
-        print("All app settings have been added successfully.")
-        print("Function App creation completed successfully.")
+        print("Function App deployment completed successfully.")
+        print(
+            "\nTo stream live logs run:\n  "
+            f"az webapp log tail --name {function_app_name} "
+            f"--resource-group {resource_group_name}"
+        )
     except Exception as e:
         print(f"Error publishing Function App: {e}")
+        raise
 
 
 async def create_function_app(
@@ -268,7 +329,7 @@ async def create_function_app(
             "--runtime",
             "python",
             "--runtime-version",
-            "3.10",
+            "3.11",
             "--functions-version",
             "4",
             "--name",

--- a/investing_algorithm_framework/cli/initialize_app.py
+++ b/investing_algorithm_framework/cli/initialize_app.py
@@ -1,5 +1,35 @@
+import json
 import os
 from enum import Enum
+
+
+# Notebook stubs created in `notebooks/` by `init`. Each entry is
+# (filename, first-markdown-cell-title) and mirrors the recommended
+# research workflow documented in
+# docusaurus/docs/Getting Started/application-setup.md.
+RECOMMENDED_NOTEBOOKS = [
+    ("01_data_exploration.ipynb",
+     "# 01 — Data Exploration\n\nDownload OHLCV, inspect coverage, "
+     "detect and fill gaps."),
+    ("02_backtest_baseline.ipynb",
+     "# 02 — Baseline Backtest\n\nSingle vector backtest of the strategy "
+     "with default parameters and HTML report."),
+    ("03_in_sample_param_grid_search.ipynb",
+     "# 03 — In-Sample Parameter Grid Search\n\nGrid search across "
+     "thousands of parameter combinations on the in-sample window."),
+    ("04_out_of_sample_param_grid_search.ipynb",
+     "# 04 — Out-of-Sample Parameter Grid Search\n\nRe-run top in-sample "
+     "candidates on the held-out out-of-sample window."),
+    ("05_overfitting_analysis.ipynb",
+     "# 05 — Overfitting Analysis\n\nCompare in-sample vs out-of-sample "
+     "performance, walk-forward / permutation checks."),
+    ("06_event_backtests.ipynb",
+     "# 06 — Event-Driven Backtests\n\nValidate the final picks with the "
+     "event-driven engine (fees, slippage, fills)."),
+]
+
+# Empty cache/output directories created in the project root.
+RECOMMENDED_DIRS = ["data", "backtest_results", "reports", "resources"]
 
 
 class AppType(Enum):
@@ -98,6 +128,71 @@ def create_file_from_template(template_path, output_path, replace=False):
 
         with open(output_path, "w") as file:
             file.write(template)
+
+
+def _create_empty_notebook(file_path, title_markdown, replace=False):
+    """
+    Create a minimal Jupyter notebook (nbformat 4) with a single
+    markdown title cell.
+    """
+    if os.path.exists(file_path):
+        if replace:
+            os.remove(file_path)
+        else:
+            return
+
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": title_markdown,
+            }
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {"name": "python"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+    with open(file_path, "w") as file:
+        json.dump(notebook, file, indent=1)
+
+
+def _scaffold_recommended_layout(path, replace=False):
+    """
+    Create the directories and notebook stubs that are part of the
+    recommended project layout but not directly tied to a specific
+    deployment target (default, web, AWS Lambda, Azure Function).
+
+    Creates:
+        notebooks/                  with 6 stub research notebooks
+        data/                       cache for downloaded market data
+        backtest_results/           saved backtest bundles
+        reports/                    generated HTML/CSV reports
+        resources/                  misc assets (databases, configs)
+    """
+    notebooks_path = os.path.join(path, "notebooks")
+    create_directory(notebooks_path)
+
+    for filename, title_markdown in RECOMMENDED_NOTEBOOKS:
+        _create_empty_notebook(
+            os.path.join(notebooks_path, filename),
+            title_markdown,
+            replace=replace,
+        )
+
+    for directory_name in RECOMMENDED_DIRS:
+        directory_path = os.path.join(path, directory_name)
+        create_directory(directory_path)
+        # .gitkeep so the empty directory is committed
+        create_file(os.path.join(directory_path, ".gitkeep"))
 
 
 def command(path=None, app_type="default", replace=False):
@@ -207,19 +302,22 @@ def create_default_app(path=None, replace=False):
         os.path.join(path, "run_backtest.py"),
         replace=replace
     )
-    # Create the main directory
+    # Create the strategies package
     create_directory(os.path.join(path, "strategies"))
     strategies_path = os.path.join(path, "strategies")
     create_file(os.path.join(strategies_path, "__init__.py"))
     create_file_from_template(
         strategy_template_path,
-        os.path.join(strategies_path, "strategy.py")
+        os.path.join(strategies_path, "my_strategy.py")
     )
+    # data_providers.py lives at the project root so app.py, notebooks
+    # and strategies can all import it as `from data_providers import ...`
     create_file_from_template(
         data_providers_template_path,
-        os.path.join(strategies_path, "data_providers.py"),
+        os.path.join(path, "data_providers.py"),
         replace=replace
     )
+    _scaffold_recommended_layout(path, replace=replace)
     gitignore_template_path = os.path.join(
         os.path.dirname(current_script_path),
         "templates",
@@ -311,19 +409,22 @@ def create_default_web_app(path=None, replace=False):
         os.path.join(path, "run_backtest.py"),
         replace=replace
     )
-    # Create the main directory
+    # Create the strategies package
     create_directory(os.path.join(path, "strategies"))
     strategies_path = os.path.join(path, "strategies")
     create_file(os.path.join(strategies_path, "__init__.py"))
     create_file_from_template(
         strategy_template_path,
-        os.path.join(strategies_path, "strategy.py")
+        os.path.join(strategies_path, "my_strategy.py")
     )
+    # data_providers.py lives at the project root so app.py, notebooks
+    # and strategies can all import it as `from data_providers import ...`
     create_file_from_template(
         data_providers_template_path,
-        os.path.join(strategies_path, "data_providers.py"),
+        os.path.join(path, "data_providers.py"),
         replace=replace
     )
+    _scaffold_recommended_layout(path, replace=replace)
     gitignore_template_path = os.path.join(
         os.path.dirname(current_script_path),
         "templates",
@@ -417,19 +518,22 @@ def create_aws_lambda_app(path=None, replace=False):
         os.path.join(path, "run_backtest.py"),
         replace=replace
     )
-    # Create the main directory
+    # Create the strategies package
     create_directory(os.path.join(path, "strategies"))
     strategies_path = os.path.join(path, "strategies")
     create_file(os.path.join(strategies_path, "__init__.py"))
     create_file_from_template(
         strategy_template_path,
-        os.path.join(strategies_path, "strategy.py")
+        os.path.join(strategies_path, "my_strategy.py")
     )
+    # data_providers.py lives at the project root so app.py, notebooks
+    # and strategies can all import it as `from data_providers import ...`
     create_file_from_template(
         data_providers_template_path,
-        os.path.join(strategies_path, "data_providers.py"),
+        os.path.join(path, "data_providers.py"),
         replace=replace
     )
+    _scaffold_recommended_layout(path, replace=replace)
     gitignore_template_path = os.path.join(
         os.path.dirname(current_script_path),
         "templates",
@@ -504,10 +608,12 @@ def create_azure_function_app(path=None, replace=False):
         "templates",
         "run_backtest.py.template"
     )
-    # Create the framework app file as app_entry.py
+    # The Azure Functions Python v2 programming model requires the
+    # entry point to be named exactly `function_app.py` at the project
+    # root. Anything else and the host won't discover any triggers.
     create_file_from_template(
         azure_function_template_path,
-        os.path.join(path, "app_web.py"),
+        os.path.join(path, "function_app.py"),
         replace=replace
     )
     # Create the host.json file
@@ -568,19 +674,22 @@ def create_azure_function_app(path=None, replace=False):
         os.path.join(path, "run_backtest.py"),
         replace=replace
     )
-    # Create the main directory
+    # Create the strategies package
     create_directory(os.path.join(path, "strategies"))
     strategies_path = os.path.join(path, "strategies")
     create_file(os.path.join(strategies_path, "__init__.py"))
     create_file_from_template(
         strategy_template_path,
-        os.path.join(strategies_path, "strategy.py")
+        os.path.join(strategies_path, "my_strategy.py")
     )
+    # data_providers.py lives at the project root so app.py, notebooks
+    # and strategies can all import it as `from data_providers import ...`
     create_file_from_template(
         data_providers_template_path,
-        os.path.join(strategies_path, "data_providers.py"),
+        os.path.join(path, "data_providers.py"),
         replace=replace
     )
+    _scaffold_recommended_layout(path, replace=replace)
     gitignore_template_path = os.path.join(
         os.path.dirname(current_script_path),
         "templates",

--- a/investing_algorithm_framework/cli/templates/.gitignore.template
+++ b/investing_algorithm_framework/cli/templates/.gitignore.template
@@ -176,3 +176,14 @@ cython_debug/
 
 # Framework related files
 # The following files are related to the investing_algorithm_framework framework.
+
+# Local caches and generated outputs (the directories themselves are kept
+# via .gitkeep, but their contents should not be committed).
+data/*
+!data/.gitkeep
+backtest_results/*
+!backtest_results/.gitkeep
+reports/*
+!reports/.gitkeep
+resources/*
+!resources/.gitkeep

--- a/investing_algorithm_framework/cli/templates/app.py.template
+++ b/investing_algorithm_framework/cli/templates/app.py.template
@@ -3,7 +3,7 @@ from dotenv import load_dotenv
 
 from investing_algorithm_framework import create_app, \
     DEFAULT_LOGGING_CONFIG, Algorithm, PortfolioConfiguration
-from strategies.strategy import MyTradingStrategy
+from strategies.my_strategy import MyTradingStrategy
 
 load_dotenv()
 logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)

--- a/investing_algorithm_framework/cli/templates/app_aws_lambda_function.py.template
+++ b/investing_algorithm_framework/cli/templates/app_aws_lambda_function.py.template
@@ -1,48 +1,48 @@
 import logging.config
 import os
-from logging import getLogger
 
 from dotenv import load_dotenv
-from finterion_investing_algorithm_framework import FinterionOrderExecutor, \
-    FinterionPingAction, FinterionPortfolioProvider
-from investing_algorithm_framework import create_app, RESOURCE_DIRECTORY, \
-    AWSS3StorageStateHandler, AWS_S3_STATE_BUCKET_NAME, AWS_LAMBDA_LOGGING_CONFIG
 
-from strategies.strategy import MyTradingStrategy
+from investing_algorithm_framework import (
+    create_app,
+    AWSS3StorageStateHandler,
+    AWS_S3_STATE_BUCKET_NAME,
+    AWS_LAMBDA_LOGGING_CONFIG,
+    RESOURCE_DIRECTORY,
+)
 
+from strategies.my_strategy import MyTradingStrategy
 
-# Make sure to set the resource directory to /tmp because this dir is writable
-app = create_app(config={RESOURCE_DIRECTORY: os.path.join("/tmp", "resources")})
+load_dotenv()
 logging.config.dictConfig(AWS_LAMBDA_LOGGING_CONFIG)
 logger = logging.getLogger(__name__)
 
-# Get the s3 state bucket name from environment variables for database
-# state storage, this is set during the deployment
-# to AWS Lambda with the `deploy_aws_lambda` cli command.
+# Lambda's filesystem is read-only except for /tmp; route the framework's
+# writable resources there.
+app = create_app(
+    config={RESOURCE_DIRECTORY: os.path.join("/tmp", "resources")}
+)
+
+# The S3 bucket is provisioned and exported as an env var by the
+# `deploy_aws_lambda` CLI command.
 app.add_state_handler(
     AWSS3StorageStateHandler(bucket_name=os.getenv(AWS_S3_STATE_BUCKET_NAME))
 )
+
+app.add_market(market="bitvavo", trading_symbol="EUR", initial_balance=1000)
 app.add_strategy(MyTradingStrategy)
-app.add_market(market="BITVAVO", trading_symbol="EUR")
 
 
 def lambda_handler(event, context):
     """
-    AWS Lambda handler function for executing a trading strategy.
-
-    Args:
-        event: dict, the event data passed to the Lambda function.
-        context: object, the context object provided by AWS Lambda.
-
-    Returns:
-        dict: The result of the trading strategy execution.
+    AWS Lambda handler that runs a single iteration of the trading bot.
     """
     try:
-        app.run(payload={"ACTION": "RUN_STRATEGY"})
+        app.run(number_of_iterations=1)
         return {
             "statusCode": 200,
-            "body": "Trading strategy executed successfully."
+            "body": "Trading strategy executed successfully.",
         }
-    except Exception as e:
-        logger.exception(e)
-        return {"statusCode": 500, "body": str(e)}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(exc)
+        return {"statusCode": 500, "body": str(exc)}

--- a/investing_algorithm_framework/cli/templates/app_azure_function.py.template
+++ b/investing_algorithm_framework/cli/templates/app_azure_function.py.template
@@ -1,14 +1,35 @@
+import logging.config
+import os
+
 from dotenv import load_dotenv
 
-from investing_algorithm_framework import create_app, PortfolioConfiguration, \
-    TimeUnit, CCXTOHLCVMarketDataSource, Algorithm, \
-    CCXTTickerMarketDataSource, MarketCredential, AzureBlobStorageStateHandler
-from strategies.strategy import MyTradingStrategy
+from investing_algorithm_framework import (
+    create_app,
+    DEFAULT_LOGGING_CONFIG,
+    AzureBlobStorageStateHandler,
+    RESOURCE_DIRECTORY,
+)
+
+from strategies.my_strategy import MyTradingStrategy
 
 load_dotenv()
+logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
 
-app = create_app()
-app.add_market(market="binance", initial_balance=1000, trading_symbol="EUR")
-algorithm = Algorithm(name="MyTradingBot")
-algorithm.add_strategy(MyTradingStrategy)
-app.add_algorithm(algorithm)
+# Azure Function workers can only write to /tmp at runtime; point the
+# framework's resource directory there so SQLite/state files land in a
+# writable location.
+app = create_app(
+    config={RESOURCE_DIRECTORY: os.path.join("/tmp", "resources")}
+)
+
+# Persist portfolio/state in Azure Blob Storage so the function is
+# stateless across cold starts. Connection string + container name are
+# read from app settings (configured by `deploy_to_azure_function`).
+app.add_state_handler(AzureBlobStorageStateHandler())
+
+app.add_market(
+    market="bitvavo",
+    trading_symbol="EUR",
+    initial_balance=1000,
+)
+app.add_strategy(MyTradingStrategy)

--- a/investing_algorithm_framework/cli/templates/app_web.py.template
+++ b/investing_algorithm_framework/cli/templates/app_web.py.template
@@ -3,7 +3,7 @@ from dotenv import load_dotenv
 
 from investing_algorithm_framework import create_app, \
     DEFAULT_LOGGING_CONFIG, Algorithm
-from strategies.strategy import MyTradingStrategy
+from strategies.my_strategy import MyTradingStrategy
 
 load_dotenv()
 logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)

--- a/investing_algorithm_framework/cli/templates/azure_function_function_app.py.template
+++ b/investing_algorithm_framework/cli/templates/azure_function_function_app.py.template
@@ -1,65 +1,52 @@
-import azure.functions as func
 import logging
-import logging.config
-from investing_algorithm_framework import DEFAULT_LOGGING_CONFIG,\
-    StatelessAction, AzureBlobStorageStateHandler
+import azure.functions as func
+
 from app import app as trading_bot_app
 
-trading_bot_app.add_state_handler(
-    state_handler=AzureBlobStorageStateHandler
-)
+logger = logging.getLogger("investing_algorithm_framework")
 
-logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
 app = func.FunctionApp()
 
-@app.route(route="ping", auth_level=func.AuthLevel.ANONYMOUS)
-def trading_bot(req: func.HttpRequest) -> func.HttpResponse:
-    logging.info("Ping request received.")
 
-    try:
-        response = trading_bot_app.run(
-            payload={"action": StatelessAction.RUN_STRATEGY.value}
-        )
-        return func.HttpResponse(response, status_code=200)
-    except Exception as e:
-        return func.HttpResponse(
-            f"Error running ping action: {e}",
-            status_code=500
-        )
+@app.route(route="ping", auth_level=func.AuthLevel.ANONYMOUS)
+def ping(req: func.HttpRequest) -> func.HttpResponse:
+    """Health check used by deployment scripts and uptime checks."""
+    logger.info("Ping request received.")
+    return func.HttpResponse("pong", status_code=200)
 
 
 @app.route(route="run", auth_level=func.AuthLevel.ANONYMOUS)
 def run_trading_bot(req: func.HttpRequest) -> func.HttpResponse:
-    logging.info("Run request received.")
+    """Manually trigger one strategy run (useful for debugging)."""
+    logger.info("Manual run request received.")
     try:
-        trading_bot_app.run(
-            payload={"action": StatelessAction.RUN_STRATEGY.value}
-        )
-    except Exception as e:
+        trading_bot_app.run(number_of_iterations=1)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Trading bot run failed: %s", exc)
         return func.HttpResponse(
-            f"Error running trading bot: {e}",
-            status_code=500
+            f"Error running trading bot: {exc}", status_code=500
         )
 
     return func.HttpResponse(
-        "Trading bot executed successfully.",
-        status_code=200
+        "Trading bot executed successfully.", status_code=200
     )
+
 
 @app.function_name(name="scheduled_trading_bot_run")
 @app.schedule(
-    schedule="*/30 * * * * *",  # Every 30 seconds Change as needed
+    # Every 5 minutes. Adjust the cron expression to your strategy's
+    # `time_unit` / `interval`. Note: Consumption Plan minimum is ~1 minute.
+    schedule="0 */5 * * * *",
     arg_name="timer",
-    auth_level=func.AuthLevel.ANONYMOUS,
-    run_on_startup=True
+    # `run_on_startup=True` is intentionally NOT set: it blocks the host
+    # readiness probe behind your full strategy initialization, which on
+    # a Consumption cold start frequently kills the worker.
 )
 def scheduled_trading_bot(timer: func.TimerRequest) -> None:
-    logging.info("Scheduled trading bot triggered.")
+    logger.info("Scheduled trading bot triggered.")
     try:
-        trading_bot_app.run(
-            payload={"action": StatelessAction.RUN_STRATEGY.value}
-        )
-    except Exception as e:
-        logging.error(f"Error running scheduled trading bot: {e}")
-        raise e
-    logging.info("Scheduled trading bot executed successfully.")
+        trading_bot_app.run(number_of_iterations=1)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Scheduled trading bot run failed: %s", exc)
+        raise
+    logger.info("Scheduled trading bot executed successfully.")

--- a/investing_algorithm_framework/cli/templates/azure_function_host.json.template
+++ b/investing_algorithm_framework/cli/templates/azure_function_host.json.template
@@ -1,10 +1,16 @@
 {
   "version": "2.0",
   "logging": {
+    "logLevel": {
+      "default": "Information",
+      "Function": "Information",
+      "Host.Aggregator": "Information",
+      "Host.Results": "Information",
+      "investing_algorithm_framework": "Information"
+    },
     "applicationInsights": {
       "samplingSettings": {
-        "isEnabled": true,
-        "excludedTypes": "Request"
+        "isEnabled": true
       }
     }
   },

--- a/investing_algorithm_framework/cli/templates/data_providers.py.template
+++ b/investing_algorithm_framework/cli/templates/data_providers.py.template
@@ -1,17 +1,40 @@
-from investing_algorithm_framework import CCXTOHLCVMarketDataSource, \
-    CCXTTickerMarketDataSource
+"""Optional custom data providers.
 
-btc_eur_ohlcv_2h = CCXTOHLCVMarketDataSource(
-    identifier="BTC/EUR-ohlcv-2h",
-    market="BITVAVO",
-    symbol="BTC/EUR",
-    time_frame="2h",
-    window_size=200
-)
+By default the framework ships with built-in data providers for CCXT
+exchanges, CSV files and pandas DataFrames, so most strategies don't
+need this file at all — they just declare ``DataSource(...)`` entries
+on the strategy class (see ``strategies/my_strategy.py``).
 
-btc_eur_ticker = CCXTTickerMarketDataSource(
-    identifier="BTC/EUR-ticker",
-    market="BITVAVO",
-    symbol="BTC/EUR",
-    backtest_time_frame="2h",
-)
+Define a custom ``DataProvider`` subclass here when you need to:
+
+* pull data from an exchange or vendor that isn't supported out of the
+  box (e.g. an internal REST API, a parquet lake, a websocket feed),
+* preprocess data before it reaches your strategy (resampling, joins,
+  alternative-data merges),
+* serve simulated data in a backtest (e.g. synthetic OHLCV).
+
+Register them with the app via ``app.add_data_provider(MyProvider())``
+in ``app.py``.
+
+Example skeleton (uncomment and adapt):
+
+    import pandas as pd
+    from investing_algorithm_framework import DataProvider, DataType
+
+
+    class MyCustomOHLCVProvider(DataProvider):
+        data_type = DataType.OHLCV
+        market = "MY_VENUE"
+
+        def get_data(
+            self,
+            symbol: str,
+            time_frame: str,
+            start_date,
+            end_date,
+            **kwargs,
+        ) -> pd.DataFrame:
+            # Fetch and return a DataFrame indexed by Datetime with
+            # columns: Open, High, Low, Close, Volume.
+            raise NotImplementedError
+"""

--- a/investing_algorithm_framework/cli/templates/run_backtest.py.template
+++ b/investing_algorithm_framework/cli/templates/run_backtest.py.template
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from investing_algorithm_framework import BacktestDateRange
 from investing_algorithm_framework import create_app
-from strategies.strategy import MyTradingStrategy
+from strategies.my_strategy import MyTradingStrategy
 
 app = create_app()
 app.add_strategy(MyTradingStrategy)

--- a/investing_algorithm_framework/cli/templates/strategy.py.template
+++ b/investing_algorithm_framework/cli/templates/strategy.py.template
@@ -1,124 +1,105 @@
-from investing_algorithm_framework import TimeUnit, TradingStrategy, Context, \
-    OrderSide
-from .data_providers import btc_eur_ohlcv_2h, btc_eur_ticker
-from pyindicators import ema, is_crossover, is_above, is_below, is_crossunder
+"""Sample trading strategy.
+
+A strategy is *declarative*: declare your data sources and implement
+``generate_buy_signals`` / ``generate_sell_signals``. Each must return a
+dict mapping ``symbol -> pd.Series[bool]`` with the same index as the
+incoming OHLCV data. The framework handles order routing, position
+sizing, stop-loss and take-profit on top of those signals.
+
+This same strategy is used by both the vector-backtest engine and the
+event-driven engine (and live), which guarantees that what you backtest
+is what you deploy.
+"""
+from typing import Any, Dict
+
+import pandas as pd
+from pyindicators import sma, crossover, crossunder
+
+from investing_algorithm_framework import (
+    TradingStrategy,
+    DataSource,
+    DataType,
+    TimeUnit,
+    PositionSize,
+    StopLossRule,
+    TakeProfitRule,
+)
 
 
 class MyTradingStrategy(TradingStrategy):
-    """
-    A simple trading strategy that uses EMA crossovers to generate buy and
-    sell signals. The strategy uses a 50-period EMA and a 100-period EMA
-    to detect golden and death crosses. It also uses a 200-period EMA to
-    determine the overall trend direction. The strategy trades BTC/EUR
-    on a 2-hour timeframe. The strategy is designed to be used with the
-    Investing Algorithm Framework and uses the PyIndicators library
-    to calculate the EMAs and crossover signals.
+    """Simple SMA-crossover strategy on BTC/EUR (1h)."""
 
-    The strategy uses a trailing stop loss and take profit to manage
-    risk. The stop loss is set to 5% below the entry price and the
-    take profit is set to 10% above the entry price. The stop loss and
-    take profit are both trailing, meaning that they will move up
-    with the price when the price goes up.
-    """
     time_unit = TimeUnit.HOUR
-    interval = 2
-    symbol_pairs = ["BTC/EUR"]
-    market_data_sources = [btc_eur_ohlcv_2h, btc_eur_ticker]
-    fast = 50
-    slow = 100
-    trend = 200
-    stop_loss_percentage = 2
-    stop_loss_sell_size = 50
-    take_profit_percentage = 8
-    take_profit_sell_size = 50
+    interval = 1
+    symbols = ["BTC"]
 
-    def apply_strategy(self, context: Context, market_data):
+    # SMA periods, exposed as class attributes so they're easy to
+    # override from a parameter grid search.
+    fast_period = 20
+    slow_period = 50
 
-        for pair in self.symbol_pairs:
-            symbol = pair.split('/')[0]
+    data_sources = [
+        DataSource(
+            identifier="btc_eur_ohlcv_1h",
+            data_type=DataType.OHLCV,
+            symbol="BTC/EUR",
+            time_frame="1h",
+            market="BITVAVO",
+            window_size=200,
+            pandas=True,
+        ),
+    ]
 
-            # Don't trade if there are open orders for the symbol
-            # This is important to avoid placing new orders while there are
-            # existing orders that are not yet filled
-            if context.has_open_orders(symbol):
-                continue
+    # Risk management — applied automatically by the framework after a
+    # buy order is filled.
+    position_sizes = [
+        PositionSize(symbol="BTC", percentage_of_portfolio=100),
+    ]
+    stop_losses = [
+        StopLossRule(
+            symbol="BTC",
+            percentage_threshold=5.0,
+            sell_percentage=100,
+            trailing=True,
+        ),
+    ]
+    take_profits = [
+        TakeProfitRule(
+            symbol="BTC",
+            percentage_threshold=10.0,
+            sell_percentage=100,
+        ),
+    ]
 
-            ohlvc_data = market_data[f"{pair}-ohlcv-2h"]
-            # ticker_data = market_data[f"{symbol}-ticker"]
-            # Add fast, slow, and trend EMAs to the data
-            ohlvc_data = ema(
-                ohlvc_data,
-                source_column="Close",
-                period=self.fast,
-                result_column=f"ema_{self.fast}"
-            )
-            ohlvc_data = ema(
-                ohlvc_data,
-                source_column="Close",
-                period=self.slow,
-                result_column=f"ema_{self.slow}"
-            )
-            ohlvc_data = ema(
-                ohlvc_data,
-                source_column="Close",
-                period=self.trend,
-                result_column=f"ema_{self.trend}"
-            )
-
-            price = ohlvc_data["Close"][-1]
-
-            if not context.has_position(symbol) \
-                    and self._is_buy_signal(ohlvc_data):
-                order = context.create_limit_order(
-                    target_symbol=symbol,
-                    order_side=OrderSide.BUY,
-                    price=price,
-                    percentage_of_portfolio=25,
-                    precision=4,
-                )
-                trade = context.get_trade(order_id=order.id)
-                context.add_stop_loss(
-                    trade=trade,
-                    trade_risk_type="trailing",
-                    percentage=self.stop_loss_percentage,
-                    sell_percentage=self.stop_loss_sell_size
-                )
-                context.add_take_profit(
-                    trade=trade,
-                    percentage=self.take_profit_percentage,
-                    trade_risk_type="trailing",
-                    sell_percentage=self.take_profit_sell_size
-                )
-
-            if context.has_position(symbol) \
-                    and self._is_sell_signal(ohlvc_data):
-                open_trades = context.get_open_trades(
-                    target_symbol=symbol
-                )
-
-                for trade in open_trades:
-                    context.close_trade(trade)
-
-    def _is_sell_signal(self, data):
-        return is_crossunder(
-            data,
-            first_column=f"ema_{self.fast}",
-            second_column=f"ema_{self.slow}",
-            number_of_data_points=2
-        ) and is_below(
-            data,
-            first_column=f"ema_{self.fast}",
-            second_column=f"ema_{self.trend}",
+    def _add_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = sma(
+            df,
+            period=self.fast_period,
+            source_column="Close",
+            result_column="sma_fast",
         )
-
-    def _is_buy_signal(self, data):
-        return is_crossover(
-            data=data,
-            first_column=f"ema_{self.fast}",
-            second_column=f"ema_{self.slow}",
-            number_of_data_points=2
-        ) and is_above(
-            data=data,
-            first_column=f"ema_{self.fast}",
-            second_column=f"ema_{self.trend}",
+        df = sma(
+            df,
+            period=self.slow_period,
+            source_column="Close",
+            result_column="sma_slow",
         )
+        return df
+
+    def generate_buy_signals(
+        self, data: Dict[str, Any]
+    ) -> Dict[str, pd.Series]:
+        df = self._add_indicators(data["btc_eur_ohlcv_1h"])
+        df = crossover(
+            df, "sma_fast", "sma_slow", result_column="cross_up"
+        )
+        return {"BTC": df["cross_up"].fillna(False).astype(bool)}
+
+    def generate_sell_signals(
+        self, data: Dict[str, Any]
+    ) -> Dict[str, pd.Series]:
+        df = self._add_indicators(data["btc_eur_ohlcv_1h"])
+        df = crossunder(
+            df, "sma_fast", "sma_slow", result_column="cross_down"
+        )
+        return {"BTC": df["cross_down"].fillna(False).astype(bool)}

--- a/investing_algorithm_framework/domain/backtesting/backtest.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest.py
@@ -172,6 +172,17 @@ class Backtest:
             return run.backtest_metrics
         return None
 
+    def get_backtest_summary(self) -> Union[BacktestSummaryMetrics, None]:
+        """
+        Retrieve the cross-window BacktestSummaryMetrics roll-up for
+        this backtest.
+
+        Returns:
+            Union[BacktestSummaryMetrics, None]: The summary metrics if
+                they have been computed, otherwise None.
+        """
+        return self.backtest_summary
+
     def to_dict(self) -> dict:
         """
         Convert the Backtest instance to a dictionary.

--- a/investing_algorithm_framework/services/metrics/generate.py
+++ b/investing_algorithm_framework/services/metrics/generate.py
@@ -3,6 +3,7 @@ from logging import getLogger
 import gc
 import os
 import sys
+import warnings
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor, wait, FIRST_COMPLETED
 
@@ -281,19 +282,20 @@ def recalculate_backtests(
     max_tasks_per_child: Optional[int] = 16,
 ) -> List[Backtest]:
     """
-    Recalculate all metrics for a set of backtests.
+    Recalculate all metrics for a set of in-memory backtests.
 
-    .. warning::
-
-        This function holds every backtest in *backtests* in the
-        parent process simultaneously. For very large batches
-        (thousands of backtests with portfolio snapshots / trades)
-        prefer :func:`recalculate_backtests_in_directory`, which
-        streams from disk in worker processes and never accumulates
-        backtests in the parent.
+    .. deprecated:: 8.7.2
+        Holding many backtests in the parent process is memory-unsafe:
+        each :class:`Backtest` carries portfolio snapshots, trades and
+        timeseries, so a list of a few thousand backtests can easily
+        consume tens of gigabytes before any work starts. Use
+        :func:`recalculate_backtests_in_directory` instead — it streams
+        backtests from disk inside worker processes and never
+        materialises a ``List[Backtest]`` in the parent. This function
+        will be removed in a future major release.
 
     Args:
-        backtests: The backtests to recalculate.
+        backtests: The backtests to recalculate (mutated in place).
         risk_free_rate: Risk-free rate to use. If ``None``, uses each
             backtest's own ``risk_free_rate`` (falling back to ``0.0``).
         metrics: Metric names to compute. ``None`` uses the default set.
@@ -307,6 +309,16 @@ def recalculate_backtests(
     Returns:
         The same backtest objects, mutated in place.
     """
+    warnings.warn(
+        "recalculate_backtests(List[Backtest]) is deprecated and will "
+        "be removed in a future major release: holding many backtests "
+        "in the parent process is memory-unsafe. Use "
+        "recalculate_backtests_in_directory(src_dir, ...) instead, "
+        "which streams from disk inside worker processes and keeps "
+        "parent memory flat.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not backtests:
         return backtests
 

--- a/tests/services/metrics/test_recalculate_backtests.py
+++ b/tests/services/metrics/test_recalculate_backtests.py
@@ -1,8 +1,16 @@
 import os
+import warnings
 from unittest import TestCase
 
 from investing_algorithm_framework import (
     Backtest, recalculate_backtests,
+)
+
+# These tests intentionally exercise the deprecated in-memory API.
+warnings.filterwarnings(
+    "ignore",
+    message=r"recalculate_backtests\(List\[Backtest\]\) is deprecated.*",
+    category=DeprecationWarning,
 )
 
 


### PR DESCRIPTION
Combines the recent dev work into a single PR for main.

## Highlights

### Docs
- New `Getting Started/metrics.md` with full reference for both `BacktestMetrics` (per-run) and `BacktestSummaryMetrics` (cross-window roll-up), grouped by domain (returns, risk-adjusted, drawdown, per-trade, win/loss, exposure, multi-window robustness)
- `Backtest.get_backtest_summary()` getter added for symmetry with the other run/metrics getters
- README feature bullets now deep-link to the relevant docs pages
- `application-setup.md`: formatted folder tree, fixed notebook table, rewrote MyStrategy example with the declarative `generate_buy_signals` / `generate_sell_signals` API

### Deprecations
- `recalculate_backtests(List[Backtest])` is now deprecated (`DeprecationWarning`) and will be removed in a future major release. Holding many backtests in the parent process is memory-unsafe (each `Backtest` carries portfolio snapshots, trades and timeseries — thousands of them can easily consume tens of GB before any work starts). Use `recalculate_backtests_in_directory(src_dir, ...)` instead, which streams backtests from disk inside worker processes and keeps parent memory flat.

### CLI
- `init` now scaffolds the recommended project layout (`data/`, `backtest_results/`, `reports/`, `resources/`, notebooks, `.gitkeep` markers)
- All variant templates (`default`, `default-web`, `aws-lambda`, `azure-function`) rewritten for the current declarative `TradingStrategy` API
- Azure variant now correctly emits `function_app.py` (Azure Functions Python v2 model)

### Azure Function deployment
- `deploy_to_azure_function` now polls for app readiness instead of `time.sleep(60)`
- Pushes app settings (`SCM_DO_BUILD_DURING_DEPLOYMENT`, `ENABLE_ORYX_BUILD`) before publish
- Adds `--build remote --python` to `func azure functionapp publish` (mandatory for native wheels on Linux Consumption)
- Bumped runtime 3.10 → 3.11
- Fixed CORS process await bug; CORS errors downgraded to warnings
- `host.json` no longer hides Request traces; explicit `Information` log level for the framework logger
- Prints `az webapp log tail` command at end

### Security
- npm `overrides` block in `docusaurus/package.json` pinning `serialize-javascript ^7.0.5` and `postcss ^8.5.10`
- Closes 3 open Dependabot alerts (1 high, 2 moderate)
- `npm audit` now reports 0 vulnerabilities