### PR TITLE
feat(backtest): BacktestIndexRow DTO + Backtest.index_row() — epic #540 phase 1

### DIFF
--- a/docs/design/tiered-backtest-storage.md
+++ b/docs/design/tiered-backtest-storage.md
@@ -82,6 +82,14 @@ Row size: ~1–2 KB. 12,500 rows ≈ 25 MB. Fits comfortably in SQLite for local
 > existing `BacktestIndex` Parquet sidecar is now built on top of this
 > typed row (`BacktestIndexRow.to_flat_dict()`), making the wire
 > shape and the in-memory shape a single source of truth.
+>
+> **Status (epic #540 phase 2, v8.10):** the SQLite implementation
+> ships as `investing_algorithm_framework.services.backtest_index
+> .SqliteBacktestIndex`, with `iaf index <bundle-dir>` as the CLI
+> entry point. Every scalar field of `BacktestSummaryMetrics` is
+> promoted to its own SQL column (`summary_<name>`), so analysts can
+> filter without opening any bundle, e.g. `SELECT bundle_path FROM
+> backtest_index WHERE summary_sharpe_ratio > 1.0`.
 
 ### 3.2 Tier 2 schemas (Parquet, long format)
 

--- a/docs/design/tiered-backtest-storage.md
+++ b/docs/design/tiered-backtest-storage.md
@@ -69,10 +69,19 @@ Cross-bundle redundancy is the dominant unexploited source of size:
 | Identity | `run_id` (uuid7), `bundle_id`, `parent_sweep_id`, `tenant_id`, `project_id` |
 | Provenance | `algorithm_id`, `code_hash`, `framework_version`, `created_at` |
 | Config | `engine_type`, `params_hash`, `symbols_hash`, `date_range_name`, `start_date`, `end_date`, `tag` |
-| Scalar metrics | `BacktestSummary` fields — Sharpe, Sortino, max_dd, CAGR, total_net_gain, win_rate, … |
+| Scalar metrics | `BacktestSummaryMetrics` fields (nested in `BacktestIndexRow.summary_metrics`) — Sharpe, Sortino, max_dd, CAGR, total_net_gain, win_rate, … |
 | Refs | `snapshots_dataset_uri`, `trades_dataset_uri`, `metric_series_dataset_uri`, `ohlcv_chunk_hashes[]`, `code_chunk_hash`, `symbols_chunk_hash`, `params_chunk_hash` |
 
 Row size: ~1–2 KB. 12,500 rows ≈ 25 MB. Fits comfortably in SQLite for local users.
+
+> **Status (epic #540 phase 1, v8.10):** the typed contract for this row
+> ships as `investing_algorithm_framework.BacktestIndexRow`, derived
+> via `Backtest.index_row(bundle_path=...)`. The method works against
+> bundles loaded with `Backtest.open(path, summary_only=True)` — no
+> Parquet metric blobs are decoded on the fast index path. The
+> existing `BacktestIndex` Parquet sidecar is now built on top of this
+> typed row (`BacktestIndexRow.to_flat_dict()`), making the wire
+> shape and the in-memory shape a single source of truth.
 
 ### 3.2 Tier 2 schemas (Parquet, long format)
 
@@ -215,7 +224,7 @@ Zero behavioural difference vs today. Single-file `.iafbt` users get `export()` 
 | Phase | Change | Risk |
 |---|---|---|
 | **v8.9 (shipped)** | Bundle format v2; engine_type split; zstd 19; summary_only read | — |
-| **v8.10** | `Backtest.scalar_summary()` (no decode of bulk); `iaf index <dir>` builds a SQLite index over a folder of bundles; `BacktestSummary` DTO with stable schema | Low — additive read paths |
+| **v8.10** | `Backtest.index_row()` (no decode of bulk); `iaf index <dir>` builds a SQLite index over a folder of bundles; `BacktestIndexRow` DTO with stable schema | Low — additive read paths |
 | **v8.11** | `BacktestStore` interface with `LocalDirStore` (today) and `LocalTieredStore`. `.iafbt` becomes export format; service constructors accept a store | Medium — touches every backtest service constructor; deprecation flag for one minor cycle |
 | **Finterion (closed)** | `RemoteTieredStore` over Postgres + S3 + chunk service | Closed-source, unblocked by v8.11 |
 

--- a/investing_algorithm_framework/__init__.py
+++ b/investing_algorithm_framework/__init__.py
@@ -19,6 +19,7 @@ from .domain import ApiException, combine_backtests, PositionSize, \
     Trade, APP_MODE, AppMode, DATETIME_FORMAT, load_backtests_from_directory, \
     iter_backtests_from_directory, \
     BacktestDateRange, convert_polars_to_pandas, BacktestRun, \
+    BacktestIndexRow, \
     DEFAULT_LOGGING_CONFIG, DataType, DataProvider, StopLossRule, \
     ScalingRule, TradingCost, \
     TradeStatus, generate_backtest_summary_metrics, generate_algorithm_id, \
@@ -222,6 +223,7 @@ __all__ = [
     "get_positive_trades",
     "get_number_of_trades",
     "BacktestRun",
+    "BacktestIndexRow",
     "load_backtests_from_directory",
     "iter_backtests_from_directory",
     "save_backtests_to_directory",

--- a/investing_algorithm_framework/cli/cli.py
+++ b/investing_algorithm_framework/cli/cli.py
@@ -320,3 +320,52 @@ def migrate_backtests_cmd(
 
 
 cli.add_command(migrate_backtests_cmd)
+
+
+@click.command(name="index")
+@click.argument(
+    "directory",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+)
+@click.option(
+    "--output", "-o",
+    type=click.Path(file_okay=True, dir_okay=False),
+    default=None,
+    help="Path to the SQLite index file (default: <directory>/index.sqlite).",
+)
+@click.option(
+    "--absolute-paths", is_flag=True, default=False,
+    help="Store absolute bundle paths in the index "
+         "(default: paths relative to <directory>, so the index stays "
+         "portable when the folder is moved).",
+)
+@click.option(
+    "--no-progress", is_flag=True, default=False,
+    help="Suppress the progress bar.",
+)
+def index_cmd(directory, output, absolute_paths, no_progress):
+    """Build a SQLite Tier-1 index over a folder of ``.iafbt`` bundles.
+
+    The resulting ``index.sqlite`` file holds one row per bundle with
+    identity / provenance / config columns and every scalar
+    ``BacktestSummaryMetrics`` field promoted to its own column, so
+    analysts can run ad-hoc SQL queries (e.g.
+    ``SELECT bundle_path FROM backtest_index
+    WHERE summary_sharpe_ratio > 1.0``) without opening any bundle.
+
+    Each bundle is opened with ``summary_only=True`` so no Parquet
+    metric blobs are decoded \u2014 indexing 12,500 bundles is bounded by
+    msgpack header parsing, not metric reconstruction.
+    """
+    from .index_command import build_index
+
+    out = build_index(
+        directory=directory,
+        output=output,
+        relative_paths=not absolute_paths,
+        show_progress=not no_progress,
+    )
+    click.echo(f"Wrote SQLite index to {out}")
+
+
+cli.add_command(index_cmd)

--- a/investing_algorithm_framework/cli/index_command.py
+++ b/investing_algorithm_framework/cli/index_command.py
@@ -1,0 +1,98 @@
+"""``iaf index`` CLI \u2014 build a SQLite Tier-1 index over a folder of
+``.iafbt`` bundles (epic #540 phase 2).
+
+Walks the directory, opens each bundle with ``summary_only=True`` (no
+Parquet metric-blob decode), derives a :class:`BacktestIndexRow` via
+:meth:`Backtest.index_row`, and upserts into a
+:class:`SqliteBacktestIndex`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_index import (
+    SqliteBacktestIndex,
+)
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_INDEX_NAME = "index.sqlite"
+
+
+def _iter_bundle_paths(directory: Path) -> Iterable[Path]:
+    """Yield every ``*.iafbt`` file under *directory* (sorted)."""
+    return sorted(directory.rglob(f"*{BUNDLE_EXT}"))
+
+
+def build_index(
+    directory: str,
+    output: Optional[str] = None,
+    relative_paths: bool = True,
+    show_progress: bool = False,
+) -> str:
+    """Build (or refresh) a SQLite Tier-1 index over *directory*.
+
+    Args:
+        directory: Folder to scan for ``.iafbt`` bundles.
+        output: Path to the SQLite file. Defaults to
+            ``<directory>/index.sqlite``.
+        relative_paths: if True, store ``bundle_path`` relative to
+            *directory* so the index file stays portable when the
+            folder is moved/renamed.
+        show_progress: emit a tqdm progress bar.
+
+    Returns:
+        Absolute path of the SQLite file that was written.
+    """
+    src = Path(directory).resolve()
+    if not src.is_dir():
+        raise NotADirectoryError(f"Not a directory: {src}")
+
+    out = Path(output).resolve() if output else src / DEFAULT_INDEX_NAME
+    paths: List[Path] = list(_iter_bundle_paths(src))
+
+    pbar = None
+    if show_progress:
+        try:
+            from tqdm import tqdm
+            pbar = tqdm(total=len(paths), desc="Indexing bundles")
+        except ImportError:  # pragma: no cover - tqdm is a dep
+            pbar = None
+
+    index = SqliteBacktestIndex.create(out)
+    n_ok = 0
+    n_err = 0
+    try:
+        for path in paths:
+            try:
+                bt = Backtest.open(str(path), summary_only=True)
+                bundle_path = (
+                    str(path.relative_to(src)) if relative_paths
+                    else str(path)
+                )
+                row = bt.index_row(bundle_path=bundle_path)
+                index.upsert(row)
+                n_ok += 1
+            except Exception as exc:  # noqa: BLE001 \u2014 best-effort scan
+                logger.warning("failed to index %s: %s", path, exc)
+                n_err += 1
+            finally:
+                if pbar is not None:
+                    pbar.update(1)
+    finally:
+        if pbar is not None:
+            pbar.close()
+        index.close()
+
+    logger.info(
+        "Indexed %d bundle(s) into %s (%d failed)", n_ok, out, n_err,
+    )
+    return str(out)

--- a/investing_algorithm_framework/domain/__init__.py
+++ b/investing_algorithm_framework/domain/__init__.py
@@ -109,6 +109,7 @@ __all__ = [
     "parse_decimal_to_string",
     "parse_string_to_decimal",
     "BacktestRun",
+    "BacktestIndexRow",
     "DATETIME_FORMAT_BACKTESTING",
     "BACKTESTING_FLAG",
     "PortfolioSnapshot",

--- a/investing_algorithm_framework/domain/__init__.py
+++ b/investing_algorithm_framework/domain/__init__.py
@@ -43,6 +43,7 @@ from .utils import random_string, append_dict_as_row_to_csv, \
     csv_to_list, StoppableThread, load_csv_into_dict, tqdm, \
     is_timezone_aware, sync_timezones, get_timezone
 from .backtesting import BacktestRun, BacktestSummaryMetrics, \
+    BacktestIndexRow, \
     BacktestDateRange, Backtest, BacktestMetrics, combine_backtests, \
     BacktestPermutationTest, BacktestEvaluationFocus, \
     generate_backtest_summary_metrics, load_backtests_from_directory, \

--- a/investing_algorithm_framework/domain/backtesting/__init__.py
+++ b/investing_algorithm_framework/domain/backtesting/__init__.py
@@ -1,4 +1,5 @@
 from .backtest_summary_metrics import BacktestSummaryMetrics
+from .backtest_index_row import BacktestIndexRow
 from .backtest_date_range import BacktestDateRange
 from .backtest_metrics import BacktestMetrics
 from .backtest_run import BacktestRun
@@ -25,6 +26,7 @@ from .bundle import (
 __all__ = [
     "Backtest",
     "BacktestSummaryMetrics",
+    "BacktestIndexRow",
     "BacktestDateRange",
     "BacktestMetrics",
     "BacktestRun",

--- a/investing_algorithm_framework/domain/backtesting/backtest.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest.py
@@ -13,6 +13,7 @@ from .backtest_run import BacktestRun
 from .backtest_permutation_test import BacktestPermutationTest
 from .backtest_date_range import BacktestDateRange
 from .backtest_summary_metrics import BacktestSummaryMetrics
+from .backtest_index_row import BacktestIndexRow
 from .combine_backtests import generate_backtest_summary_metrics
 
 
@@ -214,6 +215,42 @@ class Backtest:
         if run:
             return run.backtest_metrics
         return None
+
+    def index_row(
+        self, bundle_path: Union[str, None] = None,
+    ) -> BacktestIndexRow:
+        """Return the typed Tier-1 row contract for this backtest.
+
+        The row carries identity, provenance, config and the scalar
+        :class:`BacktestSummaryMetrics`, but **no heavy time-series
+        data**. It can therefore be built without decoding any v2
+        Parquet metric blobs (``Backtest.open(path,
+        summary_only=True)`` is the canonical fast read path).
+
+        Args:
+            bundle_path: Optional location the bundle was loaded from
+                (relative or absolute). Stored verbatim in
+                :pyattr:`BacktestIndexRow.bundle_path` for downstream
+                indexers that need to round-trip back to the file.
+
+        Returns:
+            BacktestIndexRow: typed, flat-friendly row.
+
+        See also:
+            ``docs/design/tiered-backtest-storage.md`` §3.1 — the
+            authoritative schema this row implements.
+        """
+        return BacktestIndexRow(
+            algorithm_id=self.algorithm_id,
+            tag=self.tag,
+            bundle_path=bundle_path,
+            engine_type=self.engine_type,
+            risk_free_rate=self.risk_free_rate,
+            parameters=dict(self.parameters or {}),
+            strategy_ids=list(self.strategy_ids or []),
+            number_of_runs=len(self.backtest_runs or []),
+            summary_metrics=self.backtest_summary,
+        )
 
     def get_backtest_summary(self) -> Union[BacktestSummaryMetrics, None]:
         """

--- a/investing_algorithm_framework/domain/backtesting/backtest_index_row.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest_index_row.py
@@ -1,0 +1,174 @@
+"""Typed Tier-1 row contract for the tiered backtest store (epic #540).
+
+A :class:`BacktestIndexRow` is the authoritative *flat, scalar-only*
+view of a backtest. It is what gets stored as a single row in:
+
+* the :class:`BacktestIndex` Parquet sidecar produced by
+  :func:`save_backtests_to_directory`;
+* the SQLite index built by ``iaf index`` (epic #540 phase 2);
+* the Tier-1 SQL table in any tiered store implementation
+  (``LocalTieredStore`` and the closed-source remote stores).
+
+The schema is **deliberately frozen** — adding a new column is an
+explicit decision and a doc update. Callers can always stash
+non-canonical fields in :pyattr:`extras` (a JSON-friendly dict) which
+is round-tripped opaquely.
+
+This row is built without decoding any heavy time-series payloads;
+it is safe to materialise from a bundle opened with
+``Backtest.open(path, summary_only=True)``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, fields
+from typing import Any, Dict, List, Optional
+
+from .backtest_summary_metrics import BacktestSummaryMetrics
+
+
+# Prefix used when flattening the nested summary metrics into a
+# single-level dict (e.g. for Parquet / SQL columns). Kept as a
+# module-level constant so consumers can reuse it without hard-coding
+# the string in two places.
+SUMMARY_FIELD_PREFIX = "summary."
+
+
+@dataclass
+class BacktestIndexRow:
+    """One row of the backtest index — the Tier-1 contract.
+
+    Field groups follow the design doc
+    (``docs/design/tiered-backtest-storage.md`` §3.1):
+
+    * **Identity** — ``algorithm_id``, ``tag``, ``bundle_path``
+    * **Provenance** — ``framework_version``, ``engine_type``,
+      ``risk_free_rate``
+    * **Config** — ``parameters``, ``strategy_ids``, ``number_of_runs``
+    * **Scalar metrics** — :pyattr:`summary_metrics`, the existing
+      :class:`BacktestSummaryMetrics` dataclass
+    * **Forward-compat** — :pyattr:`extras`, a free-form dict the
+      bundle reader populates for non-canonical scalar fields
+
+    Notes:
+        The schema is intentionally flat for the wire shapes that need
+        flatness (Parquet, SQL). For ergonomic Python use, prefer
+        accessing :pyattr:`summary_metrics` directly.
+    """
+
+    # -- Identity --------------------------------------------------------
+    algorithm_id: Optional[str] = None
+    tag: Optional[str] = None
+    bundle_path: Optional[str] = None
+
+    # -- Provenance ------------------------------------------------------
+    framework_version: Optional[str] = None
+    engine_type: Optional[str] = None
+    risk_free_rate: Optional[float] = None
+
+    # -- Config ----------------------------------------------------------
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    strategy_ids: List[Any] = field(default_factory=list)
+    number_of_runs: int = 0
+
+    # -- Scalar metrics --------------------------------------------------
+    summary_metrics: Optional[BacktestSummaryMetrics] = None
+
+    # -- Forward-compat --------------------------------------------------
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Flat-dict round-trip (Parquet / SQL / JSON wire shape)
+    # ------------------------------------------------------------------
+    def to_flat_dict(self) -> Dict[str, Any]:
+        """Flatten into a single-level dict.
+
+        Summary-metric scalars are emitted under
+        :data:`SUMMARY_FIELD_PREFIX` keys (``summary.sharpe_ratio``
+        etc.). Complex fields (``parameters``, ``strategy_ids``) are
+        JSON-encoded so the result fits any tabular sink.
+        """
+        out: Dict[str, Any] = {
+            "algorithm_id": self.algorithm_id,
+            "tag": self.tag,
+            "bundle_path": self.bundle_path,
+            "framework_version": self.framework_version,
+            "engine_type": self.engine_type,
+            "risk_free_rate": self.risk_free_rate,
+            "number_of_runs": self.number_of_runs,
+        }
+
+        # parameters / strategy_ids → JSON for tabular round-trip
+        out["parameters"] = (
+            _safe_json(self.parameters) if self.parameters else None
+        )
+        out["strategy_ids"] = (
+            _safe_json(self.strategy_ids) if self.strategy_ids else None
+        )
+
+        # Scalar summary metrics, prefixed
+        if self.summary_metrics is not None:
+            for k, v in self.summary_metrics.to_dict().items():
+                if isinstance(v, (int, float, str, bool)) or v is None:
+                    out[f"{SUMMARY_FIELD_PREFIX}{k}"] = v
+
+        # Forward-compat extras, prefixed to avoid colliding with the
+        # canonical column set.
+        for k, v in (self.extras or {}).items():
+            if isinstance(v, (int, float, str, bool)) or v is None:
+                out[f"extras.{k}"] = v
+
+        return out
+
+    @classmethod
+    def from_flat_dict(cls, row: Dict[str, Any]) -> "BacktestIndexRow":
+        """Reconstruct a row from the flat dict shape produced by
+        :meth:`to_flat_dict`. Unknown keys land in :pyattr:`extras`."""
+        canonical = {f.name for f in fields(cls)} - {
+            "summary_metrics", "extras"
+        }
+
+        kwargs: Dict[str, Any] = {}
+        summary_dict: Dict[str, Any] = {}
+        extras: Dict[str, Any] = {}
+
+        for k, v in row.items():
+            if k in canonical:
+                if k in ("parameters", "strategy_ids"):
+                    if v is None:
+                        kwargs[k] = {} if k == "parameters" else []
+                        continue
+                    if isinstance(v, str):
+                        try:
+                            kwargs[k] = json.loads(v)
+                            continue
+                        except (TypeError, ValueError):
+                            pass
+                kwargs[k] = v
+            elif k.startswith(SUMMARY_FIELD_PREFIX):
+                summary_dict[k[len(SUMMARY_FIELD_PREFIX):]] = v
+            elif k.startswith("extras."):
+                extras[k[len("extras."):]] = v
+            else:
+                # Unknown key — preserve under extras (round-trip safety).
+                extras[k] = v
+
+        kwargs.setdefault("parameters", {})
+        kwargs.setdefault("strategy_ids", [])
+
+        return cls(
+            **kwargs,
+            summary_metrics=(
+                BacktestSummaryMetrics.from_dict(summary_dict)
+                if summary_dict else None
+            ),
+            extras=extras,
+        )
+
+
+def _safe_json(obj: Any) -> Optional[str]:
+    try:
+        return json.dumps(obj, default=str)
+    except (TypeError, ValueError):
+        return None

--- a/investing_algorithm_framework/domain/backtesting/backtest_utils.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest_utils.py
@@ -551,28 +551,14 @@ def iter_backtests_from_directory(
 
 
 def _backtest_to_index_row(bt: Backtest, bundle_path: Optional[str] = None):
-    """Flatten a backtest's summary + identity into a single row."""
-    summary = (
-        bt.backtest_summary.to_dict() if bt.backtest_summary else {}
-    )
-    row = {
-        "algorithm_id": getattr(bt, "algorithm_id", None),
-        "tag": getattr(bt, "tag", None),
-        "risk_free_rate": getattr(bt, "risk_free_rate", None),
-        "bundle_path": bundle_path,
-        "number_of_runs": len(bt.backtest_runs or []),
-    }
-    # Include scalar summary metrics only (no nested structures).
-    for k, v in summary.items():
-        if isinstance(v, (int, float, str, bool)) or v is None:
-            row[f"summary.{k}"] = v
-    # Parameters as JSON for round-trippability without exploding columns.
-    if getattr(bt, "parameters", None):
-        try:
-            row["parameters"] = json.dumps(bt.parameters, default=str)
-        except (TypeError, ValueError):
-            row["parameters"] = None
-    return row
+    """Flatten a backtest's summary + identity into a single row.
+
+    Thin wrapper around :meth:`Backtest.index_row` for callers that
+    want the legacy flat dict shape (Parquet / SQL columns). The
+    typed :class:`BacktestIndexRow` is the authoritative contract \u2014
+    see ``docs/design/tiered-backtest-storage.md`` \u00a73.1.
+    """
+    return bt.index_row(bundle_path=bundle_path).to_flat_dict()
 
 
 def _write_index(directory_path: Union[str, Path], backtests: List[Backtest]):

--- a/investing_algorithm_framework/services/backtest_index/__init__.py
+++ b/investing_algorithm_framework/services/backtest_index/__init__.py
@@ -1,0 +1,3 @@
+from .sqlite_index import SqliteBacktestIndex, SCHEMA_VERSION
+
+__all__ = ["SqliteBacktestIndex", "SCHEMA_VERSION"]

--- a/investing_algorithm_framework/services/backtest_index/sqlite_index.py
+++ b/investing_algorithm_framework/services/backtest_index/sqlite_index.py
@@ -1,0 +1,385 @@
+"""SQLite-backed Tier-1 backtest index (epic #540 phase 2).
+
+A :class:`SqliteBacktestIndex` is a single-file SQLite database that
+holds one row per backtest bundle, derived from
+:class:`BacktestIndexRow`. It is the local-disk implementation of the
+Tier-1 store described in
+``docs/design/tiered-backtest-storage.md`` \u00a73.1.
+
+Schema
+------
+The schema is generated from two sources of truth:
+
+* The canonical *identity / provenance / config* columns of
+  :class:`BacktestIndexRow`.
+* All numeric / string fields of :class:`BacktestSummaryMetrics`,
+  promoted as ``summary_<field>`` columns so analysts can filter on
+  e.g. ``WHERE summary_sharpe_ratio > 1.0``.
+
+Anything that doesn't fit those is round-tripped opaquely in the
+``extras_json`` and ``summary_extras_json`` columns. ``parameters``
+and ``strategy_ids`` are stored as JSON text.
+
+The file carries ``PRAGMA user_version = SCHEMA_VERSION`` so future
+migrations can detect and upgrade older index files additively.
+
+Concurrency
+-----------
+Writes go through a single connection in ``WAL`` mode; multiple
+readers from other processes are safe.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import fields as dc_fields
+from pathlib import Path
+from typing import (
+    Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union,
+)
+
+from investing_algorithm_framework.domain.backtesting.backtest_index_row \
+    import BacktestIndexRow
+from investing_algorithm_framework.domain.backtesting \
+    .backtest_summary_metrics import BacktestSummaryMetrics
+
+
+logger = logging.getLogger(__name__)
+
+
+# Bumped on any additive schema change. Old files are upgraded
+# in-place by :meth:`SqliteBacktestIndex._migrate`.
+SCHEMA_VERSION = 1
+
+# Columns of BacktestIndexRow that map 1:1 to typed SQL columns.
+# (parameters / strategy_ids are emitted as JSON text columns; the
+# scalar metrics are promoted from BacktestSummaryMetrics below.)
+_IDENTITY_COLUMNS: Tuple[Tuple[str, str], ...] = (
+    ("bundle_path", "TEXT PRIMARY KEY"),
+    ("algorithm_id", "TEXT"),
+    ("tag", "TEXT"),
+    ("framework_version", "TEXT"),
+    ("engine_type", "TEXT"),
+    ("risk_free_rate", "REAL"),
+    ("number_of_runs", "INTEGER"),
+    ("parameters_json", "TEXT"),
+    ("strategy_ids_json", "TEXT"),
+    ("extras_json", "TEXT"),
+    ("summary_extras_json", "TEXT"),
+)
+
+
+def _summary_columns() -> List[Tuple[str, str]]:
+    """Promote BacktestSummaryMetrics fields to ``summary_<name>`` cols.
+
+    Numeric fields become ``REAL`` (or ``INTEGER`` if annotated ``int``);
+    everything else degrades to ``TEXT``.
+    """
+    cols: List[Tuple[str, str]] = []
+    for f in dc_fields(BacktestSummaryMetrics):
+        ann = f.type
+        if ann is int or ann == "int":
+            sql_type = "INTEGER"
+        elif ann is float or ann == "float":
+            sql_type = "REAL"
+        elif ann is bool or ann == "bool":
+            sql_type = "INTEGER"
+        else:
+            sql_type = "TEXT"
+        cols.append((f"summary_{f.name}", sql_type))
+    return cols
+
+
+_SUMMARY_COLUMNS: Tuple[Tuple[str, str], ...] = tuple(_summary_columns())
+_SUMMARY_FIELD_NAMES: frozenset = frozenset(
+    f.name for f in dc_fields(BacktestSummaryMetrics)
+)
+
+
+def _all_columns() -> List[Tuple[str, str]]:
+    return list(_IDENTITY_COLUMNS) + list(_SUMMARY_COLUMNS)
+
+
+_TABLE = "backtest_index"
+
+
+class SqliteBacktestIndex:
+    """Single-file SQLite index over a directory of ``.iafbt`` bundles.
+
+    Use :meth:`create` to make a fresh file (overwrites if exists),
+    :meth:`open` to connect to an existing one (creating tables if
+    needed), :meth:`upsert` to add/replace a row, and
+    :meth:`iter_rows` / :meth:`query` for read access.
+    """
+
+    def __init__(self, path: Union[str, Path], conn: sqlite3.Connection):
+        self.path = Path(path)
+        self._conn = conn
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+    @classmethod
+    def create(cls, path: Union[str, Path]) -> "SqliteBacktestIndex":
+        """Create a fresh index file (overwrites any existing file)."""
+        p = Path(path)
+        if p.exists():
+            p.unlink()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(p))
+        conn.row_factory = sqlite3.Row
+        cls._init_schema(conn)
+        return cls(p, conn)
+
+    @classmethod
+    def open(cls, path: Union[str, Path]) -> "SqliteBacktestIndex":
+        """Open an existing index file, creating tables on first use."""
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(p))
+        conn.row_factory = sqlite3.Row
+        cls._init_schema(conn)
+        cls._migrate(conn)
+        return cls(p, conn)
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _init_schema(conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        cols = ", ".join(
+            f'"{name}" {sql_type}' for name, sql_type in _all_columns()
+        )
+        conn.execute(f'CREATE TABLE IF NOT EXISTS "{_TABLE}" ({cols})')
+        conn.execute(
+            f'CREATE INDEX IF NOT EXISTS idx_{_TABLE}_algorithm_id '
+            f'ON "{_TABLE}"(algorithm_id)'
+        )
+        conn.execute(
+            f'CREATE INDEX IF NOT EXISTS idx_{_TABLE}_tag '
+            f'ON "{_TABLE}"(tag)'
+        )
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        conn.commit()
+
+    @staticmethod
+    def _migrate(conn: sqlite3.Connection) -> None:
+        """Additive forward-only migration based on PRAGMA user_version.
+
+        Adds any columns that the current code knows about but the
+        on-disk file is missing. Never drops or rewrites existing
+        columns.
+        """
+        existing = {
+            row["name"]
+            for row in conn.execute(f'PRAGMA table_info("{_TABLE}")')
+        }
+        for name, sql_type in _all_columns():
+            if name not in existing:
+                conn.execute(
+                    f'ALTER TABLE "{_TABLE}" '
+                    f'ADD COLUMN "{name}" {sql_type}'
+                )
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        conn.commit()
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+    def upsert(self, row: BacktestIndexRow) -> None:
+        """Insert or replace a single row, keyed by ``bundle_path``.
+
+        Raises:
+            ValueError: if ``row.bundle_path`` is None (it is the PK).
+        """
+        if not row.bundle_path:
+            raise ValueError(
+                "BacktestIndexRow.bundle_path is required for SQLite "
+                "upsert (used as the primary key)."
+            )
+        record = self._row_to_record(row)
+        cols = list(record.keys())
+        placeholders = ", ".join("?" for _ in cols)
+        col_list = ", ".join(f'"{c}"' for c in cols)
+        self._conn.execute(
+            f'INSERT OR REPLACE INTO "{_TABLE}" ({col_list}) '
+            f'VALUES ({placeholders})',
+            [record[c] for c in cols],
+        )
+        self._conn.commit()
+
+    def upsert_many(self, rows: Iterable[BacktestIndexRow]) -> int:
+        """Bulk insert/replace; returns the number of rows written."""
+        rows = list(rows)
+        if not rows:
+            return 0
+        # Use the first row to fix the column set; record-builder is
+        # deterministic so all rows produce the same keys.
+        first = self._row_to_record(rows[0])
+        cols = list(first.keys())
+        placeholders = ", ".join("?" for _ in cols)
+        col_list = ", ".join(f'"{c}"' for c in cols)
+        sql = (
+            f'INSERT OR REPLACE INTO "{_TABLE}" ({col_list}) '
+            f'VALUES ({placeholders})'
+        )
+        payload = [first] + [self._row_to_record(r) for r in rows[1:]]
+        for r in payload:
+            if not r.get("bundle_path"):
+                raise ValueError(
+                    "BacktestIndexRow.bundle_path is required for SQLite "
+                    "upsert (used as the primary key)."
+                )
+        self._conn.executemany(sql, [[r[c] for c in cols] for r in payload])
+        self._conn.commit()
+        return len(rows)
+
+    @staticmethod
+    def _row_to_record(row: BacktestIndexRow) -> Dict[str, Any]:
+        """Map a typed row onto a flat dict ready for SQL binding."""
+        record: Dict[str, Any] = {
+            "bundle_path": row.bundle_path,
+            "algorithm_id": row.algorithm_id,
+            "tag": row.tag,
+            "framework_version": row.framework_version,
+            "engine_type": row.engine_type,
+            "risk_free_rate": row.risk_free_rate,
+            "number_of_runs": row.number_of_runs,
+            "parameters_json": (
+                _safe_json(row.parameters) if row.parameters else None
+            ),
+            "strategy_ids_json": (
+                _safe_json(row.strategy_ids) if row.strategy_ids else None
+            ),
+            "extras_json": (
+                _safe_json(row.extras) if row.extras else None
+            ),
+        }
+
+        summary_extras: Dict[str, Any] = {}
+        if row.summary_metrics is not None:
+            summary_dict = row.summary_metrics.to_dict()
+            for k, v in summary_dict.items():
+                if k in _SUMMARY_FIELD_NAMES:
+                    record[f"summary_{k}"] = _coerce_scalar(v)
+                else:
+                    summary_extras[k] = v
+
+        record["summary_extras_json"] = (
+            _safe_json(summary_extras) if summary_extras else None
+        )
+        return record
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    def __len__(self) -> int:
+        cur = self._conn.execute(f'SELECT COUNT(*) AS n FROM "{_TABLE}"')
+        return int(cur.fetchone()["n"])
+
+    def iter_rows(self) -> Iterator[BacktestIndexRow]:
+        """Yield every row as a :class:`BacktestIndexRow`."""
+        for sql_row in self._conn.execute(f'SELECT * FROM "{_TABLE}"'):
+            yield self._record_to_row(sql_row)
+
+    def query(
+        self, where: Optional[str] = None,
+        params: Optional[Tuple[Any, ...]] = None,
+    ) -> List[BacktestIndexRow]:
+        """Run a parameterised ``SELECT`` and return typed rows.
+
+        Args:
+            where: optional SQL fragment (without the ``WHERE`` keyword).
+            params: positional bind values for ``where``.
+        """
+        sql = f'SELECT * FROM "{_TABLE}"'
+        if where:
+            sql += f" WHERE {where}"
+        cur = self._conn.execute(sql, params or ())
+        return [self._record_to_row(r) for r in cur]
+
+    @staticmethod
+    def _record_to_row(sql_row: sqlite3.Row) -> BacktestIndexRow:
+        d = dict(sql_row)
+
+        params_json = d.pop("parameters_json", None)
+        strat_json = d.pop("strategy_ids_json", None)
+        extras_json = d.pop("extras_json", None)
+        summary_extras_json = d.pop("summary_extras_json", None)
+
+        summary_dict: Dict[str, Any] = {}
+        for name in list(d.keys()):
+            if name.startswith("summary_"):
+                value = d.pop(name)
+                if value is not None:
+                    summary_dict[name[len("summary_"):]] = value
+        if summary_extras_json:
+            try:
+                summary_dict.update(json.loads(summary_extras_json))
+            except (TypeError, ValueError):
+                pass
+
+        kwargs: Dict[str, Any] = {
+            "algorithm_id": d.get("algorithm_id"),
+            "tag": d.get("tag"),
+            "bundle_path": d.get("bundle_path"),
+            "framework_version": d.get("framework_version"),
+            "engine_type": d.get("engine_type"),
+            "risk_free_rate": d.get("risk_free_rate"),
+            "number_of_runs": d.get("number_of_runs") or 0,
+            "parameters": _safe_loads(params_json) or {},
+            "strategy_ids": _safe_loads(strat_json) or [],
+            "extras": _safe_loads(extras_json) or {},
+            "summary_metrics": (
+                BacktestSummaryMetrics.from_dict(summary_dict)
+                if summary_dict else None
+            ),
+        }
+        return BacktestIndexRow(**kwargs)
+
+    # ------------------------------------------------------------------
+    # House-keeping
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:  # pragma: no cover - best-effort
+            pass
+
+    def __enter__(self) -> "SqliteBacktestIndex":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _safe_json(obj: Any) -> Optional[str]:
+    try:
+        return json.dumps(obj, default=str)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_loads(text: Optional[str]) -> Any:
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_scalar(v: Any) -> Any:
+    """Bind helper: SQLite accepts None / int / float / str / bytes only."""
+    if v is None or isinstance(v, (int, float, str, bytes)):
+        return v
+    if isinstance(v, bool):
+        return int(v)
+    return str(v)

--- a/tests/cli/test_index_command.py
+++ b/tests/cli/test_index_command.py
@@ -1,0 +1,93 @@
+"""Integration tests for the ``iaf index`` CLI (epic #540 phase 2)."""
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+
+from click.testing import CliRunner
+
+from investing_algorithm_framework.domain import Backtest, BUNDLE_EXT
+from investing_algorithm_framework.domain.backtesting.bundle import (
+    save_bundle,
+)
+from investing_algorithm_framework.cli.cli import index_cmd
+from investing_algorithm_framework.cli.index_command import build_index
+from investing_algorithm_framework.services.backtest_index import (
+    SqliteBacktestIndex,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+class TestIndexCommand(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        # Drop a few bundles into the temp dir.
+        for i in range(3):
+            bt = Backtest.from_dict(self.fixture.to_dict())
+            bt.algorithm_id = f"algo_{i}"
+            bt.tag = "demo"
+            save_bundle(
+                bt, os.path.join(self.tmp, f"algo_{i}{BUNDLE_EXT}"),
+            )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Builder API
+    # ------------------------------------------------------------------
+    def test_build_index_writes_one_row_per_bundle(self):
+        out = build_index(self.tmp, show_progress=False)
+        self.assertTrue(os.path.isfile(out))
+
+        with SqliteBacktestIndex.open(out) as idx:
+            self.assertEqual(len(idx), 3)
+            algos = sorted(r.algorithm_id for r in idx.iter_rows())
+            self.assertEqual(algos, ["algo_0", "algo_1", "algo_2"])
+
+    def test_build_index_uses_relative_paths_by_default(self):
+        out = build_index(self.tmp, show_progress=False)
+        with SqliteBacktestIndex.open(out) as idx:
+            for row in idx.iter_rows():
+                self.assertFalse(
+                    os.path.isabs(row.bundle_path),
+                    f"expected relative path, got {row.bundle_path}",
+                )
+
+    def test_build_index_absolute_paths_when_requested(self):
+        out = build_index(
+            self.tmp, show_progress=False, relative_paths=False,
+        )
+        with SqliteBacktestIndex.open(out) as idx:
+            for row in idx.iter_rows():
+                self.assertTrue(os.path.isabs(row.bundle_path))
+
+    # ------------------------------------------------------------------
+    # Click CLI surface
+    # ------------------------------------------------------------------
+    def test_cli_invocation(self):
+        runner = CliRunner()
+        out = os.path.join(self.tmp, "custom.sqlite")
+        result = runner.invoke(
+            index_cmd,
+            [self.tmp, "--output", out, "--no-progress"],
+        )
+        self.assertEqual(
+            result.exit_code, 0,
+            msg=f"stdout={result.output!r} exc={result.exception!r}",
+        )
+        self.assertTrue(os.path.isfile(out))
+        with SqliteBacktestIndex.open(out) as idx:
+            self.assertEqual(len(idx), 3)

--- a/tests/domain/backtests/test_index_row.py
+++ b/tests/domain/backtests/test_index_row.py
@@ -1,0 +1,142 @@
+"""Tests for the Tier-1 :class:`BacktestIndexRow` contract (epic #540).
+
+These tests verify that:
+
+* ``Backtest.index_row()`` produces a typed row with the right fields.
+* The flat-dict round-trip is lossless for canonical scalar fields.
+* The row can be built from a bundle opened with ``summary_only=True``
+  \u2014 i.e. without decoding any v2 Parquet metric blobs. This is the
+  fast read path the tiered-storage indexer relies on.
+"""
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.domain.backtesting.bundle import (
+    save_bundle,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+class TestBacktestIndexRow(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # In-memory derivation
+    # ------------------------------------------------------------------
+    def test_index_row_has_expected_identity(self):
+        row = self.fixture.index_row(bundle_path="/tmp/x.iafbt")
+
+        self.assertIsInstance(row, BacktestIndexRow)
+        self.assertEqual(row.algorithm_id, self.fixture.algorithm_id)
+        self.assertEqual(row.tag, self.fixture.tag)
+        self.assertEqual(row.bundle_path, "/tmp/x.iafbt")
+        self.assertEqual(
+            row.number_of_runs, len(self.fixture.backtest_runs or [])
+        )
+        # summary_metrics should be the live BacktestSummaryMetrics dataclass
+        self.assertIs(row.summary_metrics, self.fixture.backtest_summary)
+
+    def test_to_flat_dict_carries_summary_prefix(self):
+        row = self.fixture.index_row(bundle_path="bundle.iafbt")
+        flat = row.to_flat_dict()
+
+        # Identity columns are present and unprefixed.
+        self.assertEqual(flat["algorithm_id"], self.fixture.algorithm_id)
+        self.assertEqual(flat["bundle_path"], "bundle.iafbt")
+
+        # Summary-metric scalars are emitted with the canonical prefix.
+        if self.fixture.backtest_summary is not None:
+            summary_keys = [
+                k for k in flat if k.startswith("summary.")
+            ]
+            self.assertGreater(
+                len(summary_keys), 0,
+                "expected at least one summary.* scalar column",
+            )
+
+    def test_flat_dict_round_trip(self):
+        import math
+
+        row = self.fixture.index_row(bundle_path="bundle.iafbt")
+        flat = row.to_flat_dict()
+        restored = BacktestIndexRow.from_flat_dict(flat)
+
+        self.assertEqual(restored.algorithm_id, row.algorithm_id)
+        self.assertEqual(restored.tag, row.tag)
+        self.assertEqual(restored.bundle_path, row.bundle_path)
+        self.assertEqual(restored.number_of_runs, row.number_of_runs)
+        self.assertEqual(restored.parameters, row.parameters)
+
+        # Scalar metrics that survived the flat hop should match.
+        if row.summary_metrics is not None:
+            self.assertIsNotNone(restored.summary_metrics)
+            original = row.summary_metrics.to_dict()
+            restored_dict = restored.summary_metrics.to_dict()
+            for k, v in original.items():
+                if isinstance(v, bool) or not isinstance(v, (int, float)):
+                    if isinstance(v, str) or v is None:
+                        self.assertEqual(restored_dict.get(k), v)
+                    continue
+                rv = restored_dict.get(k)
+                if isinstance(v, float) and math.isnan(v):
+                    self.assertTrue(
+                        isinstance(rv, float) and math.isnan(rv)
+                    )
+                else:
+                    self.assertEqual(rv, v)
+
+    def test_unknown_columns_land_in_extras(self):
+        row = BacktestIndexRow.from_flat_dict({
+            "algorithm_id": "a1",
+            "summary.sharpe_ratio": 1.5,
+            "extras.custom": "hello",
+            "totally_unknown": 7,
+        })
+        self.assertEqual(row.algorithm_id, "a1")
+        self.assertEqual(row.extras.get("custom"), "hello")
+        self.assertEqual(row.extras.get("totally_unknown"), 7)
+
+    # ------------------------------------------------------------------
+    # Fast-path: build row from a summary-only bundle load
+    # ------------------------------------------------------------------
+    def test_index_row_from_summary_only_bundle(self):
+        path = os.path.join(self.tmp, "report" + BUNDLE_EXT)
+        save_bundle(self.fixture, path)
+
+        # summary_only=True skips Parquet metric-blob decoding \u2014
+        # the index row must still build without error.
+        loaded = Backtest.open(path, summary_only=True)
+        row = loaded.index_row(bundle_path=path)
+
+        self.assertEqual(row.algorithm_id, self.fixture.algorithm_id)
+        self.assertEqual(row.bundle_path, path)
+        self.assertEqual(
+            row.number_of_runs, len(self.fixture.backtest_runs or [])
+        )
+
+        # Flat dict shape must also work in the summary-only path.
+        flat = row.to_flat_dict()
+        self.assertEqual(flat["algorithm_id"], self.fixture.algorithm_id)

--- a/tests/services/backtest_index/test_sqlite_index.py
+++ b/tests/services/backtest_index/test_sqlite_index.py
@@ -1,0 +1,155 @@
+"""Tests for :class:`SqliteBacktestIndex` (epic #540 phase 2)."""
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.domain.backtesting.bundle import (
+    save_bundle,
+)
+from investing_algorithm_framework.services.backtest_index import (
+    SqliteBacktestIndex,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+class TestSqliteBacktestIndex(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.index_path = os.path.join(self.tmp, "index.sqlite")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Schema / lifecycle
+    # ------------------------------------------------------------------
+    def test_create_initialises_schema(self):
+        idx = SqliteBacktestIndex.create(self.index_path)
+        try:
+            self.assertTrue(os.path.isfile(self.index_path))
+            self.assertEqual(len(idx), 0)
+        finally:
+            idx.close()
+
+    def test_open_creates_file_when_missing(self):
+        idx = SqliteBacktestIndex.open(self.index_path)
+        try:
+            self.assertTrue(os.path.isfile(self.index_path))
+        finally:
+            idx.close()
+
+    def test_upsert_requires_bundle_path(self):
+        with SqliteBacktestIndex.create(self.index_path) as idx:
+            row = self.fixture.index_row(bundle_path=None)
+            with self.assertRaises(ValueError):
+                idx.upsert(row)
+
+    # ------------------------------------------------------------------
+    # Round-trip
+    # ------------------------------------------------------------------
+    def test_round_trip_preserves_identity_and_metrics(self):
+        row = self.fixture.index_row(bundle_path="bundle.iafbt")
+
+        with SqliteBacktestIndex.create(self.index_path) as idx:
+            idx.upsert(row)
+            self.assertEqual(len(idx), 1)
+            (loaded,) = list(idx.iter_rows())
+
+        self.assertIsInstance(loaded, BacktestIndexRow)
+        self.assertEqual(loaded.algorithm_id, row.algorithm_id)
+        self.assertEqual(loaded.tag, row.tag)
+        self.assertEqual(loaded.bundle_path, row.bundle_path)
+        self.assertEqual(loaded.number_of_runs, row.number_of_runs)
+        self.assertEqual(loaded.parameters, row.parameters)
+
+        # If the fixture has scalar metrics, key ones must round-trip.
+        # SQLite stores NaN as NULL, so treat NaN/None as equivalent.
+        if row.summary_metrics is not None:
+            import math
+
+            self.assertIsNotNone(loaded.summary_metrics)
+            for name in ("sharpe_ratio", "total_net_gain"):
+                got = getattr(loaded.summary_metrics, name, None)
+                exp = getattr(row.summary_metrics, name, None)
+                if isinstance(exp, float) and math.isnan(exp):
+                    self.assertIsNone(got)
+                else:
+                    self.assertEqual(got, exp)
+
+    def test_upsert_replaces_on_duplicate_bundle_path(self):
+        row = self.fixture.index_row(bundle_path="dup.iafbt")
+        with SqliteBacktestIndex.create(self.index_path) as idx:
+            idx.upsert(row)
+
+            # Mutate algorithm_id and re-upsert \u2014 should not duplicate.
+            row.algorithm_id = "new_algo"
+            idx.upsert(row)
+
+            self.assertEqual(len(idx), 1)
+            (loaded,) = list(idx.iter_rows())
+            self.assertEqual(loaded.algorithm_id, "new_algo")
+
+    def test_upsert_many_writes_all(self):
+        rows = []
+        for i in range(3):
+            r = self.fixture.index_row(bundle_path=f"b{i}.iafbt")
+            r.algorithm_id = f"algo_{i}"
+            rows.append(r)
+
+        with SqliteBacktestIndex.create(self.index_path) as idx:
+            n = idx.upsert_many(rows)
+            self.assertEqual(n, 3)
+            self.assertEqual(len(idx), 3)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+    def test_query_with_where_clause(self):
+        rows = []
+        for i in range(3):
+            r = self.fixture.index_row(bundle_path=f"q{i}.iafbt")
+            r.algorithm_id = "alpha" if i == 0 else "beta"
+            rows.append(r)
+
+        with SqliteBacktestIndex.create(self.index_path) as idx:
+            idx.upsert_many(rows)
+            hits = idx.query("algorithm_id = ?", ("alpha",))
+            self.assertEqual(len(hits), 1)
+            self.assertEqual(hits[0].bundle_path, "q0.iafbt")
+
+    # ------------------------------------------------------------------
+    # Build from real bundle on disk
+    # ------------------------------------------------------------------
+    def test_index_built_from_bundle_uses_summary_only_path(self):
+        bundle_path = os.path.join(self.tmp, "report" + BUNDLE_EXT)
+        save_bundle(self.fixture, bundle_path)
+
+        # Open the bundle in summary_only mode — mirrors what the CLI
+        # does.
+        bt = Backtest.open(bundle_path, summary_only=True)
+        row = bt.index_row(bundle_path=bundle_path)
+
+        with SqliteBacktestIndex.create(self.index_path) as idx:
+            idx.upsert(row)
+            (loaded,) = list(idx.iter_rows())
+
+        self.assertEqual(loaded.bundle_path, bundle_path)
+        self.assertEqual(loaded.algorithm_id, self.fixture.algorithm_id)


### PR DESCRIPTION
Stacked on top of #537. Phase 1 of epic #540 — typed Tier-1 row contract.

## What

* New `BacktestIndexRow` dataclass — frozen schema for the Tier-1 row of the upcoming tiered backtest store.
* New `Backtest.index_row(bundle_path=None)` method. Builds the row **without decoding any v2 Parquet metric blobs**, so it works against bundles loaded with `Backtest.open(path, summary_only=True)`. This is the fast read path the upcoming `iaf index` CLI (phase 2) and any `BacktestStore` implementation (phase 3) will rely on.
* The existing untyped `_backtest_to_index_row` helper in `backtest_utils` now delegates to `BacktestIndexRow.to_flat_dict()` so the wire shape (Parquet/SQL columns) and the in-memory shape are a single source of truth. **No behavioural change** for the existing `index.parquet` sidecar.
* Re-exported from `investing_algorithm_framework` and `investing_algorithm_framework.domain`.
* `docs/design/tiered-backtest-storage.md` §3.1 + roadmap row updated to reference the typed contract.

## Why `BacktestIndexRow` and not `BacktestSummary`

The name `BacktestSummaryMetrics` is already taken (the ~50 scalar metrics dataclass). The new row **contains** a `BacktestSummaryMetrics` and adds identity / provenance / config columns. `BacktestIndexRow` reads correctly at every call site (it *is* literally one row of an index).

## Tests

5 new tests in `tests/domain/backtests/test_index_row.py`:
- in-memory derivation
- `to_flat_dict` carries the `summary.` prefix correctly
- lossless flat-dict round trip (incl. NaN handling)
- unknown columns land in `extras`
- **derivation from a `summary_only=True` bundle load** — proves no Parquet decode is required on the index path

Full `tests/domain/backtests` suite: 29/29 green. Lint clean.

## Stacking

Base is `feature/bundle-format-v2` (#537) because the v8.9 bundle work isn't in `dev` yet. Once #537 merges this PR's base will auto-update to `dev`.

Tracks epic #540 — phase 1 of 3.