### PR TITLE
Add headers for external URL data sources

### DIFF
--- a/docusaurus/docs/Data/external-data.md
+++ b/docusaurus/docs/Data/external-data.md
@@ -13,7 +13,7 @@ The framework provides two ways to load external data:
 1. **Data Sources** — Declare `DataSource.from_csv()`, `DataSource.from_json()`, or `DataSource.from_parquet()` in your strategy's `data_sources` list. Data is fetched automatically and available in your `data` dict.
 2. **Context methods** — Call `context.fetch_csv()`, `context.fetch_json()`, or `context.fetch_parquet()` on demand inside your strategy's `run_strategy` method.
 
-Both approaches support caching, refresh intervals, date parsing, and pre/post-processing callbacks.
+Both approaches support caching, refresh intervals, date parsing, request headers, and pre/post-processing callbacks.
 
 ## Supported Formats
 
@@ -112,6 +112,7 @@ class MyStrategy(TradingStrategy):
         earnings = context.fetch_json(
             url="https://api.example.com/earnings",
             date_column="report_date",
+            headers={"Authorization": "Bearer <token>"},
         )
 
         # Fetch Parquet on demand
@@ -132,8 +133,49 @@ All three factory methods and context methods accept the same core parameters:
 | `date_format` | `str` | `None` | strftime format for parsing dates (e.g., `"%Y-%m-%d"`). Auto-detected if omitted. |
 | `cache` | `bool` | `True` | Cache fetched data locally to avoid repeated downloads. |
 | `refresh_interval` | `str` | `None` | How often to re-fetch: `"1m"`, `"5m"`, `"15m"`, `"30m"`, `"1h"`, `"4h"`, `"1d"`, `"1W"`. |
+| `headers` | `dict` | `None` | Optional HTTP headers to send with the request, such as API keys or bearer tokens. |
 | `pre_process` | `callable` | `None` | Transform raw text before parsing. Receives `str`, returns `str`. Not available for Parquet. |
 | `post_process` | `callable` | `None` | Transform the parsed DataFrame. Receives `DataFrame`, returns `DataFrame`. |
+
+## Authenticated APIs
+
+Use `headers` when an external data API requires authentication. For example, Adanos Market Sentiment can be loaded as an optional alternative-data signal without writing a custom provider:
+
+```python
+import json
+import os
+
+import polars as pl
+
+from investing_algorithm_framework import TimeUnit, TradingStrategy
+
+
+def extract_adanos_stocks(raw_text):
+    payload = json.loads(raw_text)
+    return json.dumps(payload.get("stocks", []))
+
+
+class SentimentStrategy(TradingStrategy):
+    time_unit = TimeUnit.DAY
+    interval = 1
+    symbols = ["AAPL", "MSFT"]
+
+    def run_strategy(self, context, data):
+        sentiment = context.fetch_json(
+            url=(
+                "https://api.adanos.org/news/stocks/v1/compare"
+                "?tickers=AAPL,MSFT&days=7"
+            ),
+            headers={"X-API-Key": os.environ["ADANOS_API_KEY"]},
+            pre_process=extract_adanos_stocks,
+            cache=True,
+            refresh_interval="1d",
+        )
+
+        aapl = sentiment.filter(pl.col("ticker") == "AAPL")
+        if len(aapl) and aapl["sentiment_score"][0] > 0.2:
+            context.create_limit_order(...)
+```
 
 ## Pre/Post Processing
 

--- a/investing_algorithm_framework/app/context.py
+++ b/investing_algorithm_framework/app/context.py
@@ -2092,6 +2092,15 @@ class Context:
 
         return self.trade_stop_loss_service.get_all(query_params)
 
+    def _get_url_provider_cache_key(self, url, headers):
+        if not headers:
+            return url
+
+        return (
+            url,
+            tuple(sorted(headers.items()))
+        )
+
     def fetch_csv(
         self,
         url,
@@ -2099,6 +2108,7 @@ class Context:
         date_format=None,
         cache=True,
         refresh_interval=None,
+        headers=None,
         pre_process=None,
         post_process=None,
     ):
@@ -2118,6 +2128,8 @@ class Context:
             cache (bool): Cache fetched data locally (default: True).
             refresh_interval (str, optional): Re-fetch interval
                 (e.g., "1d", "1h").
+            headers (dict, optional): HTTP headers to send with the
+                request.
             pre_process (callable, optional): Transform raw CSV text
                 before parsing.
             post_process (callable, optional): Transform the parsed
@@ -2141,20 +2153,23 @@ class Context:
         if not hasattr(self, '_csv_url_providers'):
             self._csv_url_providers = {}
 
-        if url not in self._csv_url_providers:
+        provider_key = self._get_url_provider_cache_key(url, headers)
+
+        if provider_key not in self._csv_url_providers:
             provider = CSVURLDataProvider(
                 url=url,
                 date_column=date_column,
                 date_format=date_format,
                 cache=cache,
                 refresh_interval=refresh_interval,
+                headers=headers,
                 pre_process=pre_process,
                 post_process=post_process,
             )
             provider.config = self.configuration_service.get_config()
-            self._csv_url_providers[url] = provider
+            self._csv_url_providers[provider_key] = provider
 
-        return self._csv_url_providers[url].get_data()
+        return self._csv_url_providers[provider_key].get_data()
 
     def fetch_json(
         self,
@@ -2163,6 +2178,7 @@ class Context:
         date_format=None,
         cache=True,
         refresh_interval=None,
+        headers=None,
         pre_process=None,
         post_process=None,
     ):
@@ -2185,6 +2201,8 @@ class Context:
             cache (bool): Cache fetched data locally (default: True).
             refresh_interval (str, optional): Re-fetch interval
                 (e.g., "1d", "1h").
+            headers (dict, optional): HTTP headers to send with the
+                request.
             pre_process (callable, optional): Transform raw JSON text
                 before parsing.
             post_process (callable, optional): Transform the parsed
@@ -2207,20 +2225,23 @@ class Context:
         if not hasattr(self, '_json_url_providers'):
             self._json_url_providers = {}
 
-        if url not in self._json_url_providers:
+        provider_key = self._get_url_provider_cache_key(url, headers)
+
+        if provider_key not in self._json_url_providers:
             provider = JSONURLDataProvider(
                 url=url,
                 date_column=date_column,
                 date_format=date_format,
                 cache=cache,
                 refresh_interval=refresh_interval,
+                headers=headers,
                 pre_process=pre_process,
                 post_process=post_process,
             )
             provider.config = self.configuration_service.get_config()
-            self._json_url_providers[url] = provider
+            self._json_url_providers[provider_key] = provider
 
-        return self._json_url_providers[url].get_data()
+        return self._json_url_providers[provider_key].get_data()
 
     def fetch_parquet(
         self,
@@ -2229,6 +2250,7 @@ class Context:
         date_format=None,
         cache=True,
         refresh_interval=None,
+        headers=None,
         post_process=None,
     ):
         """
@@ -2247,6 +2269,8 @@ class Context:
             cache (bool): Cache fetched data locally (default: True).
             refresh_interval (str, optional): Re-fetch interval
                 (e.g., "1d", "1h").
+            headers (dict, optional): HTTP headers to send with the
+                request.
             post_process (callable, optional): Transform the parsed
                 DataFrame.
 
@@ -2266,19 +2290,22 @@ class Context:
         if not hasattr(self, '_parquet_url_providers'):
             self._parquet_url_providers = {}
 
-        if url not in self._parquet_url_providers:
+        provider_key = self._get_url_provider_cache_key(url, headers)
+
+        if provider_key not in self._parquet_url_providers:
             provider = ParquetURLDataProvider(
                 url=url,
                 date_column=date_column,
                 date_format=date_format,
                 cache=cache,
                 refresh_interval=refresh_interval,
+                headers=headers,
                 post_process=post_process,
             )
             provider.config = self.configuration_service.get_config()
-            self._parquet_url_providers[url] = provider
+            self._parquet_url_providers[provider_key] = provider
 
-        return self._parquet_url_providers[url].get_data()
+        return self._parquet_url_providers[provider_key].get_data()
 
     def batch_order(self, orders, market=None):
         """

--- a/investing_algorithm_framework/domain/models/data/data_source.py
+++ b/investing_algorithm_framework/domain/models/data/data_source.py
@@ -47,6 +47,7 @@ class DataSource:
     date_format: Optional[str] = None
     cache: bool = True
     refresh_interval: Optional[str] = None
+    headers: Optional[dict] = None
     pre_process: Optional[Callable] = field(
         default=None, repr=False, compare=False
     )
@@ -133,6 +134,7 @@ class DataSource:
         date_format: str = None,
         cache: bool = True,
         refresh_interval: str = None,
+        headers: dict = None,
         pre_process: Callable = None,
         post_process: Callable = None,
     ) -> "DataSource":
@@ -149,6 +151,7 @@ class DataSource:
             refresh_interval: How often to re-fetch the data
                 (e.g., "1d", "1h"). If None, data is fetched once and
                 cached indefinitely.
+            headers: Optional HTTP headers to send with the request.
             pre_process: Optional callback to transform the raw CSV
                 text before parsing. Receives a string, must return
                 a string.
@@ -178,6 +181,7 @@ class DataSource:
             date_format=date_format,
             cache=cache,
             refresh_interval=refresh_interval,
+            headers=headers,
             pre_process=pre_process,
             post_process=post_process,
         )
@@ -191,6 +195,7 @@ class DataSource:
         date_format: str = None,
         cache: bool = True,
         refresh_interval: str = None,
+        headers: dict = None,
         pre_process: Callable = None,
         post_process: Callable = None,
     ) -> "DataSource":
@@ -209,6 +214,7 @@ class DataSource:
                 (default: True).
             refresh_interval: How often to re-fetch the data
                 (e.g., "1d", "1h").
+            headers: Optional HTTP headers to send with the request.
             pre_process: Optional callback to transform the raw JSON
                 text before parsing. Receives a string, must return
                 a string.
@@ -234,6 +240,7 @@ class DataSource:
             date_format=date_format,
             cache=cache,
             refresh_interval=refresh_interval,
+            headers=headers,
             pre_process=pre_process,
             post_process=post_process,
         )
@@ -247,6 +254,7 @@ class DataSource:
         date_format: str = None,
         cache: bool = True,
         refresh_interval: str = None,
+        headers: dict = None,
         post_process: Callable = None,
     ) -> "DataSource":
         """
@@ -262,6 +270,7 @@ class DataSource:
                 (default: True).
             refresh_interval: How often to re-fetch the data
                 (e.g., "1d", "1h").
+            headers: Optional HTTP headers to send with the request.
             post_process: Optional callback to transform the parsed
                 DataFrame.
 
@@ -284,6 +293,7 @@ class DataSource:
             date_format=date_format,
             cache=cache,
             refresh_interval=refresh_interval,
+            headers=headers,
             post_process=post_process,
         )
 
@@ -330,6 +340,10 @@ class DataSource:
             non_null_attributes['data_type'] = self.data_type.value
         if self.time_frame is not None:
             non_null_attributes['time_frame'] = self.time_frame.value
+        if self.headers is not None:
+            non_null_attributes['headers'] = {
+                key: "***" for key in self.headers
+            }
 
         return non_null_attributes
 

--- a/investing_algorithm_framework/infrastructure/data_providers/base_url.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/base_url.py
@@ -45,6 +45,7 @@ class BaseURLDataProvider(DataProvider):
         date_format=None,
         cache=True,
         refresh_interval=None,
+        headers=None,
         pre_process=None,
         post_process=None,
         priority=5,
@@ -62,6 +63,7 @@ class BaseURLDataProvider(DataProvider):
         self._date_format = date_format
         self._cache = cache
         self._refresh_interval = refresh_interval
+        self._headers = headers or {}
         self._pre_process = pre_process
         self._post_process = post_process
         self._cached_data = None
@@ -194,6 +196,7 @@ class BaseURLDataProvider(DataProvider):
         date_format = self._date_format
         cache = self._cache
         refresh_interval = self._refresh_interval
+        headers = self._headers
         pre_process = self._pre_process
         post_process = self._post_process
         identifier = self.data_provider_identifier
@@ -206,6 +209,7 @@ class BaseURLDataProvider(DataProvider):
                 else cache
             refresh_interval = data_source.refresh_interval \
                 or refresh_interval
+            headers = data_source.headers or headers
             pre_process = data_source.pre_process or pre_process
             post_process = data_source.post_process or post_process
 
@@ -215,6 +219,7 @@ class BaseURLDataProvider(DataProvider):
             date_format=date_format,
             cache=cache,
             refresh_interval=refresh_interval,
+            headers=headers,
             pre_process=pre_process,
             post_process=post_process,
             priority=self.priority,
@@ -277,9 +282,11 @@ class BaseURLDataProvider(DataProvider):
 
         # Fetch from URL
         ctx = ssl.create_default_context()
+        headers = {"User-Agent": "investing-algorithm-framework"}
+        headers.update(self._headers)
         req = urllib.request.Request(
             url,
-            headers={"User-Agent": "investing-algorithm-framework"}
+            headers=headers
         )
         with urllib.request.urlopen(req, context=ctx) as response:
             raw_bytes = response.read()
@@ -350,8 +357,12 @@ class BaseURLDataProvider(DataProvider):
         if storage_dir is None:
             storage_dir = os.path.join(os.getcwd(), ".data_cache")
 
+        cache_key = self._url
+        if self._headers:
+            cache_key = f"{cache_key}|headers:{sorted(self._headers.items())}"
+
         url_hash = hashlib.md5(
-            self._url.encode()
+            cache_key.encode()
         ).hexdigest()[:12]
         suffix = self._cache_file_suffix()
         return os.path.join(storage_dir, f"url_{url_hash}{suffix}")

--- a/tests/domain/models/data/test_data_source.py
+++ b/tests/domain/models/data/test_data_source.py
@@ -119,7 +119,7 @@ class TestDataSource(TestCase):
         self.assertNotEqual(data_source1, data_source2)
 
     def test_data_source_in_set_uniqueness(self):
-        """Test that DataSource instances are unique in sets based on all attributes"""
+        """Test DataSource set uniqueness based on all attributes"""
         data_source1 = DataSource(
             data_provider_identifier="provider1",
             data_type=DataType.OHLCV,
@@ -159,9 +159,14 @@ class TestDataSource(TestCase):
             market="binance"
         )
 
-        data_sources_set = {data_source1, data_source2, data_source3, data_source4}
+        data_sources_set = {
+            data_source1,
+            data_source2,
+            data_source3,
+            data_source4,
+        }
 
-        # Should only have 3 unique data sources (data_source1 and data_source2 are the same)
+        # data_source1 and data_source2 are the same.
         self.assertEqual(len(data_sources_set), 3)
         self.assertIn(data_source1, data_sources_set)
         self.assertIn(data_source3, data_sources_set)
@@ -223,11 +228,11 @@ class TestDataSource(TestCase):
         )  # Same as data_source1
 
         set1 = {data_source1, data_source2}
-        set2 = {data_source3, data_source2}  # data_source3 is same as data_source1
+        set2 = {data_source3, data_source2}
 
         # Test intersection
         intersection = set1 & set2
-        self.assertEqual(len(intersection), 2)  # Both data sources are in common
+        self.assertEqual(len(intersection), 2)
 
         # Test union
         union = set1 | set2
@@ -235,7 +240,7 @@ class TestDataSource(TestCase):
 
         # Test difference
         difference = set1 - set2
-        self.assertEqual(len(difference), 0)  # No difference since sets are equal
+        self.assertEqual(len(difference), 0)
 
     def test_data_source_uniqueness_edge_cases(self):
         """Test uniqueness with edge cases like None values"""
@@ -261,7 +266,9 @@ class TestDataSource(TestCase):
         try:
             data_source.symbol = "ETH/USD"
             # If we reach here, the class is not frozen
-            self.skipTest("DataSource is not frozen, skipping immutability test")
+            self.skipTest(
+                "DataSource is not frozen, skipping immutability test"
+            )
         except FrozenInstanceError:
             # This is expected behavior when frozen=True
             pass
@@ -283,6 +290,28 @@ class TestDataSource(TestCase):
         self.assertIsNone(data_source.window_size)
         self.assertIsNone(data_source.time_frame)
         self.assertIsNone(data_source.market)
+
+    def test_to_dict_redacts_headers(self):
+        data_source = DataSource.from_json(
+            identifier="sentiment",
+            url="https://api.example.com/sentiment",
+            headers={
+                "Authorization": "Bearer secret-token",
+                "X-API-Key": "secret-key",
+            },
+        )
+
+        data = data_source.to_dict()
+
+        self.assertEqual(
+            data["headers"],
+            {
+                "Authorization": "***",
+                "X-API-Key": "***",
+            }
+        )
+        self.assertNotIn("secret-token", str(data))
+        self.assertNotIn("secret-key", str(data))
 
     def test_data_source_window_size_types(self):
         """Test DataSource with different window_size values"""
@@ -354,6 +383,7 @@ class TestDataSource(TestCase):
             "date_format",
             "cache",
             "refresh_interval",
+            "headers",
             "pre_process",
             "post_process"
         ]

--- a/tests/infrastructure/data_providers/test_csv_url_data_provider.py
+++ b/tests/infrastructure/data_providers/test_csv_url_data_provider.py
@@ -44,6 +44,7 @@ class TestDataSourceFromCsv(unittest.TestCase):
             date_format="%m/%d/%Y",
             cache=False,
             refresh_interval="1d",
+            headers={"X-API-Key": "test-key"},
             pre_process=pre,
             post_process=post,
         )
@@ -51,6 +52,7 @@ class TestDataSourceFromCsv(unittest.TestCase):
         self.assertEqual(ds.url, "https://example.com/earnings.csv")
         self.assertFalse(ds.cache)
         self.assertEqual(ds.refresh_interval, "1d")
+        self.assertEqual(ds.headers, {"X-API-Key": "test-key"})
         self.assertEqual(ds.pre_process, pre)
         self.assertEqual(ds.post_process, post)
 
@@ -72,6 +74,7 @@ class TestDataSourceFromCsv(unittest.TestCase):
         self.assertIsNone(ds.date_format)
         self.assertTrue(ds.cache)
         self.assertIsNone(ds.refresh_interval)
+        self.assertIsNone(ds.headers)
         self.assertIsNone(ds.pre_process)
         self.assertIsNone(ds.post_process)
 
@@ -160,7 +163,10 @@ class TestCSVURLDataProvider(unittest.TestCase):
 
         def add_header_comment(text):
             # Remove any comment lines
-            lines = [line for line in text.split("\n") if not line.startswith("#")]
+            lines = [
+                line for line in text.split("\n")
+                if not line.startswith("#")
+            ]
             return "\n".join(lines)
 
         provider = CSVURLDataProvider(

--- a/tests/infrastructure/data_providers/test_json_url_data_provider.py
+++ b/tests/infrastructure/data_providers/test_json_url_data_provider.py
@@ -44,6 +44,14 @@ class TestDataSourceFromJson(unittest.TestCase):
         self.assertIsNone(ds.pre_process)
         self.assertIsNone(ds.post_process)
 
+    def test_from_json_accepts_headers(self):
+        ds = DataSource.from_json(
+            identifier="sentiment",
+            url="https://api.example.com/sentiment",
+            headers={"X-API-Key": "test-key"},
+        )
+        self.assertEqual(ds.headers, {"X-API-Key": "test-key"})
+
 
 class TestJSONURLDataProvider(unittest.TestCase):
     """Tests for JSONURLDataProvider."""
@@ -123,6 +131,40 @@ class TestJSONURLDataProvider(unittest.TestCase):
         self.assertEqual(len(df), 2)
 
     @patch(MOCK_TARGET)
+    def test_get_data_sends_configured_headers(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen()
+
+        provider = JSONURLDataProvider(
+            url="https://api.example.com/sentiment",
+            headers={"X-API-Key": "test-key"},
+            cache=False,
+        )
+
+        provider.get_data()
+
+        request = mock_urlopen.call_args.args[0]
+        self.assertEqual(request.headers["X-api-key"], "test-key")
+        self.assertEqual(
+            request.headers["User-agent"],
+            "investing-algorithm-framework"
+        )
+
+    def test_cache_path_includes_headers(self):
+        provider_a = JSONURLDataProvider(
+            url="https://api.example.com/sentiment",
+            headers={"X-API-Key": "key-a"},
+        )
+        provider_b = JSONURLDataProvider(
+            url="https://api.example.com/sentiment",
+            headers={"X-API-Key": "key-b"},
+        )
+
+        self.assertNotEqual(
+            provider_a._get_cache_path(),
+            provider_b._get_cache_path()
+        )
+
+    @patch(MOCK_TARGET)
     def test_get_data_with_date_parsing(self, mock_urlopen):
         mock_urlopen.return_value = self._mock_urlopen()
 
@@ -186,12 +228,14 @@ class TestJSONURLDataProvider(unittest.TestCase):
     def test_copy_with_data_source_overrides(self):
         provider = JSONURLDataProvider(
             url="https://example.com/default.json",
+            headers={"X-API-Key": "default-key"},
         )
 
         ds = DataSource.from_json(
             identifier="test",
             url="https://example.com/override.json",
             date_column="my_date",
+            headers={"X-API-Key": "override-key"},
         )
 
         copied = provider.copy(data_source=ds)
@@ -199,6 +243,7 @@ class TestJSONURLDataProvider(unittest.TestCase):
             copied._url, "https://example.com/override.json"
         )
         self.assertEqual(copied._date_column, "my_date")
+        self.assertEqual(copied._headers, {"X-API-Key": "override-key"})
 
     def test_raises_on_missing_url(self):
         provider = JSONURLDataProvider(cache=False)

--- a/tests/infrastructure/data_providers/test_parquet_url_data_provider.py
+++ b/tests/infrastructure/data_providers/test_parquet_url_data_provider.py
@@ -39,6 +39,17 @@ class TestDataSourceFromParquet(unittest.TestCase):
         )
         self.assertTrue(ds.cache)
 
+    def test_from_parquet_accepts_headers(self):
+        ds = DataSource.from_parquet(
+            identifier="features",
+            url="https://storage.example.com/features.parquet",
+            headers={"Authorization": "Bearer test-token"},
+        )
+        self.assertEqual(
+            ds.headers,
+            {"Authorization": "Bearer test-token"}
+        )
+
     def test_from_parquet_defaults(self):
         ds = DataSource.from_parquet(
             identifier="test",
@@ -48,6 +59,7 @@ class TestDataSourceFromParquet(unittest.TestCase):
         self.assertIsNone(ds.date_format)
         self.assertTrue(ds.cache)
         self.assertIsNone(ds.refresh_interval)
+        self.assertIsNone(ds.headers)
         self.assertIsNone(ds.post_process)
 
     def test_from_parquet_no_pre_process(self):


### PR DESCRIPTION
## Summary
- add optional HTTP `headers` support to external CSV, JSON, and Parquet URL data sources
- pass headers through `context.fetch_csv`, `context.fetch_json`, and `context.fetch_parquet`, with cache keys separated by headers
- redact configured header values from `DataSource.to_dict()` so API keys do not appear in diagnostic/error payloads
- document authenticated external APIs with an optional Adanos Market Sentiment example
- add tests for CSV/JSON/Parquet DataSource header storage, request header propagation, provider copy overrides, cache separation, redacted diagnostics, and the updated dataclass field list

## Validation
- `.venv/bin/python -m pytest tests/ -q` — `1605 passed, 42 skipped, 103 warnings, 47 subtests passed`
- `.venv/bin/python -m pytest tests/domain/models/data/test_data_source.py tests/infrastructure/data_providers/test_csv_url_data_provider.py tests/infrastructure/data_providers/test_json_url_data_provider.py tests/infrastructure/data_providers/test_parquet_url_data_provider.py -q`
- `.venv/bin/python -m flake8 investing_algorithm_framework/domain/models/data/data_source.py investing_algorithm_framework/infrastructure/data_providers/base_url.py investing_algorithm_framework/app/context.py tests/domain/models/data/test_data_source.py tests/infrastructure/data_providers/test_csv_url_data_provider.py tests/infrastructure/data_providers/test_json_url_data_provider.py tests/infrastructure/data_providers/test_parquet_url_data_provider.py`
- `.venv/bin/python -m py_compile investing_algorithm_framework/domain/models/data/data_source.py investing_algorithm_framework/infrastructure/data_providers/base_url.py investing_algorithm_framework/app/context.py tests/domain/models/data/test_data_source.py tests/infrastructure/data_providers/test_csv_url_data_provider.py tests/infrastructure/data_providers/test_json_url_data_provider.py tests/infrastructure/data_providers/test_parquet_url_data_provider.py`
- `git diff --check`
