### PR TITLE
feat(store): LocalTieredStore — Tier-1 SQLite + Tier-2 Parquet (epic #540 phase 3b)

### DIFF
--- a/investing_algorithm_framework/services/backtest_store/__init__.py
+++ b/investing_algorithm_framework/services/backtest_store/__init__.py
@@ -19,6 +19,7 @@ from .base import (
     SupportsCopyFrom,
 )
 from .local_dir_store import LocalDirStore
+from .local_tiered_store import LocalTieredStore
 
 __all__ = [
     "BacktestStore",
@@ -27,4 +28,5 @@ __all__ = [
     "StoreHandleNotFoundError",
     "SupportsCopyFrom",
     "LocalDirStore",
+    "LocalTieredStore",
 ]

--- a/investing_algorithm_framework/services/backtest_store/decompose.py
+++ b/investing_algorithm_framework/services/backtest_store/decompose.py
@@ -1,0 +1,70 @@
+"""Backtest → flat-records decomposer for Tier-2 Parquet writes
+(epic #540 phase 3b).
+
+Given a :class:`Backtest`, yields flat record lists for each Tier-2
+dataset (``portfolio_snapshots`` / ``trades`` / ``orders``). The
+output is shaped for direct ingestion by
+:func:`pyarrow.dataset.write_dataset` with hive partitioning on
+``run_id``.
+
+The bundle (``.iafbt``) remains the canonical source of truth in
+Phase 3b; these Parquet datasets are *auxiliary* — they make
+DuckDB / Polars analytics work across thousands of runs without
+re-decoding bundles. Round-tripping Tier-2 back to a Backtest is
+Phase 3d territory.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List
+
+from investing_algorithm_framework.domain import Backtest
+
+
+def _windowed_records(
+    backtest: Backtest, attr: str, run_id: str,
+) -> Iterator[Dict[str, Any]]:
+    """Yield ``to_dict()``-shaped records from every BacktestRun.
+
+    Adds ``run_id`` and ``window_name`` columns so downstream
+    columnar tools can group / partition cleanly across a Backtest's
+    walk-forward windows.
+    """
+    if not backtest.backtest_runs:
+        return
+    for window in backtest.backtest_runs:
+        items = getattr(window, attr, None) or []
+        window_name = getattr(window, "backtest_date_range_name", None) or (
+            window.create_directory_name()
+            if hasattr(window, "create_directory_name") else ""
+        )
+        for obj in items:
+            d = obj.to_dict() if hasattr(obj, "to_dict") else dict(obj)
+            d["run_id"] = run_id
+            d["window_name"] = window_name
+            yield d
+
+
+def snapshots(backtest: Backtest, run_id: str) -> List[Dict[str, Any]]:
+    """Flat portfolio_snapshots records, one per BacktestRun timestep."""
+    return list(_windowed_records(backtest, "portfolio_snapshots", run_id))
+
+
+def trades(backtest: Backtest, run_id: str) -> List[Dict[str, Any]]:
+    """Flat trades records (one per trade across all windows)."""
+    return list(_windowed_records(backtest, "trades", run_id))
+
+
+def orders(backtest: Backtest, run_id: str) -> List[Dict[str, Any]]:
+    """Flat orders records (one per order across all windows)."""
+    return list(_windowed_records(backtest, "orders", run_id))
+
+
+# Datasets exposed by LocalTieredStore. Each entry is
+# (dataset_name, decomposer_fn). Add new kinds here (e.g.
+# metric_series) once their decomposer is in place.
+DATASETS = (
+    ("portfolio_snapshots", snapshots),
+    ("trades", trades),
+    ("orders", orders),
+)

--- a/investing_algorithm_framework/services/backtest_store/local_tiered_store.py
+++ b/investing_algorithm_framework/services/backtest_store/local_tiered_store.py
@@ -1,0 +1,410 @@
+"""``LocalTieredStore`` — Tier-1 SQLite + Tier-2 Parquet + canonical
+``.iafbt`` bundles on a local filesystem (epic #540 phase 3b).
+
+Layout under *root*::
+
+    <root>/
+        index.sqlite               # Tier-1, kept in sync on every write
+        bundles/<handle>.iafbt     # canonical bytes (source of truth)
+        parquet/
+            portfolio_snapshots/run_id=<handle>/part-0.parquet
+            trades/run_id=<handle>/part-0.parquet
+            orders/run_id=<handle>/part-0.parquet
+
+The bundle file is the canonical representation. The Tier-1 index and
+the Tier-2 Parquet datasets are derived, eagerly maintained, and
+best-effort: a malformed sidecar never blocks a write or read against
+the bundle. This keeps Phase 3b's invariants simple and trivially
+preserves byte-identical round-trips through ``Backtest.save_bundle``
+/ ``Backtest.open``. Byte-identical *Tier-2 → Backtest* reassembly is
+Phase 3d.
+
+The Parquet datasets are hive-partitioned on ``run_id`` (which is the
+store handle), so cross-run analytics is one DuckDB / Polars scan::
+
+    duckdb.sql(\"\"\"
+        SELECT run_id, total_value
+        FROM read_parquet('store/parquet/portfolio_snapshots/**/*.parquet',
+                          hive_partitioning=True)
+        WHERE run_id IN (SELECT bundle_path FROM
+                         read_csv('top20.csv'))
+    \"\"\")
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Any, Iterable, Iterator, List, Optional, Union
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_index import (
+    SqliteBacktestIndex,
+)
+
+from .base import (
+    BacktestStore,
+    StoreError,
+    StoreHandle,
+    StoreHandleNotFoundError,
+)
+from . import decompose as _decompose
+
+logger = logging.getLogger(__name__)
+
+
+INDEX_FILENAME = "index.sqlite"
+BUNDLES_SUBDIR = "bundles"
+PARQUET_SUBDIR = "parquet"
+
+
+def _records_to_table(records: List[dict]) -> Optional[Any]:
+    """Convert ``to_dict()``-shaped records to a pyarrow Table.
+
+    Returns ``None`` when there are no records, the table cannot be
+    built (heterogeneous schema, unsupported types, …), or pyarrow is
+    not importable. Callers must treat the absence of a sidecar as
+    valid — the bundle is canonical.
+    """
+    if not records:
+        return None
+    try:
+        import pyarrow as pa
+        import pandas as pd
+    except ImportError:  # pragma: no cover - dependency missing
+        return None
+    try:
+        df = pd.DataFrame.from_records(records)
+        # Object columns containing dicts/lists can blow up Parquet
+        # schema inference. Stringify them so the analytics path stays
+        # usable; the bundle still has the original structured data.
+        for col in df.columns:
+            if df[col].dtype == object:
+                df[col] = df[col].map(
+                    lambda v: (
+                        v if v is None
+                        or isinstance(v, (str, int, float, bool))
+                        else str(v)
+                    )
+                )
+        return pa.Table.from_pandas(df, preserve_index=False)
+    except Exception as exc:  # pragma: no cover - logged
+        logger.warning(
+            "Tier-2 Parquet table build failed: %s", exc,
+        )
+        return None
+
+
+class LocalTieredStore(BacktestStore):
+    """Tier-1 + Tier-2 + canonical-bundle store on a local filesystem.
+
+    The store is fully self-contained: a single root directory holds
+    every artefact, so it can be copied, symlinked, or rsync'd with
+    a single ``cp -r``. Concurrent readers are safe; concurrent
+    writers from different processes may race on the SQLite index
+    (WAL handles it) but per-handle write atomicity is the caller's
+    responsibility.
+
+    Phase 3b deliberately keeps the .iafbt bundle as the canonical
+    representation. Reads always go through the bundle so the
+    Backtest round-trip is bit-for-bit identical to today's
+    behaviour. Tier-2 sidecars are *auxiliary* — used only for
+    cross-run analytics — and are rebuilt from the bundle on demand.
+    """
+
+    def __init__(self, root: Union[str, Path]) -> None:
+        self.root = Path(root).resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._bundles_dir = self.root / BUNDLES_SUBDIR
+        self._parquet_dir = self.root / PARQUET_SUBDIR
+        self._index_path = self.root / INDEX_FILENAME
+        self._bundles_dir.mkdir(parents=True, exist_ok=True)
+        self._parquet_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_handle(handle: StoreHandle) -> str:
+        """Strip the .iafbt suffix; handles are stored bare in Tier-1."""
+        if handle.endswith(BUNDLE_EXT):
+            return handle[: -len(BUNDLE_EXT)]
+        return handle
+
+    def _bundle_path(self, handle: StoreHandle) -> Path:
+        bare = self._normalize_handle(handle)
+        candidate = (self._bundles_dir / (bare + BUNDLE_EXT)).resolve()
+        try:
+            candidate.relative_to(self._bundles_dir)
+        except ValueError as exc:
+            raise StoreError(
+                f"handle {handle!r} resolves outside the bundles "
+                f"directory {self._bundles_dir}"
+            ) from exc
+        return candidate
+
+    def _partition_dir(self, dataset: str, handle: StoreHandle) -> Path:
+        bare = self._normalize_handle(handle)
+        return self._parquet_dir / dataset / f"run_id={bare}"
+
+    def _default_handle(self, backtest: Backtest) -> StoreHandle:
+        if backtest.algorithm_id:
+            return str(backtest.algorithm_id)
+        from datetime import datetime, timezone
+        return "backtest_" + datetime.now(timezone.utc).strftime(
+            "%Y%m%dT%H%M%S%f"
+        )
+
+    def _open_index(self) -> SqliteBacktestIndex:
+        if self._index_path.is_file():
+            return SqliteBacktestIndex.open(self._index_path)
+        return SqliteBacktestIndex.create(self._index_path)
+
+    # ------------------------------------------------------------------
+    # BacktestStore: write / open / exists / delete
+    # ------------------------------------------------------------------
+    def write(
+        self,
+        backtest: Backtest,
+        *,
+        handle: Optional[StoreHandle] = None,
+    ) -> StoreHandle:
+        if handle is None:
+            handle = self._default_handle(backtest)
+        bare = self._normalize_handle(handle)
+        bundle_path = self._bundle_path(bare)
+        bundle_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # 1. Canonical bytes — bundle.
+        backtest.save_bundle(bundle_path)
+
+        # 2. Tier-1 — SQLite row.
+        stat = bundle_path.stat()
+        row = backtest.index_row(bundle_path=bare)
+        index = self._open_index()
+        try:
+            index.upsert(
+                row,
+                bundle_mtime_ns=stat.st_mtime_ns,
+                bundle_size=stat.st_size,
+            )
+        finally:
+            index.close()
+
+        # 3. Tier-2 — Parquet sidecars (best-effort).
+        self._write_parquet_sidecars(backtest, bare)
+
+        return bare
+
+    def _write_parquet_sidecars(
+        self, backtest: Backtest, handle: str,
+    ) -> None:
+        try:
+            import pyarrow.parquet as pq
+        except ImportError:  # pragma: no cover - pyarrow missing
+            logger.debug("pyarrow unavailable, skipping Tier-2 sidecars")
+            return
+        for name, decomposer in _decompose.DATASETS:
+            try:
+                records = decomposer(backtest, handle)
+                table = _records_to_table(records)
+                if table is None:
+                    # Always overwrite empties so deletion of all
+                    # snapshots leaves no stale data.
+                    target_dir = self._partition_dir(name, handle)
+                    if target_dir.exists():
+                        shutil.rmtree(target_dir)
+                    continue
+                target_dir = self._partition_dir(name, handle)
+                target_dir.mkdir(parents=True, exist_ok=True)
+                pq.write_table(
+                    table,
+                    target_dir / "part-0.parquet",
+                    compression="zstd",
+                )
+            except Exception as exc:  # pragma: no cover - logged
+                logger.warning(
+                    "Tier-2 sidecar write failed for %s/%s: %s",
+                    name, handle, exc,
+                )
+
+    def open(
+        self,
+        handle: StoreHandle,
+        *,
+        summary_only: bool = False,
+    ) -> Backtest:
+        path = self._bundle_path(handle)
+        if not path.is_file():
+            raise StoreHandleNotFoundError(handle)
+        return Backtest.open(str(path), summary_only=summary_only)
+
+    def exists(self, handle: StoreHandle) -> bool:
+        try:
+            return self._bundle_path(handle).is_file()
+        except StoreError:
+            return False
+
+    def delete(self, handle: StoreHandle) -> None:
+        bare = self._normalize_handle(handle)
+        try:
+            path = self._bundle_path(bare)
+        except StoreError:
+            return
+        if path.is_file():
+            path.unlink()
+        # Tier-2 partitions.
+        for name, _ in _decompose.DATASETS:
+            part = self._partition_dir(name, bare)
+            if part.exists():
+                shutil.rmtree(part, ignore_errors=True)
+        # Tier-1 row.
+        if self._index_path.is_file():
+            index = self._open_index()
+            try:
+                index._conn.execute(
+                    'DELETE FROM "backtest_index" WHERE bundle_path = ?',
+                    (bare,),
+                )
+                index._conn.commit()
+            finally:
+                index.close()
+
+    # ------------------------------------------------------------------
+    # BacktestStore: listing
+    # ------------------------------------------------------------------
+    def iter_handles(self) -> Iterator[StoreHandle]:
+        if not self._bundles_dir.is_dir():
+            return
+        for p in sorted(self._bundles_dir.rglob(f"*{BUNDLE_EXT}")):
+            if p.is_file():
+                yield p.stem  # handle is the bare basename
+
+    def iter_index_rows(self) -> Iterator[BacktestIndexRow]:
+        if not self._index_path.is_file():
+            return
+        index = self._open_index()
+        try:
+            yield from index.iter_rows()
+        finally:
+            index.close()
+
+    def __len__(self) -> int:
+        if not self._index_path.is_file():
+            return sum(1 for _ in self.iter_handles())
+        index = self._open_index()
+        try:
+            return len(index)
+        finally:
+            index.close()
+
+    def __contains__(self, handle: object) -> bool:
+        if not isinstance(handle, str):
+            return False
+        return self.exists(handle)
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom
+    # ------------------------------------------------------------------
+    def copy_from(
+        self,
+        src: BacktestStore,
+        *,
+        handles: Optional[Iterable[StoreHandle]] = None,
+    ) -> int:
+        chosen = list(handles) if handles is not None else list(
+            src.iter_handles()
+        )
+        n = 0
+        for h in chosen:
+            try:
+                bt = src.open(h)
+            except StoreHandleNotFoundError:
+                logger.warning("copy_from: handle %r missing in src", h)
+                continue
+            self.write(bt, handle=h)
+            n += 1
+        return n
+
+    # ------------------------------------------------------------------
+    # Tier-2 cross-run analytics helpers
+    # ------------------------------------------------------------------
+    def scan(self, dataset: str) -> Any:
+        """Return a :class:`pyarrow.dataset.Dataset` over *dataset*.
+
+        ``dataset`` must be one of ``"portfolio_snapshots"``,
+        ``"trades"``, ``"orders"``. The returned object is
+        hive-partitioned on ``run_id`` and can be filtered /
+        materialised with the standard Arrow / DuckDB APIs.
+
+        Example::
+
+            ds = store.scan("trades")
+            df = ds.to_table(filter=ds.field("run_id") == "abc").to_pandas()
+
+        Returns ``None`` if the dataset directory does not exist yet.
+        """
+        known = {name for name, _ in _decompose.DATASETS}
+        if dataset not in known:
+            raise ValueError(
+                f"unknown dataset {dataset!r}; expected one of {sorted(known)}"
+            )
+        root = self._parquet_dir / dataset
+        if not root.is_dir():
+            return None
+        import pyarrow.dataset as ds  # local import: pyarrow optional
+        return ds.dataset(
+            str(root), format="parquet", partitioning="hive",
+        )
+
+    def scan_snapshots(self) -> Any:
+        return self.scan("portfolio_snapshots")
+
+    def scan_trades(self) -> Any:
+        return self.scan("trades")
+
+    def scan_orders(self) -> Any:
+        return self.scan("orders")
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+    def rebuild_index(self) -> int:
+        """Drop the Tier-1 SQLite and rebuild it from the bundles.
+
+        Useful when sidecars were edited out-of-band or after a
+        software upgrade adds new index columns. Returns the number of
+        rows written.
+        """
+        if self._index_path.is_file():
+            self._index_path.unlink()
+        n = 0
+        index = self._open_index()
+        try:
+            for handle in self.iter_handles():
+                bundle = self._bundle_path(handle)
+                stat = bundle.stat()
+                try:
+                    bt = Backtest.open(str(bundle), summary_only=True)
+                except Exception as exc:  # pragma: no cover - logged
+                    logger.warning(
+                        "rebuild_index: skipping %s: %s", handle, exc,
+                    )
+                    continue
+                index.upsert(
+                    bt.index_row(bundle_path=handle),
+                    bundle_mtime_ns=stat.st_mtime_ns,
+                    bundle_size=stat.st_size,
+                )
+                n += 1
+        finally:
+            index.close()
+        return n
+
+    def __repr__(self) -> str:
+        return f"LocalTieredStore(root={str(self.root)!r})"

--- a/tests/services/backtest_store/test_local_tiered_store.py
+++ b/tests/services/backtest_store/test_local_tiered_store.py
@@ -1,0 +1,241 @@
+"""Tests for :class:`LocalTieredStore` (epic #540 phase 3b)."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_store import (
+    BacktestStore,
+    LocalDirStore,
+    LocalTieredStore,
+    StoreHandleNotFoundError,
+    SupportsCopyFrom,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+class TestLocalTieredStore(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = LocalTieredStore(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Protocol conformance
+    # ------------------------------------------------------------------
+    def test_implements_protocol(self):
+        self.assertIsInstance(self.store, BacktestStore)
+
+    def test_implements_supports_copy_from(self):
+        self.assertIsInstance(self.store, SupportsCopyFrom)
+
+    # ------------------------------------------------------------------
+    # Layout
+    # ------------------------------------------------------------------
+    def test_write_creates_three_tiers(self):
+        handle = self.store.write(self.fixture, handle="r1")
+        root = Path(self.tmp)
+        # Tier-0: canonical bundle.
+        self.assertTrue((root / "bundles" / (handle + BUNDLE_EXT)).is_file())
+        # Tier-1: SQLite index.
+        self.assertTrue((root / "index.sqlite").is_file())
+        # Tier-2: parquet root exists; per-dataset partitions are only
+        # created when there is at least one record to write (the
+        # fixture may have empty snapshots/trades/orders).
+        self.assertTrue((root / "parquet").is_dir())
+
+    def test_handle_normalization_strips_bundle_suffix(self):
+        h1 = self.store.write(self.fixture, handle="with" + BUNDLE_EXT)
+        # Stored bare; iter_handles returns bare names.
+        self.assertNotIn(BUNDLE_EXT, h1)
+        self.assertIn("with", list(self.store.iter_handles()))
+
+    # ------------------------------------------------------------------
+    # Round-trip via canonical bundle
+    # ------------------------------------------------------------------
+    def test_round_trip_preserves_algorithm_id(self):
+        self.store.write(self.fixture, handle="rt")
+        loaded = self.store.open("rt")
+        self.assertEqual(loaded.algorithm_id, self.fixture.algorithm_id)
+
+    def test_summary_only_open(self):
+        self.store.write(self.fixture, handle="so")
+        bt = self.store.open("so", summary_only=True)
+        self.assertEqual(bt.algorithm_id, self.fixture.algorithm_id)
+
+    # ------------------------------------------------------------------
+    # Tier-1: index is always in sync
+    # ------------------------------------------------------------------
+    def test_iter_index_rows_after_write(self):
+        self.store.write(self.fixture, handle="a")
+        self.store.write(self.fixture, handle="b")
+        rows = list(self.store.iter_index_rows())
+        self.assertEqual(len(rows), 2)
+        handles = {row.bundle_path for row in rows}
+        self.assertSetEqual(handles, {"a", "b"})
+        for row in rows:
+            self.assertIsInstance(row, BacktestIndexRow)
+
+    def test_delete_removes_all_tiers(self):
+        self.store.write(self.fixture, handle="gone")
+        self.store.delete("gone")
+        self.assertFalse(self.store.exists("gone"))
+        rows = list(self.store.iter_index_rows())
+        self.assertEqual(len(rows), 0)
+        # Tier-2 partitions for this handle are removed.
+        root = Path(self.tmp)
+        for name in ("portfolio_snapshots", "trades", "orders"):
+            self.assertFalse(
+                (root / "parquet" / name / "run_id=gone").exists()
+            )
+
+    def test_len_uses_index(self):
+        self.assertEqual(len(self.store), 0)
+        self.store.write(self.fixture, handle="x")
+        self.store.write(self.fixture, handle="y")
+        self.assertEqual(len(self.store), 2)
+
+    # ------------------------------------------------------------------
+    # Tier-2: cross-run analytics
+    # ------------------------------------------------------------------
+    def test_scan_returns_arrow_dataset_when_available(self):
+        try:
+            import pyarrow  # noqa: F401
+            import pyarrow.dataset  # noqa: F401
+        except ImportError:
+            self.skipTest("pyarrow not installed")
+        self.store.write(self.fixture, handle="a")
+        self.store.write(self.fixture, handle="b")
+        ds = self.store.scan("portfolio_snapshots")
+        # Fixture may have empty snapshots; dataset may be None if no
+        # sidecar was written. Tolerate both — what we are asserting
+        # is that the scan API works when sidecars are present.
+        if ds is None:
+            return
+        table = ds.to_table()
+        self.assertIn("run_id", table.column_names)
+        # If any rows were written, run_id values are a subset of our
+        # two handles.
+        if table.num_rows:
+            unique = set(table.column("run_id").to_pylist())
+            self.assertTrue(unique.issubset({"a", "b"}))
+
+    def test_scan_unknown_dataset_raises(self):
+        with self.assertRaises(ValueError):
+            self.store.scan("nope")
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom — interop with LocalDirStore
+    # ------------------------------------------------------------------
+    def test_copy_from_local_dir_store(self):
+        src = LocalDirStore(tempfile.mkdtemp())
+        try:
+            src.write(self.fixture, handle="alpha")
+            src.write(self.fixture, handle="beta")
+            n = self.store.copy_from(src)
+            self.assertEqual(n, 2)
+            self.assertEqual(len(self.store), 2)
+            self.assertTrue(self.store.exists("alpha"))
+            self.assertTrue(self.store.exists("beta"))
+        finally:
+            shutil.rmtree(src.root, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Maintenance
+    # ------------------------------------------------------------------
+    def test_rebuild_index_recreates_tier1(self):
+        self.store.write(self.fixture, handle="rebuild_me")
+        # Drop the sqlite file and rebuild from the bundles.
+        (Path(self.tmp) / "index.sqlite").unlink()
+        n = self.store.rebuild_index()
+        self.assertEqual(n, 1)
+        rows = list(self.store.iter_index_rows())
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].bundle_path, "rebuild_me")
+
+    # ------------------------------------------------------------------
+    # Errors
+    # ------------------------------------------------------------------
+    def test_open_missing_handle_raises(self):
+        with self.assertRaises(StoreHandleNotFoundError):
+            self.store.open("nope")
+
+    # ------------------------------------------------------------------
+    # Tier-2 with real rows (synthetic, not the fixture)
+    # ------------------------------------------------------------------
+    def test_tier2_partition_written_when_records_present(self):
+        try:
+            import pyarrow  # noqa: F401
+            import pyarrow.dataset as ds
+        except ImportError:
+            self.skipTest("pyarrow not installed")
+
+        # Patch decomposers to yield deterministic synthetic records.
+        from investing_algorithm_framework.services.backtest_store \
+            import decompose
+
+        original = decompose.DATASETS
+
+        def fake_snaps(_bt, run_id):
+            return [
+                {"ts": 1, "total_value": 100.0, "run_id": run_id},
+                {"ts": 2, "total_value": 110.0, "run_id": run_id},
+            ]
+
+        def fake_trades(_bt, run_id):
+            return [{"trade_id": "t1", "net_gain": 5.0, "run_id": run_id}]
+
+        def fake_orders(_bt, _run_id):
+            return []  # exercise the empty branch too
+
+        decompose.DATASETS = (
+            ("portfolio_snapshots", fake_snaps),
+            ("trades", fake_trades),
+            ("orders", fake_orders),
+        )
+        try:
+            self.store.write(self.fixture, handle="synthetic")
+            root = Path(self.tmp) / "parquet"
+            self.assertTrue(
+                (root / "portfolio_snapshots" / "run_id=synthetic").is_dir()
+            )
+            self.assertTrue(
+                (root / "trades" / "run_id=synthetic").is_dir()
+            )
+            # Empty orders => no partition directory.
+            self.assertFalse(
+                (root / "orders" / "run_id=synthetic").exists()
+            )
+
+            scan = self.store.scan("portfolio_snapshots")
+            self.assertIsNotNone(scan)
+            tbl = scan.to_table()
+            self.assertEqual(tbl.num_rows, 2)
+            self.assertIn("run_id", tbl.column_names)
+            self.assertEqual(
+                set(tbl.column("run_id").to_pylist()), {"synthetic"}
+            )
+        finally:
+            decompose.DATASETS = original


### PR DESCRIPTION
> **Stacked on #544** (`feature/iaf-backtest-store`), which is stacked on #543 → #537. Merge order: #537 → #543 → #544 → this PR.

Second slice of Phase 3 of epic #540 — adds a real tiered storage implementation that delivers the cross-run analytics value while keeping the canonical `.iafbt` bundle as the source of truth (full Tier-2-as-canonical lands in Phase 3d).

## What's in this PR

### Storage layout

```
<root>/
  index.sqlite                                  ← Tier-1, always in sync
  bundles/<handle>.iafbt                        ← canonical bytes
  parquet/
    portfolio_snapshots/run_id=<handle>/part-0.parquet   ← Tier-2 hive-partitioned
    trades/run_id=<handle>/part-0.parquet                ← Tier-2
    orders/run_id=<handle>/part-0.parquet                ← Tier-2
```

The bundle is the canonical representation. Tier-1 and Tier-2 are derived, eagerly maintained, and best-effort: a malformed sidecar never blocks a write or read against the bundle. This keeps Phase 3b's invariants simple and trivially preserves byte-identical `Backtest.save_bundle` / `Backtest.open` round-trips today. Byte-identical *Tier-2 → Backtest* reassembly (no bundle on the read path) is Phase 3d.

### Modules

- **`decompose.py`** — `Backtest` → flat record lists for snapshots / trades / orders, adding `run_id` and `window_name` columns so downstream tools group cleanly across walk-forward windows. Extension point for `metric_series` and any future kind is the `DATASETS` tuple.
- **`LocalTieredStore`** — implements `BacktestStore` + `SupportsCopyFrom`. `write()` saves the bundle, upserts the Tier-1 row, and writes hive-partitioned Parquet sidecars per dataset. `delete()` removes all three tiers. `iter_index_rows()` serves from SQLite directly. `rebuild_index()` recreates Tier-1 from the bundles (useful after a software upgrade that adds new index columns).

### Cross-run analytics

```python
store = LocalTieredStore("~/.iaf/store")
ds = store.scan("portfolio_snapshots")  # pyarrow.dataset.Dataset
df = ds.to_table(filter=ds.field("run_id") == "top_run_x").to_pandas()
```

Or directly from DuckDB:

```sql
SELECT run_id, total_value
FROM read_parquet('store/parquet/portfolio_snapshots/**/*.parquet',
                  hive_partitioning=True)
WHERE run_id IN (SELECT bundle_path FROM read_csv('top20.csv'));
```

Partition pruning on `run_id` is automatic — DuckDB scans only the relevant directories.

### Tests

15 new tests, all passing:

- Protocol + `SupportsCopyFrom` conformance.
- Three-tier layout on `write()`.
- Handle normalisation (`.iafbt` suffix stripped).
- Round-trip preserves `algorithm_id`; `summary_only` honoured.
- Tier-1 always in sync: `iter_index_rows` after writes; `delete` removes all tiers; `__len__` uses the index.
- Tier-2 cross-run scan returns an Arrow `Dataset` with `run_id` column; unknown dataset name raises.
- `copy_from` from `LocalDirStore` (interop with Phase 3a).
- `rebuild_index()` recreates Tier-1 from bundles.
- Missing handles raise `StoreHandleNotFoundError`.
- Synthetic-records test asserts hive partitions are written and that `scan()` returns the expected rows + columns when records are present.

Targeted suite (`tests/services/backtest_store/` + `tests/services/backtest_index/` + `tests/cli/`): **101 / 101 passing**.

## What's still coming in Phase 3

| Slice | Scope |
|---|---|
| **3c** | Tier-3 content-addressed chunks (`ohlcv`, `code`, `params`, `symbols`) with SHA-256 dedup — where the 64 GB → 20 GB headline lives |
| **3d** | `iaf migrate-store --from local-dir --to local-tiered`; byte-identical Tier-2 → `Backtest` reassembly (`.iafbt` becomes export-only); the parameterised test fixture that runs every backtest test against both stores |