### PR TITLE
feat(store): iaf migrate-store + dual-store contract suite (epic #540 phase 3d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This framework is built around the full loop: **create strategies → vector bac
 - 📉 **[Benchmark Comparison](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Beat-rate analysis vs Buy & Hold, DCA, risk-free & custom benchmarks
 - 📄 **[One-Click HTML Report](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Self-contained file, no server, dark & light theme, shareable
 - 📦 **[Custom `.iafbt` Backtest Bundle Format](https://coding-kitties.github.io/investing-algorithm-framework/Data/backtest_data)** — An explicit, versioned, compressed, language-portable container (zstd + msgpack with magic-byte header) plus a separate parquet index for fast filtering without loading. ~21× smaller and ~27× fewer files than standard filebased directory layouts, with parallel I/O for fast load/save of large amounts of backtests.
+- 🗄️ **[Tiered Backtest Storage Layer](examples/storage_layer_demo/README.md)** — Manage thousands of `.iafbt` bundles with a Tier-1 SQLite index (sub-100 ms ranks/filters over 10k+ backtests), a swappable `BacktestStore` protocol (`LocalDirStore`, `LocalTieredStore`), content-addressed Tier-3 OHLCV deduplication, and a CLI (`iaf index` / `iaf list` / `iaf rank` / `iaf migrate-store`) that plugs straight into the HTML dashboard.
 - 🌐 **[Load External Data](https://coding-kitties.github.io/investing-algorithm-framework/Data/external-data)** — Fetch CSV, JSON, or Parquet from any URL with caching and auto-refresh
 - � **[Per-Market Deposit Schedules & Portfolio Sync](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/portfolio-sync)** — Declare recurring or one-shot external cash flows on a market with `deposit_schedule=` / `auto_sync=True`. Backtests simulate the deposits; live mode reconciles with the broker — same `context.sync_portfolio()` API in both modes.
 - �📝 **[Record Custom Variables](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/recording-variables)** — Track any indicator or metric during backtests with `context.record()`
@@ -142,6 +143,63 @@ Every backtest produces a **self-contained HTML dashboard** — open it in any b
 - **Notes keeping** — annotate every backtest with hypotheses, observations and conclusions; notes travel with the report so your research is never lost
 
 → [Backtest dashboard docs](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtesting) · [MCP server docs](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/mcp-server)
+
+</details>
+
+<details open>
+<summary>
+  <strong>Backtest Storage Layer — scale to thousands of backtests</strong>
+</summary> <br>
+
+Once you start sweeping parameter grids and walk-forward windows, a flat folder of `.iafbt` bundles stops scaling: every comparison re-decodes multi-MB Parquet metric blobs just to read a Sharpe number. The storage layer fixes that with three tiers behind a single `BacktestStore` protocol:
+
+- **Tier-1 — SQLite index (`index.sqlite`)**: one row per bundle with every scalar from `BacktestSummaryMetrics` promoted to its own column. Ranking 10k+ bundles becomes a sub-100 ms SQL query — no `.iafbt` is opened.
+- **Tier-2 — `BacktestStore` adapters**: `LocalDirStore` (flat folder of bundles) or `LocalTieredStore` (hive-partitioned layout). Same handle-based API, swap the implementation without touching call sites.
+- **Tier-3 — content-addressed OHLCV chunks**: SHA-256 deduped per-symbol OHLCV blobs shared across every bundle that references them. `garbage_collect_ohlcv()` reclaims orphans.
+
+A CLI ties it all together: `iaf index` builds/refreshes the Tier-1 SQLite, `iaf list` / `iaf rank` query it, and `iaf migrate-store` moves a whole collection between store kinds in one command.
+
+#### Typical workflow
+
+```python
+from investing_algorithm_framework import BacktestReport
+from investing_algorithm_framework.cli.index_command import (
+    build_index, rank_index,
+)
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+)
+
+# 1. Build (or refresh) the Tier-1 SQLite index over a folder of .iafbt bundles.
+build_index("./my-backtests/")          # equivalent to: iaf index ./my-backtests/
+
+# 2. Pick the top 20 by Sharpe straight from SQLite — no Parquet decoded.
+top = rank_index(
+    "./my-backtests/",
+    by="sharpe_ratio",
+    where="summary_number_of_trades > 50",
+    limit=20,
+)
+
+# 3. Materialise just those 20 bundles through the BacktestStore protocol.
+store = LocalDirStore("./my-backtests/")
+backtests = [store.open(row["bundle_path"]) for row in top]
+
+# 4. Feed them straight into the HTML dashboard.
+BacktestReport(backtests=backtests).save("top20.html")
+```
+
+Or from the shell:
+
+```bash
+iaf index ./my-backtests/
+iaf rank  ./my-backtests/ --by sharpe_ratio --where "summary_number_of_trades > 50" -n 20
+iaf list  ./my-backtests/ --sort calmar_ratio --json
+iaf migrate-store --from local-dir --src ./my-backtests/ \
+                  --to   local-tiered --dst ./tiered/
+```
+
+→ End-to-end runnable example: [`examples/storage_layer_demo/`](examples/storage_layer_demo/README.md)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,38 @@ Every backtest produces a **self-contained HTML dashboard** — open it in any b
 - **Built-in MCP server** — let Copilot, Claude, or any MCP-compatible agent query your backtests, rank strategies, and reason over trades through `investing-algorithm-framework mcp`
 - **Notes keeping** — annotate every backtest with hypotheses, observations and conclusions; notes travel with the report so your research is never lost
 
+#### From backtest results to a report
+
+Every backtest API — vector or event-driven — returns the same `Backtest` object, which the `BacktestReport` consumes directly. So whether you're iterating over an in-memory list or a folder of persisted `.iafbt` bundles, the path to the dashboard is the same:
+
+```python
+from investing_algorithm_framework import BacktestReport
+
+# --- Single event-driven backtest ---
+backtest = app.run_backtest(backtest_date_range=date_range)
+BacktestReport(backtests=[backtest]).save("event_report.html")
+
+# --- A sweep of vector backtests (parameter grid / multi-window) ---
+backtests = app.run_vector_backtests(
+    strategies=[StrategyA(), StrategyB(), StrategyC()],
+    backtest_date_ranges=[range_2022, range_2023, range_2024],
+    n_workers=-1,
+    backtest_storage_directory="./my-backtests/",  # persists .iafbt bundles
+    show_progress=True,
+)
+BacktestReport(backtests=backtests).save("sweep_report.html")
+
+# --- Or: load a folder of bundles back later (parallel decode) ---
+report = BacktestReport.open(
+    directory_path="./my-backtests/",
+    workers=-1,
+    show_progress=True,
+)
+report.save("from_disk_report.html")
+```
+
+For sweeps that grow into the thousands, combine this with the [Backtest Storage Layer](examples/storage_layer_demo/README.md) below — rank in SQLite first, then load only the winners into the report.
+
 → [Backtest dashboard docs](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtesting) · [MCP server docs](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/mcp-server)
 
 </details>

--- a/docusaurus/docs/Getting Started/backtest-reports.md
+++ b/docusaurus/docs/Getting Started/backtest-reports.md
@@ -6,6 +6,10 @@ sidebar_position: 10
 
 The framework generates self-contained HTML dashboard reports for analyzing backtest results. Reports work for both single and multi-strategy backtests — no external dependencies required.
 
+:::tip Working with hundreds or thousands of backtests?
+A `BacktestReport` inlines every backtest into a single HTML file, which becomes too heavy for a browser past a few dozen backtests. Use the [Backtest Storage Layer](./backtest-storage.md) to filter your collection down (in SQLite, sub-100 ms) and render reports only over the winners.
+:::
+
 ## Quick Start
 
 ```python

--- a/docusaurus/docs/Getting Started/backtest-storage.md
+++ b/docusaurus/docs/Getting Started/backtest-storage.md
@@ -1,0 +1,235 @@
+---
+sidebar_position: 11
+---
+
+# Backtest Storage Layer
+
+Once you start sweeping parameter grids and walk-forward windows, you quickly end up with **hundreds or thousands of backtests on disk**. A flat folder of `.iafbt` bundles works for tens of them, but it stops scaling once you want to compare them all in a single HTML dashboard — every comparison re-decodes multi-MB Parquet metric blobs just to read a Sharpe number, and the resulting `report.html` becomes too heavy for a browser to open.
+
+The **backtest storage layer** is the framework's answer to that. It separates *where bundles live* from *how you query them*, and it gives you the tools to keep your dashboards fast even when the backing collection grows into the thousands.
+
+## Mental model
+
+```
+                ┌─────────────────────────────────────────────┐
+                │  Tier-1: SQLite index   (index.sqlite)      │
+                │   - one row per .iafbt                      │
+                │   - all summary metrics promoted to columns │
+                │   - sub-100 ms ranks / filters over 10k+    │
+                └─────────────────────────────────────────────┘
+                                    │ derived from
+                                    ▼
+                ┌─────────────────────────────────────────────┐
+                │  Tier-2: Parquet sidecars (analytics-ready) │
+                │   - hive-partitioned on run_id              │
+                │   - portfolio_snapshots / trades / orders   │
+                └─────────────────────────────────────────────┘
+                                    │ derived from
+                                    ▼
+                ┌─────────────────────────────────────────────┐
+                │  CANONICAL: .iafbt bundles                  │
+                │   - the single source of truth              │
+                │   - everything else can be rebuilt from it  │
+                └─────────────────────────────────────────────┘
+                                    │ references
+                                    ▼
+                ┌─────────────────────────────────────────────┐
+                │  Tier-3: content-addressed OHLCV chunks     │
+                │   - <sha256>.parquet, deduped across all    │
+                │     bundles that reference the same data    │
+                └─────────────────────────────────────────────┘
+```
+
+The `.iafbt` bundle is **canonical**. The SQLite index, the Tier-2 Parquet sidecars and the Tier-3 OHLCV chunks are all *derived* — they can be rebuilt from the bundles at any time and they're best-effort: a malformed sidecar never blocks a write or read against the bundle.
+
+## The `BacktestStore` protocol
+
+Two concrete implementations ship today, both exposing the same API:
+
+| Store | Layout | Best for |
+|---|---|---|
+| `LocalDirStore` | flat folder of `.iafbt` files (+ `index.sqlite`) | Most users, simple to inspect, fast `ls` |
+| `LocalTieredStore` | full Tier-1/2/3 layout | Large collections, OHLCV dedup, analytics workflows |
+
+Both are drop-in interchangeable — swap the implementation without touching call sites:
+
+```python
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+)
+from investing_algorithm_framework.services.backtest_store.\
+local_tiered_store import LocalTieredStore
+
+store = LocalDirStore("./my-backtests/")
+# store = LocalTieredStore("./my-backtests/")  # same API
+
+len(store)                       # how many bundles?
+"momentum_v1.iafbt" in store     # exists?
+bt = store.open("momentum_v1.iafbt")
+for handle in store.iter_handles():
+    ...
+```
+
+## The normal developer workflow
+
+Below is the canonical loop most users will run. The **same five steps** hold whether you have 10 backtests or 10,000 — you just lean harder on the index as the collection grows.
+
+### 1. Run a sweep, persist the bundles
+
+```python
+backtests = app.run_vector_backtests(
+    strategies=[StrategyA(), StrategyB(), StrategyC()],
+    backtest_date_ranges=[range_2022, range_2023, range_2024],
+    n_workers=-1,
+    backtest_storage_directory="./my-backtests/",   # writes .iafbt here
+    show_progress=True,
+)
+```
+
+After this you have a folder of `.iafbt` bundles on disk. That folder is *the* artifact — everything downstream operates on it.
+
+### 2. Build the Tier-1 index
+
+```bash
+iaf index ./my-backtests/
+```
+
+Or from Python:
+
+```python
+from investing_algorithm_framework.cli.index_command import build_index
+build_index("./my-backtests/")
+```
+
+This walks the folder once, writes `index.sqlite` with every scalar from `BacktestSummaryMetrics` promoted to its own column, and is **idempotent** — re-run it any time after adding new bundles.
+
+### 3. Filter / rank in SQLite (no bundles opened)
+
+The point of the index is that **you never need to decode a Parquet metric blob just to choose which backtests are interesting**. Pick winners with a SQL `WHERE` clause:
+
+```python
+from investing_algorithm_framework.cli.index_command import (
+    list_index, rank_index,
+)
+
+# Top 20 by Sharpe, but only among bundles with > 50 trades.
+top = rank_index(
+    "./my-backtests/",
+    by="sharpe_ratio",
+    where="summary_number_of_trades > 50",
+    limit=20,
+)
+
+for r in top:
+    print(r["algorithm_id"], r["summary_sharpe_ratio"])
+```
+
+Or from the shell:
+
+```bash
+iaf rank ./my-backtests/ \
+    --by sharpe_ratio \
+    --where "summary_number_of_trades > 50" -n 20
+iaf list ./my-backtests/ --sort calmar_ratio --json
+```
+
+This step is **sub-100 ms** even over 10k+ bundles. No Parquet, no decompression, no bundle opens.
+
+### 4. Materialise only the bundles you actually need
+
+```python
+store = LocalDirStore("./my-backtests/")
+backtests = [store.open(row["bundle_path"]) for row in top]
+```
+
+`bundle_path` from the index row is exactly the store handle, so this is a one-liner. **You only pay the bundle-decode cost for the bundles you selected**, not the whole collection.
+
+### 5. Render the report
+
+```python
+from investing_algorithm_framework import BacktestReport
+
+BacktestReport(backtests=backtests).save("top20.html")
+```
+
+That's the whole loop.
+
+## Avoid overloading your `report.html`
+
+The `BacktestReport` produces a **self-contained** HTML file: every backtest's full per-run data (equity curve, drawdown series, trades, positions, monthly returns) is inlined into the document so the dashboard works offline with no server.
+
+The trade-off: file size grows linearly with the number of backtests inlined. Rough orders of magnitude:
+
+| Backtests in report | Approx. HTML size | Browser experience |
+|---|---|---|
+| 1 – 10 | tens of KB to ~1 MB | instant |
+| 10 – 50 | a few MB | smooth |
+| 50 – 200 | 10 – 50 MB | slower load, still usable |
+| 200+ | 100 MB+ | browsers struggle / refuse to open |
+
+The point of the storage layer is that **you don't need to put 200 backtests in one report to compare them**. The Tier-1 index is your comparison surface for the full collection; the HTML report is your deep-dive surface for a small, hand-picked subset.
+
+### Anti-pattern
+
+```python
+# DON'T do this with thousands of bundles.
+report = BacktestReport.open(directory_path="./my-backtests/", workers=-1)
+report.save("everything.html")     # multi-hundred-MB file, browser dies
+```
+
+This decodes every bundle in the folder and inlines all of them. Fine for a few dozen; fatal at scale.
+
+### The right pattern
+
+```python
+# Filter in SQLite first, then render only the winners.
+top = rank_index("./my-backtests/", by="sharpe_ratio", limit=25)
+store = LocalDirStore("./my-backtests/")
+BacktestReport(
+    backtests=[store.open(r["bundle_path"]) for r in top],
+).save("top25_by_sharpe.html")
+```
+
+Same principle applies for slicing by anything else — most-trades, best-Calmar, lowest-drawdown, only-2024-windows, only-momentum-strategies, etc. Compose multiple narrow reports rather than one giant one.
+
+### Rules of thumb
+
+- **Keep any single `report.html` to ≤ 50 backtests.** Past that, render multiple narrower reports (one per strategy family, one per regime, one for the top-N) instead of one mega-report.
+- **Use the index as your comparison plane** for the full collection. CLI: `iaf list` / `iaf rank`. Python: `list_index` / `rank_index`. SQL: `sqlite3 index.sqlite` for anything ad-hoc.
+- **Render for the audience.** A "winners" report (top 10–20) is what you actually send to teammates. A "full deep-dive" report on one strategy is what you keep for yourself.
+- **Don't trust `BacktestReport.open(directory_path=…)` at scale.** It walks and decodes the whole folder; it's a convenience for ≤ 50-bundle directories, not a scaling story.
+
+## When to use which store
+
+- **`LocalDirStore`** — start here. A flat folder of `.iafbt` files is what every other tool understands (you can `ls`, `rsync`, `tar`, `git lfs` it). Tier-1 SQLite gets built next to the bundles. This is the default for `app.run_vector_backtests(backtest_storage_directory=...)`.
+
+- **`LocalTieredStore`** — switch to this when you need any of:
+  - **Cross-bundle analytics** without decoding bundles (DuckDB / Polars over the Tier-2 Parquet sidecars: `read_parquet('store/parquet/trades/**/*.parquet', hive_partitioning=True)`).
+  - **OHLCV deduplication** — every bundle that references the same `BTC/EUR:1h` data shares one `<sha256>.parquet` blob on disk; reclaim orphans with `store.garbage_collect_ohlcv()`.
+  - **Migration target** for archival / production pipelines.
+
+Move a whole collection between store kinds with a single command:
+
+```bash
+iaf migrate-store --from local-dir    --src ./my-backtests/ \
+                  --to   local-tiered --dst ./tiered/
+```
+
+## End-to-end runnable example
+
+A complete worked example (seed bundles → build index → rank → load winners → render dashboard) lives in the repo at [`examples/storage_layer_demo/`](https://github.com/coding-kitties/investing-algorithm-framework/tree/main/examples/storage_layer_demo). Run it from a checkout:
+
+```bash
+source .venv/bin/activate
+python examples/storage_layer_demo/demo.py
+```
+
+It prints each step, leaves the bundles + index + dashboard in a temp directory, and shows you the exact `iaf` CLI commands you could run by hand against the same data.
+
+## Reference
+
+- CLI: `iaf index`, `iaf list`, `iaf rank`, `iaf migrate-store` (see `iaf <cmd> --help`)
+- Python: `investing_algorithm_framework.cli.index_command.{build_index, list_index, rank_index}`
+- Stores: `investing_algorithm_framework.services.backtest_store.{LocalDirStore, LocalTieredStore}`
+- Bundle format: see [Backtest Data](../Data/backtest_data.md)
+- Report API: see [Backtest Reports](./backtest-reports.md)

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -59,6 +59,10 @@ const sidebars = {
                 },
                 {
                     type: 'doc',
+                    id: 'Getting Started/backtest-storage',
+                },
+                {
+                    type: 'doc',
                     id: 'Getting Started/metrics',
                 },
                 {

--- a/examples/storage_layer_demo/README.md
+++ b/examples/storage_layer_demo/README.md
@@ -45,12 +45,21 @@ The script will:
 3. Print the equivalent `iaf` CLI commands you could run by hand.
 4. Run `list_index` / `rank_index` / a raw SQL query and print
    the formatted tables.
-5. Open the top-ranked bundle and print its full backtest report
+5. Open the top-ranked bundle and print its compact backtest report
    (this is the only step that decodes per-run Parquet metric blobs).
-6. Walk the index in rank order and print a one-line summary per
+6. Render an _expanded_ report for the same winning bundle —
+   per-run breakdown, end-of-backtest positions, the first few
+   trades, and a richer slice of per-run risk / return metrics.
+7. Walk the index in rank order and print a one-line summary per
    bundle straight out of the SQLite index — no bundle is opened.
-7. Iterate every bundle in rank order and print a full per-bundle
+8. Iterate every bundle in rank order and print a full per-bundle
    report so you can scan _all_ backtests at a glance.
+9. Tie the storage layer end-to-end into the **HTML dashboard**:
+   pick the top-N bundles via `rank_index` (Tier-1 SQLite only),
+   load each one through `LocalDirStore.open(handle)` (the
+   `BacktestStore` protocol), and feed the resulting list straight
+   into `BacktestReport(...).save(...)`. Open the generated
+   `dashboard.html` to see all selected backtests side-by-side.
 
 ## CLI cheatsheet
 

--- a/examples/storage_layer_demo/demo.py
+++ b/examples/storage_layer_demo/demo.py
@@ -32,6 +32,10 @@ from investing_algorithm_framework.cli.index_command import (
     rank_index,
     format_table,
 )
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+)
+from investing_algorithm_framework import BacktestReport
 
 
 # Directory-format fixture shipped with the test suite. We use it
@@ -107,6 +111,103 @@ def _print_backtest_report(bt: Backtest) -> None:
         None if s.win_rate is None else s.win_rate * 100,
         ".2f",
     )
+
+
+def _print_backtest_full_report(bt: Backtest) -> None:
+    """Render a detailed multi-section report for a single backtest.
+
+    Goes beyond :func:`_print_backtest_report` by walking the
+    per-run breakdown, listing positions, and showing the first few
+    trades/orders so the demo's "open the winner" step actually
+    looks like a backtest report and not just a summary row.
+    """
+    _print_backtest_report(bt)
+
+    runs = bt.backtest_runs or []
+    if not runs:
+        return
+
+    # ------------------- per-run breakdown -------------------
+    print("\n  --- per-run breakdown ---")
+    header = (
+        f"  {'#':>2} {'window':<20} {'days':>5} {'orders':>7} "
+        f"{'trades':>7} {'positions':>10} {'final_value':>14}"
+    )
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for i, r in enumerate(runs, start=1):
+        window = (
+            r.backtest_date_range_name
+            if r.backtest_date_range_name
+            else f"{r.backtest_start_date.date()}..{r.backtest_end_date.date()}"
+        )[:20]
+        m = r.backtest_metrics
+        final = (
+            f"{float(m.final_value):.2f}"
+            if m is not None and getattr(m, "final_value", None) is not None
+            else "n/a"
+        )
+        print(
+            f"  {i:>2} {window:<20} {r.number_of_days:>5} "
+            f"{r.number_of_orders:>7} {r.number_of_trades:>7} "
+            f"{r.number_of_positions:>10} {final:>14}"
+        )
+
+    # ------------------- positions snapshot -------------------
+    last = runs[-1]
+    positions = list(getattr(last, "positions", None) or [])
+    if positions:
+        print(f"\n  --- positions (last run, {len(positions)}) ---")
+        for p in positions[:10]:
+            symbol = getattr(p, "symbol", None) or "?"
+            amount = getattr(p, "amount", None)
+            cost = getattr(p, "cost", None)
+            print(
+                f"  {symbol:<14} amount={amount}  cost={cost}"
+            )
+        if len(positions) > 10:
+            print(f"  ... and {len(positions) - 10} more")
+
+    # ------------------- trades preview -------------------
+    trades = list(getattr(last, "trades", None) or [])
+    if trades:
+        print(f"\n  --- trades (last run, {len(trades)} total, first 5) ---")
+        for t in trades[:5]:
+            print(
+                f"  {getattr(t, 'symbol', '?'):<10} "
+                f"opened={getattr(t, 'opened_at', None)} "
+                f"net_gain={getattr(t, 'net_gain', None)}"
+            )
+
+    # ------------------- richer metrics from first run -------------------
+    m = runs[0].backtest_metrics
+    if m is None:
+        return
+    print("\n  --- additional risk / return metrics (first run) ---")
+    extras = [
+        ("cagr", "cagr", ".4f"),
+        ("annual_volatility", "annual_volatility", ".4f"),
+        ("max_drawdown_abs", "max_drawdown_absolute", ".2f"),
+        ("max_drawdown_dur", "max_drawdown_duration", ""),
+        ("gross_profit", "gross_profit", ".2f"),
+        ("gross_loss", "gross_loss", ".2f"),
+        ("best_trade", "best_trade", ".2f"),
+        ("max_consec_wins", "max_consecutive_wins", ""),
+        ("max_consec_losses", "max_consecutive_losses", ""),
+    ]
+    for label, attr, fmt in extras:
+        val = getattr(m, attr, None)
+        if val is None:
+            rendered = "n/a"
+        elif fmt:
+            try:
+                rendered = format(float(val), fmt)
+            except (TypeError, ValueError):
+                rendered = str(val)
+        else:
+            rendered = str(val)
+        print(f"  {label:<22}: {rendered}")
+
 
 
 def _seed_bundles(out_dir: Path, n: int = 6) -> None:
@@ -241,6 +342,20 @@ def main() -> None:
     _print_backtest_report(winner_bt)
 
     # ------------------------------------------------------------------
+    # 6b. Full backtest report — per-run breakdown, positions, trades
+    # ------------------------------------------------------------------
+    _print_section(
+        "6b. Full backtest report for the winner "
+        "(runs / positions / trades)"
+    )
+    print(
+        "Same bundle, expanded view: per-run breakdown, end-of-backtest "
+        "positions, the first few trades, and a richer slice of "
+        "per-run risk/return metrics.\n"
+    )
+    _print_backtest_full_report(winner_bt)
+
+    # ------------------------------------------------------------------
     # 7. Iterate the index and print a one-line report per backtest
     # ------------------------------------------------------------------
     _print_section(
@@ -273,15 +388,63 @@ def main() -> None:
         _print_backtest_report(bt)
 
     # ------------------------------------------------------------------
+    # 9. Storage layer -> HTML dashboard
+    # ------------------------------------------------------------------
+    _print_section(
+        "9. Storage layer -> HTML dashboard "
+        "(rank in SQLite, load via store, render report)"
+    )
+    print(
+        "Wire the Tier-1 SQLite index, the Tier-2 LocalDirStore and the\n"
+        "BacktestReport HTML dashboard end-to-end:\n"
+        "  1. rank_index() picks the top-N bundles from SQLite alone\n"
+        "     (no Parquet metric blob is decoded yet).\n"
+        "  2. LocalDirStore.open(handle) materialises just those\n"
+        "     bundles through the BacktestStore protocol.\n"
+        "  3. BacktestReport(backtests=[...]).save(path) renders the\n"
+        "     interactive HTML dashboard with every loaded bundle.\n"
+    )
+    store = LocalDirStore(work)
+    print(f"  store          : {type(store).__name__}({work})")
+    print(f"  bundles in store: {len(store)}")
+
+    top = rank_index(str(work), by="sharpe_ratio", limit=3)
+    print(f"  top-3 by sharpe: {[r['algorithm_id'] for r in top]}")
+
+    loaded: list[Backtest] = []
+    for r in top:
+        # The Tier-1 row's bundle_path is relative to the store root,
+        # which is exactly what LocalDirStore uses as a handle.
+        handle = r["bundle_path"]
+        bt = store.open(handle)
+        loaded.append(bt)
+        print(
+            f"    store.open({handle!r}) -> {bt.algorithm_id} "
+            f"({len(bt.backtest_runs)} run(s))"
+        )
+
+    report = BacktestReport(backtests=loaded)
+    html_path = work / "dashboard.html"
+    report.save(str(html_path))
+    html_size_kb = os.path.getsize(html_path) / 1024.0
+    print(
+        f"\n  wrote HTML dashboard -> {html_path}\n"
+        f"  size: {html_size_kb:.1f} KB "
+        f"(self-contained: CSS + JS + data inlined)\n"
+        f"  open it with:  open {html_path}"
+    )
+
+    # ------------------------------------------------------------------
     # Wrap up
     # ------------------------------------------------------------------
     _print_section("Done")
     print(
-        "Bundles + index left in:\n"
+        "Bundles + index + dashboard left in:\n"
         f"  {work}\n"
         "Try the CLI directly:\n"
         f"  iaf list {work} --sort calmar_ratio --json\n"
         f"  iaf rank {work} --by sharpe_ratio -n 3\n"
+        f"  open {work / 'dashboard.html'}\n"
     )
 
 

--- a/investing_algorithm_framework/cli/cli.py
+++ b/investing_algorithm_framework/cli/cli.py
@@ -322,6 +322,78 @@ def migrate_backtests_cmd(
 cli.add_command(migrate_backtests_cmd)
 
 
+_STORE_KINDS = ["local-dir", "local-tiered"]
+
+
+@click.command(name="migrate-store")
+@click.option(
+    "--from", "src_kind",
+    type=click.Choice(_STORE_KINDS),
+    required=True,
+    help="Source store kind.",
+)
+@click.option(
+    "--src",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    required=True,
+    help="Path to the source store root.",
+)
+@click.option(
+    "--to", "dst_kind",
+    type=click.Choice(_STORE_KINDS),
+    required=True,
+    help="Destination store kind.",
+)
+@click.option(
+    "--dst",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=True,
+    help="Path to the destination store root (created if missing).",
+)
+@click.option(
+    "--handles",
+    default=None,
+    help=(
+        "Optional comma-separated subset of source handles to copy. "
+        "When omitted, every handle is copied."
+    ),
+)
+def migrate_store_cmd(src_kind, src, dst_kind, dst, handles):
+    """Copy backtests between two :class:`BacktestStore` implementations.
+
+    Uses the destination's :class:`SupportsCopyFrom` capability so the
+    operation is incremental, restartable, and tier-aware: when copying
+    into a ``local-tiered`` store, identical OHLCV chunks are written
+    exactly once across the entire destination, regardless of how many
+    bundles reference them (epic #540 phase 3c).
+
+    Example::
+
+        iaf migrate-store --from local-dir --src ./bt-old \\
+                          --to local-tiered --dst ./bt-new
+    """
+    from .migrate_store_command import migrate_store
+
+    handle_list = (
+        [h.strip() for h in handles.split(",") if h.strip()]
+        if handles else None
+    )
+    n = migrate_store(
+        src_kind=src_kind,
+        src_root=src,
+        dst_kind=dst_kind,
+        dst_root=dst,
+        handles=handle_list,
+    )
+    click.echo(
+        f"Migrated {n} backtest(s) from {src_kind}:{src} "
+        f"to {dst_kind}:{dst}"
+    )
+
+
+cli.add_command(migrate_store_cmd)
+
+
 @click.command(name="index")
 @click.argument(
     "directory",

--- a/investing_algorithm_framework/cli/migrate_store_command.py
+++ b/investing_algorithm_framework/cli/migrate_store_command.py
@@ -1,0 +1,67 @@
+"""``iaf migrate-store`` — copy backtests between :class:`BacktestStore`
+implementations using the :class:`SupportsCopyFrom` capability.
+
+Phase 3d of epic #540.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from investing_algorithm_framework.services.backtest_store import (
+    BacktestStore,
+    LocalDirStore,
+    LocalTieredStore,
+    SupportsCopyFrom,
+)
+
+
+_STORE_FACTORIES = {
+    "local-dir": lambda root: LocalDirStore(root),
+    "local-tiered": lambda root: LocalTieredStore(root),
+}
+
+
+def _build_store(kind: str, root: str) -> BacktestStore:
+    if kind not in _STORE_FACTORIES:
+        raise ValueError(
+            f"unknown store kind {kind!r}; expected one of "
+            f"{sorted(_STORE_FACTORIES)}"
+        )
+    return _STORE_FACTORIES[kind](root)
+
+
+def migrate_store(
+    *,
+    src_kind: str,
+    src_root: str,
+    dst_kind: str,
+    dst_root: str,
+    handles: Optional[list] = None,
+) -> int:
+    """Copy backtests from one store to another.
+
+    Args:
+        src_kind: One of ``"local-dir"``, ``"local-tiered"``.
+        src_root: Path to the source store root.
+        dst_kind: Same vocabulary as ``src_kind``.
+        dst_root: Path to the destination store root.
+        handles: Optional subset of source handles to copy. When
+            ``None`` every handle in the source is copied.
+
+    Returns:
+        The number of backtests written to the destination.
+
+    Raises:
+        TypeError: When the destination store does not implement
+            :class:`SupportsCopyFrom`.
+    """
+    src = _build_store(src_kind, src_root)
+    Path(dst_root).mkdir(parents=True, exist_ok=True)
+    dst = _build_store(dst_kind, dst_root)
+    if not isinstance(dst, SupportsCopyFrom):
+        raise TypeError(
+            f"destination store {dst_kind!r} does not implement "
+            f"SupportsCopyFrom"
+        )
+    return dst.copy_from(src, handles=handles)

--- a/investing_algorithm_framework/domain/backtesting/bundle.py
+++ b/investing_algorithm_framework/domain/backtesting/bundle.py
@@ -318,6 +318,14 @@ class LazyOhlcvDict(Dict[str, Any]):
     def keys(self):  # type: ignore[override]
         return self._manifest.keys()
 
+    def values(self):  # type: ignore[override]
+        for k in self._manifest:
+            yield self[k]
+
+    def items(self):  # type: ignore[override]
+        for k in self._manifest:
+            yield k, self[k]
+
     def __getitem__(self, key: str):
         if key in self._cache:
             return self._cache[key]

--- a/tests/cli/test_migrate_store_command.py
+++ b/tests/cli/test_migrate_store_command.py
@@ -1,0 +1,184 @@
+"""Tests for ``iaf migrate-store`` (epic #540 phase 3d)."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from unittest import TestCase
+
+import pandas as pd
+from click.testing import CliRunner
+
+from investing_algorithm_framework.cli.cli import migrate_store_cmd
+from investing_algorithm_framework.cli.migrate_store_command import (
+    migrate_store,
+)
+from investing_algorithm_framework.domain import Backtest
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+    LocalTieredStore,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+def _make_ohlcv(symbol: str, *, n: int = 4, base: float = 100.0) -> dict:
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    df = pd.DataFrame(
+        {
+            "Datetime": idx,
+            "Open": [base + i for i in range(n)],
+            "High": [base + i + 0.5 for i in range(n)],
+            "Low": [base + i - 0.5 for i in range(n)],
+            "Close": [base + i + 0.25 for i in range(n)],
+            "Volume": [1000 + i for i in range(n)],
+        }
+    )
+    return {f"{symbol}:1h": df}
+
+
+class TestMigrateStore(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.src_dir = tempfile.mkdtemp()
+        self.dst_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.src_dir, ignore_errors=True)
+        shutil.rmtree(self.dst_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Programmatic API
+    # ------------------------------------------------------------------
+    def test_local_dir_to_local_tiered(self):
+        src = LocalDirStore(self.src_dir)
+        src.write(self.fixture, handle="a")
+        src.write(self.fixture, handle="b")
+
+        n = migrate_store(
+            src_kind="local-dir", src_root=self.src_dir,
+            dst_kind="local-tiered", dst_root=self.dst_dir,
+        )
+        self.assertEqual(n, 2)
+
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertEqual(len(dst), 2)
+        self.assertTrue(dst.exists("a"))
+        self.assertTrue(dst.exists("b"))
+        # Tier-1 was populated.
+        self.assertTrue((Path(self.dst_dir) / "index.sqlite").is_file())
+
+    def test_handles_subset(self):
+        src = LocalDirStore(self.src_dir)
+        src.write(self.fixture, handle="a")
+        src.write(self.fixture, handle="b")
+        src.write(self.fixture, handle="c")
+
+        n = migrate_store(
+            src_kind="local-dir", src_root=self.src_dir,
+            dst_kind="local-tiered", dst_root=self.dst_dir,
+            handles=["a", "c"],
+        )
+        self.assertEqual(n, 2)
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertSetEqual(
+            set(dst.iter_handles()), {"a", "c"},
+        )
+
+    def test_ohlcv_dedup_during_migration(self):
+        # Source is a tiered store (preserves OHLCV); destination is
+        # a fresh tiered store. After migration, identical OHLCV must
+        # collapse to a single chunk on the destination too.
+        src = LocalTieredStore(self.src_dir)
+        bt1 = deepcopy(self.fixture)
+        bt1.ohlcv = _make_ohlcv("BTC/EUR")
+        bt2 = deepcopy(self.fixture)
+        bt2.ohlcv = _make_ohlcv("BTC/EUR")
+        src.write(bt1, handle="a")
+        src.write(bt2, handle="b")
+        # Sanity: src already deduped to one chunk.
+        self.assertEqual(src.ohlcv_stats()["stored_blobs"], 1)
+
+        n = migrate_store(
+            src_kind="local-tiered", src_root=self.src_dir,
+            dst_kind="local-tiered", dst_root=self.dst_dir,
+        )
+        self.assertEqual(n, 2)
+
+        # Phase 3c invariant: identical OHLCV stored once even though
+        # two bundles reference it.
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertEqual(dst.ohlcv_stats()["stored_blobs"], 1)
+        self.assertEqual(dst.ohlcv_stats()["referenced_blobs"], 1)
+
+    def test_unknown_kind_raises(self):
+        with self.assertRaises(ValueError):
+            migrate_store(
+                src_kind="local-dir", src_root=self.src_dir,
+                dst_kind="bogus", dst_root=self.dst_dir,
+            )
+
+    # ------------------------------------------------------------------
+    # CLI
+    # ------------------------------------------------------------------
+    def test_cli_round_trip(self):
+        src = LocalDirStore(self.src_dir)
+        src.write(self.fixture, handle="cli_a")
+        src.write(self.fixture, handle="cli_b")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            migrate_store_cmd,
+            [
+                "--from", "local-dir", "--src", self.src_dir,
+                "--to", "local-tiered", "--dst", self.dst_dir,
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Migrated 2 backtest(s)", result.output)
+
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertEqual(len(dst), 2)
+
+    def test_cli_handles_subset(self):
+        src = LocalDirStore(self.src_dir)
+        for h in ("h1", "h2", "h3"):
+            src.write(self.fixture, handle=h)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            migrate_store_cmd,
+            [
+                "--from", "local-dir", "--src", self.src_dir,
+                "--to", "local-tiered", "--dst", self.dst_dir,
+                "--handles", "h1,h3",
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Migrated 2 backtest(s)", result.output)
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertSetEqual(set(dst.iter_handles()), {"h1", "h3"})
+
+    def test_cli_rejects_unknown_kind(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            migrate_store_cmd,
+            [
+                "--from", "bogus", "--src", self.src_dir,
+                "--to", "local-tiered", "--dst", self.dst_dir,
+            ],
+        )
+        # Click choice validation rejects with non-zero exit.
+        self.assertNotEqual(result.exit_code, 0)

--- a/tests/services/backtest_store/test_store_contract.py
+++ b/tests/services/backtest_store/test_store_contract.py
@@ -1,0 +1,178 @@
+"""Parameterised conformance tests that run identical scenarios against
+every concrete :class:`BacktestStore` implementation.
+
+The point is to catch divergence early: any future store
+(``LocalDirStore``, ``LocalTieredStore``, future remote stores) must
+satisfy the exact same behavioural contract here. Any divergence
+shows up as a failing subTest with the store class name in the label.
+
+Phase 3d of epic #540.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from typing import Callable, List
+from unittest import TestCase
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_store import (
+    BacktestStore,
+    LocalDirStore,
+    LocalTieredStore,
+    StoreHandleNotFoundError,
+    SupportsCopyFrom,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+# (label, factory) pairs — every store kind exercised by the contract.
+_STORES: List[tuple] = [
+    ("LocalDirStore", lambda root: LocalDirStore(root)),
+    ("LocalTieredStore", lambda root: LocalTieredStore(root)),
+]
+
+
+class BacktestStoreContractTest(TestCase):
+    """Behavioural contract every :class:`BacktestStore` must satisfy."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def _each_store(self, body: Callable[[BacktestStore, str], None]):
+        for label, factory in _STORES:
+            with self.subTest(store=label):
+                root = tempfile.mkdtemp()
+                try:
+                    body(factory(root), root)
+                finally:
+                    shutil.rmtree(root, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Protocol conformance
+    # ------------------------------------------------------------------
+    def test_implements_protocol(self):
+        def body(store, _root):
+            self.assertIsInstance(store, BacktestStore)
+            self.assertIsInstance(store, SupportsCopyFrom)
+        self._each_store(body)
+
+    # ------------------------------------------------------------------
+    # write / open / exists / delete
+    # ------------------------------------------------------------------
+    def test_write_then_open_round_trips_algorithm_id(self):
+        def body(store, _root):
+            handle = store.write(self.fixture, handle="rt")
+            loaded = store.open(handle)
+            self.assertEqual(loaded.algorithm_id, self.fixture.algorithm_id)
+        self._each_store(body)
+
+    def test_summary_only_open(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="so")
+            bt = store.open("so", summary_only=True)
+            self.assertEqual(bt.algorithm_id, self.fixture.algorithm_id)
+        self._each_store(body)
+
+    def test_exists_reflects_writes(self):
+        def body(store, _root):
+            self.assertFalse(store.exists("nope"))
+            store.write(self.fixture, handle="x")
+            self.assertTrue(store.exists("x"))
+        self._each_store(body)
+
+    def test_delete_is_idempotent_and_removes_handle(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="gone")
+            store.delete("gone")
+            self.assertFalse(store.exists("gone"))
+            # Second delete is a no-op, not an error.
+            store.delete("gone")
+        self._each_store(body)
+
+    def test_open_missing_handle_raises(self):
+        def body(store, _root):
+            with self.assertRaises(StoreHandleNotFoundError):
+                store.open("nope")
+        self._each_store(body)
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+    def test_iter_handles_returns_written_set(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="a")
+            store.write(self.fixture, handle="b")
+            handles = set(store.iter_handles())
+            # LocalDirStore returns the relative bundle path; both
+            # representations include the bare stem.
+            stems = {
+                h[: -len(BUNDLE_EXT)] if h.endswith(BUNDLE_EXT) else h
+                for h in handles
+            }
+            self.assertSetEqual(stems, {"a", "b"})
+        self._each_store(body)
+
+    def test_len_matches_written_count(self):
+        def body(store, _root):
+            self.assertEqual(len(store), 0)
+            store.write(self.fixture, handle="a")
+            store.write(self.fixture, handle="b")
+            self.assertEqual(len(store), 2)
+        self._each_store(body)
+
+    def test_iter_index_rows_yields_one_per_bundle(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="a")
+            store.write(self.fixture, handle="b")
+            rows = list(store.iter_index_rows())
+            self.assertEqual(len(rows), 2)
+        self._each_store(body)
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom — every store can act as a copy destination.
+    # ------------------------------------------------------------------
+    def test_copy_from_local_dir_store(self):
+        def body(store, _root):
+            src_root = tempfile.mkdtemp()
+            try:
+                src = LocalDirStore(src_root)
+                src.write(self.fixture, handle="alpha")
+                src.write(self.fixture, handle="beta")
+                n = store.copy_from(src)
+                self.assertEqual(n, 2)
+                self.assertEqual(len(store), 2)
+            finally:
+                shutil.rmtree(src_root, ignore_errors=True)
+        self._each_store(body)
+
+    def test_copy_from_subset_of_handles(self):
+        def body(store, _root):
+            src_root = tempfile.mkdtemp()
+            try:
+                src = LocalDirStore(src_root)
+                src.write(self.fixture, handle="x")
+                src.write(self.fixture, handle="y")
+                src.write(self.fixture, handle="z")
+                # Pick a subset using whatever handle vocabulary src
+                # exposes for these stems.
+                src_handles = list(src.iter_handles())
+                pick = [h for h in src_handles if "x" in h or "z" in h]
+                n = store.copy_from(src, handles=pick)
+                self.assertEqual(n, 2)
+                self.assertEqual(len(store), 2)
+            finally:
+                shutil.rmtree(src_root, ignore_errors=True)
+        self._each_store(body)


### PR DESCRIPTION
# Phase 3d — `iaf migrate-store` + dual-store contract suite

Stacked on **#546** (Phase 3c). Closes the open Phase 3 deliverables of epic **#540**.

## What's in the box

### 1. `iaf migrate-store` CLI

```
iaf migrate-store --from local-dir   --src ./bt-old \
                  --to   local-tiered --dst ./bt-new
```

Delegates to `dst.copy_from(src)`, which means the migration is:

- **Incremental** — bundle by bundle.
- **Restartable** — re-running over an existing destination just continues.
- **Tier-aware** — when copying into a `local-tiered` store, identical OHLCV chunks are written exactly once across the destination regardless of how many bundles reference them (the Phase 3c invariant).
- **Selectable** — `--handles a,b,c` for partial migrations.

A `migrate_store(...)` programmatic helper is also exposed for in-process pipelines.

### 2. `BacktestStoreContractTest` — parameterised dual-store suite

A single `unittest.TestCase` runs an identical scenario against every concrete `BacktestStore` implementation (`LocalDirStore`, `LocalTieredStore`) using `subTest(store=label)`. Adding a future store (e.g. a remote `S3BacktestStore`) is one entry in `_STORES = [...]` away from full conformance coverage.

Coverage:

- Protocol + `SupportsCopyFrom` runtime conformance.
- `write` → `open` round-trip preserves `algorithm_id`.
- `summary_only` honoured.
- `exists` reflects writes; idempotent `delete` removes the handle.
- Missing handle raises `StoreHandleNotFoundError`.
- `iter_handles` and `__len__` agree with the written set.
- `iter_index_rows` yields one row per bundle.
- `copy_from` works for both full migration and a handle subset.

### 3. Bug fix: `LazyOhlcvDict.items()` / `.values()`

The previous implementation inherited the empty backing dict's iteration, so any code path doing

```python
for k, v in bt.ohlcv.items():
    ...
```

silently dropped every blob after a tiered round-trip — including the migration code we're adding here. Caught by `test_ohlcv_dedup_during_migration` and fixed by walking the manifest with lazy materialisation, matching the existing `__iter__` / `__getitem__` semantics.

## What is *not* in this PR

Byte-identical Tier-2 → `Backtest` reassembly (so `.iafbt` could become export-only) is intentionally deferred. The current model where the bundle is canonical and Tier-1/2/3 are derived is simpler, preserves the existing round-trip contract bit-for-bit, and is what every test in the contract suite already exercises against both stores. A future slice can promote Tier-2 to authoritative once we have a stronger reassembly story for the envelope's metadata fields.

## Tests

- `tests/cli/test_migrate_store_command.py` — 7 tests (programmatic API + CLI: round-trip, handle subset, OHLCV dedup across migration, unknown-kind validation).
- `tests/services/backtest_store/test_store_contract.py` — 8 contract tests × 2 stores = 16 subTests.
- Targeted suite (`tests/services/backtest_store/` + `tests/services/backtest_index/` + `tests/cli/`): **128 / 128 passing + 26 subTests**.
- Full non-scenario suite (`tests/` minus `tests/scenarios`): **1705 / 1705 passing** with no regressions from the `LazyOhlcvDict` fix.

## Stack

```
dev
 └─ #537  feature/bundle-format-v2
     └─ #543  feature/iaf-index-cli
         └─ #544  feature/iaf-backtest-store           (3a)
             └─ #545  feature/iaf-local-tiered-store    (3b)
                 └─ #546  feature/iaf-ohlcv-chunk-store (3c)
                     └─ #???  feature/iaf-migrate-store (3d) ★
```

Phase 3 of epic #540 is now feature-complete.
