### PR TITLE
feat(store): epic #540 phase 3 (a-d) + docs/demo — rescue merge to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This framework is built around the full loop: **create strategies → vector bac
 - 📉 **[Benchmark Comparison](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Beat-rate analysis vs Buy & Hold, DCA, risk-free & custom benchmarks
 - 📄 **[One-Click HTML Report](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtest-reports)** — Self-contained file, no server, dark & light theme, shareable
 - 📦 **[Custom `.iafbt` Backtest Bundle Format](https://coding-kitties.github.io/investing-algorithm-framework/Data/backtest_data)** — An explicit, versioned, compressed, language-portable container (zstd + msgpack with magic-byte header) plus a separate parquet index for fast filtering without loading. ~21× smaller and ~27× fewer files than standard filebased directory layouts, with parallel I/O for fast load/save of large amounts of backtests.
+- 🗄️ **[Tiered Backtest Storage Layer](examples/storage_layer_demo/README.md)** — Manage thousands of `.iafbt` bundles with a Tier-1 SQLite index (sub-100 ms ranks/filters over 10k+ backtests), a swappable `BacktestStore` protocol (`LocalDirStore`, `LocalTieredStore`), content-addressed Tier-3 OHLCV deduplication, and a CLI (`iaf index` / `iaf list` / `iaf rank` / `iaf migrate-store`) that plugs straight into the HTML dashboard.
 - 🌐 **[Load External Data](https://coding-kitties.github.io/investing-algorithm-framework/Data/external-data)** — Fetch CSV, JSON, or Parquet from any URL with caching and auto-refresh
 - � **[Per-Market Deposit Schedules & Portfolio Sync](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/portfolio-sync)** — Declare recurring or one-shot external cash flows on a market with `deposit_schedule=` / `auto_sync=True`. Backtests simulate the deposits; live mode reconciles with the broker — same `context.sync_portfolio()` API in both modes.
 - �📝 **[Record Custom Variables](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/recording-variables)** — Track any indicator or metric during backtests with `context.record()`
@@ -142,6 +143,63 @@ Every backtest produces a **self-contained HTML dashboard** — open it in any b
 - **Notes keeping** — annotate every backtest with hypotheses, observations and conclusions; notes travel with the report so your research is never lost
 
 → [Backtest dashboard docs](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtesting) · [MCP server docs](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/mcp-server)
+
+</details>
+
+<details open>
+<summary>
+  <strong>Backtest Storage Layer — scale to thousands of backtests</strong>
+</summary> <br>
+
+Once you start sweeping parameter grids and walk-forward windows, a flat folder of `.iafbt` bundles stops scaling: every comparison re-decodes multi-MB Parquet metric blobs just to read a Sharpe number. The storage layer fixes that with three tiers behind a single `BacktestStore` protocol:
+
+- **Tier-1 — SQLite index (`index.sqlite`)**: one row per bundle with every scalar from `BacktestSummaryMetrics` promoted to its own column. Ranking 10k+ bundles becomes a sub-100 ms SQL query — no `.iafbt` is opened.
+- **Tier-2 — `BacktestStore` adapters**: `LocalDirStore` (flat folder of bundles) or `LocalTieredStore` (hive-partitioned layout). Same handle-based API, swap the implementation without touching call sites.
+- **Tier-3 — content-addressed OHLCV chunks**: SHA-256 deduped per-symbol OHLCV blobs shared across every bundle that references them. `garbage_collect_ohlcv()` reclaims orphans.
+
+A CLI ties it all together: `iaf index` builds/refreshes the Tier-1 SQLite, `iaf list` / `iaf rank` query it, and `iaf migrate-store` moves a whole collection between store kinds in one command.
+
+#### Typical workflow
+
+```python
+from investing_algorithm_framework import BacktestReport
+from investing_algorithm_framework.cli.index_command import (
+    build_index, rank_index,
+)
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+)
+
+# 1. Build (or refresh) the Tier-1 SQLite index over a folder of .iafbt bundles.
+build_index("./my-backtests/")          # equivalent to: iaf index ./my-backtests/
+
+# 2. Pick the top 20 by Sharpe straight from SQLite — no Parquet decoded.
+top = rank_index(
+    "./my-backtests/",
+    by="sharpe_ratio",
+    where="summary_number_of_trades > 50",
+    limit=20,
+)
+
+# 3. Materialise just those 20 bundles through the BacktestStore protocol.
+store = LocalDirStore("./my-backtests/")
+backtests = [store.open(row["bundle_path"]) for row in top]
+
+# 4. Feed them straight into the HTML dashboard.
+BacktestReport(backtests=backtests).save("top20.html")
+```
+
+Or from the shell:
+
+```bash
+iaf index ./my-backtests/
+iaf rank  ./my-backtests/ --by sharpe_ratio --where "summary_number_of_trades > 50" -n 20
+iaf list  ./my-backtests/ --sort calmar_ratio --json
+iaf migrate-store --from local-dir --src ./my-backtests/ \
+                  --to   local-tiered --dst ./tiered/
+```
+
+→ End-to-end runnable example: [`examples/storage_layer_demo/`](examples/storage_layer_demo/README.md)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,38 @@ Every backtest produces a **self-contained HTML dashboard** — open it in any b
 - **Built-in MCP server** — let Copilot, Claude, or any MCP-compatible agent query your backtests, rank strategies, and reason over trades through `investing-algorithm-framework mcp`
 - **Notes keeping** — annotate every backtest with hypotheses, observations and conclusions; notes travel with the report so your research is never lost
 
+#### From backtest results to a report
+
+Every backtest API — vector or event-driven — returns the same `Backtest` object, which the `BacktestReport` consumes directly. So whether you're iterating over an in-memory list or a folder of persisted `.iafbt` bundles, the path to the dashboard is the same:
+
+```python
+from investing_algorithm_framework import BacktestReport
+
+# --- Single event-driven backtest ---
+backtest = app.run_backtest(backtest_date_range=date_range)
+BacktestReport(backtests=[backtest]).save("event_report.html")
+
+# --- A sweep of vector backtests (parameter grid / multi-window) ---
+backtests = app.run_vector_backtests(
+    strategies=[StrategyA(), StrategyB(), StrategyC()],
+    backtest_date_ranges=[range_2022, range_2023, range_2024],
+    n_workers=-1,
+    backtest_storage_directory="./my-backtests/",  # persists .iafbt bundles
+    show_progress=True,
+)
+BacktestReport(backtests=backtests).save("sweep_report.html")
+
+# --- Or: load a folder of bundles back later (parallel decode) ---
+report = BacktestReport.open(
+    directory_path="./my-backtests/",
+    workers=-1,
+    show_progress=True,
+)
+report.save("from_disk_report.html")
+```
+
+For sweeps that grow into the thousands, combine this with the [Backtest Storage Layer](examples/storage_layer_demo/README.md) below — rank in SQLite first, then load only the winners into the report.
+
 → [Backtest dashboard docs](https://coding-kitties.github.io/investing-algorithm-framework/Getting%20Started/backtesting) · [MCP server docs](https://coding-kitties.github.io/investing-algorithm-framework/Advanced%20Concepts/mcp-server)
 
 </details>

--- a/docusaurus/docs/Getting Started/backtest-reports.md
+++ b/docusaurus/docs/Getting Started/backtest-reports.md
@@ -6,6 +6,10 @@ sidebar_position: 10
 
 The framework generates self-contained HTML dashboard reports for analyzing backtest results. Reports work for both single and multi-strategy backtests — no external dependencies required.
 
+:::tip Working with hundreds or thousands of backtests?
+A `BacktestReport` inlines every backtest into a single HTML file, which becomes too heavy for a browser past a few dozen backtests. Use the [Backtest Storage Layer](./backtest-storage.md) to filter your collection down (in SQLite, sub-100 ms) and render reports only over the winners.
+:::
+
 ## Quick Start
 
 ```python

--- a/docusaurus/docs/Getting Started/backtest-storage.md
+++ b/docusaurus/docs/Getting Started/backtest-storage.md
@@ -1,0 +1,235 @@
+---
+sidebar_position: 11
+---
+
+# Backtest Storage Layer
+
+Once you start sweeping parameter grids and walk-forward windows, you quickly end up with **hundreds or thousands of backtests on disk**. A flat folder of `.iafbt` bundles works for tens of them, but it stops scaling once you want to compare them all in a single HTML dashboard — every comparison re-decodes multi-MB Parquet metric blobs just to read a Sharpe number, and the resulting `report.html` becomes too heavy for a browser to open.
+
+The **backtest storage layer** is the framework's answer to that. It separates *where bundles live* from *how you query them*, and it gives you the tools to keep your dashboards fast even when the backing collection grows into the thousands.
+
+## Mental model
+
+```
+                ┌─────────────────────────────────────────────┐
+                │  Tier-1: SQLite index   (index.sqlite)      │
+                │   - one row per .iafbt                      │
+                │   - all summary metrics promoted to columns │
+                │   - sub-100 ms ranks / filters over 10k+    │
+                └─────────────────────────────────────────────┘
+                                    │ derived from
+                                    ▼
+                ┌─────────────────────────────────────────────┐
+                │  Tier-2: Parquet sidecars (analytics-ready) │
+                │   - hive-partitioned on run_id              │
+                │   - portfolio_snapshots / trades / orders   │
+                └─────────────────────────────────────────────┘
+                                    │ derived from
+                                    ▼
+                ┌─────────────────────────────────────────────┐
+                │  CANONICAL: .iafbt bundles                  │
+                │   - the single source of truth              │
+                │   - everything else can be rebuilt from it  │
+                └─────────────────────────────────────────────┘
+                                    │ references
+                                    ▼
+                ┌─────────────────────────────────────────────┐
+                │  Tier-3: content-addressed OHLCV chunks     │
+                │   - <sha256>.parquet, deduped across all    │
+                │     bundles that reference the same data    │
+                └─────────────────────────────────────────────┘
+```
+
+The `.iafbt` bundle is **canonical**. The SQLite index, the Tier-2 Parquet sidecars and the Tier-3 OHLCV chunks are all *derived* — they can be rebuilt from the bundles at any time and they're best-effort: a malformed sidecar never blocks a write or read against the bundle.
+
+## The `BacktestStore` protocol
+
+Two concrete implementations ship today, both exposing the same API:
+
+| Store | Layout | Best for |
+|---|---|---|
+| `LocalDirStore` | flat folder of `.iafbt` files (+ `index.sqlite`) | Most users, simple to inspect, fast `ls` |
+| `LocalTieredStore` | full Tier-1/2/3 layout | Large collections, OHLCV dedup, analytics workflows |
+
+Both are drop-in interchangeable — swap the implementation without touching call sites:
+
+```python
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+)
+from investing_algorithm_framework.services.backtest_store.\
+local_tiered_store import LocalTieredStore
+
+store = LocalDirStore("./my-backtests/")
+# store = LocalTieredStore("./my-backtests/")  # same API
+
+len(store)                       # how many bundles?
+"momentum_v1.iafbt" in store     # exists?
+bt = store.open("momentum_v1.iafbt")
+for handle in store.iter_handles():
+    ...
+```
+
+## The normal developer workflow
+
+Below is the canonical loop most users will run. The **same five steps** hold whether you have 10 backtests or 10,000 — you just lean harder on the index as the collection grows.
+
+### 1. Run a sweep, persist the bundles
+
+```python
+backtests = app.run_vector_backtests(
+    strategies=[StrategyA(), StrategyB(), StrategyC()],
+    backtest_date_ranges=[range_2022, range_2023, range_2024],
+    n_workers=-1,
+    backtest_storage_directory="./my-backtests/",   # writes .iafbt here
+    show_progress=True,
+)
+```
+
+After this you have a folder of `.iafbt` bundles on disk. That folder is *the* artifact — everything downstream operates on it.
+
+### 2. Build the Tier-1 index
+
+```bash
+iaf index ./my-backtests/
+```
+
+Or from Python:
+
+```python
+from investing_algorithm_framework.cli.index_command import build_index
+build_index("./my-backtests/")
+```
+
+This walks the folder once, writes `index.sqlite` with every scalar from `BacktestSummaryMetrics` promoted to its own column, and is **idempotent** — re-run it any time after adding new bundles.
+
+### 3. Filter / rank in SQLite (no bundles opened)
+
+The point of the index is that **you never need to decode a Parquet metric blob just to choose which backtests are interesting**. Pick winners with a SQL `WHERE` clause:
+
+```python
+from investing_algorithm_framework.cli.index_command import (
+    list_index, rank_index,
+)
+
+# Top 20 by Sharpe, but only among bundles with > 50 trades.
+top = rank_index(
+    "./my-backtests/",
+    by="sharpe_ratio",
+    where="summary_number_of_trades > 50",
+    limit=20,
+)
+
+for r in top:
+    print(r["algorithm_id"], r["summary_sharpe_ratio"])
+```
+
+Or from the shell:
+
+```bash
+iaf rank ./my-backtests/ \
+    --by sharpe_ratio \
+    --where "summary_number_of_trades > 50" -n 20
+iaf list ./my-backtests/ --sort calmar_ratio --json
+```
+
+This step is **sub-100 ms** even over 10k+ bundles. No Parquet, no decompression, no bundle opens.
+
+### 4. Materialise only the bundles you actually need
+
+```python
+store = LocalDirStore("./my-backtests/")
+backtests = [store.open(row["bundle_path"]) for row in top]
+```
+
+`bundle_path` from the index row is exactly the store handle, so this is a one-liner. **You only pay the bundle-decode cost for the bundles you selected**, not the whole collection.
+
+### 5. Render the report
+
+```python
+from investing_algorithm_framework import BacktestReport
+
+BacktestReport(backtests=backtests).save("top20.html")
+```
+
+That's the whole loop.
+
+## Avoid overloading your `report.html`
+
+The `BacktestReport` produces a **self-contained** HTML file: every backtest's full per-run data (equity curve, drawdown series, trades, positions, monthly returns) is inlined into the document so the dashboard works offline with no server.
+
+The trade-off: file size grows linearly with the number of backtests inlined. Rough orders of magnitude:
+
+| Backtests in report | Approx. HTML size | Browser experience |
+|---|---|---|
+| 1 – 10 | tens of KB to ~1 MB | instant |
+| 10 – 50 | a few MB | smooth |
+| 50 – 200 | 10 – 50 MB | slower load, still usable |
+| 200+ | 100 MB+ | browsers struggle / refuse to open |
+
+The point of the storage layer is that **you don't need to put 200 backtests in one report to compare them**. The Tier-1 index is your comparison surface for the full collection; the HTML report is your deep-dive surface for a small, hand-picked subset.
+
+### Anti-pattern
+
+```python
+# DON'T do this with thousands of bundles.
+report = BacktestReport.open(directory_path="./my-backtests/", workers=-1)
+report.save("everything.html")     # multi-hundred-MB file, browser dies
+```
+
+This decodes every bundle in the folder and inlines all of them. Fine for a few dozen; fatal at scale.
+
+### The right pattern
+
+```python
+# Filter in SQLite first, then render only the winners.
+top = rank_index("./my-backtests/", by="sharpe_ratio", limit=25)
+store = LocalDirStore("./my-backtests/")
+BacktestReport(
+    backtests=[store.open(r["bundle_path"]) for r in top],
+).save("top25_by_sharpe.html")
+```
+
+Same principle applies for slicing by anything else — most-trades, best-Calmar, lowest-drawdown, only-2024-windows, only-momentum-strategies, etc. Compose multiple narrow reports rather than one giant one.
+
+### Rules of thumb
+
+- **Keep any single `report.html` to ≤ 50 backtests.** Past that, render multiple narrower reports (one per strategy family, one per regime, one for the top-N) instead of one mega-report.
+- **Use the index as your comparison plane** for the full collection. CLI: `iaf list` / `iaf rank`. Python: `list_index` / `rank_index`. SQL: `sqlite3 index.sqlite` for anything ad-hoc.
+- **Render for the audience.** A "winners" report (top 10–20) is what you actually send to teammates. A "full deep-dive" report on one strategy is what you keep for yourself.
+- **Don't trust `BacktestReport.open(directory_path=…)` at scale.** It walks and decodes the whole folder; it's a convenience for ≤ 50-bundle directories, not a scaling story.
+
+## When to use which store
+
+- **`LocalDirStore`** — start here. A flat folder of `.iafbt` files is what every other tool understands (you can `ls`, `rsync`, `tar`, `git lfs` it). Tier-1 SQLite gets built next to the bundles. This is the default for `app.run_vector_backtests(backtest_storage_directory=...)`.
+
+- **`LocalTieredStore`** — switch to this when you need any of:
+  - **Cross-bundle analytics** without decoding bundles (DuckDB / Polars over the Tier-2 Parquet sidecars: `read_parquet('store/parquet/trades/**/*.parquet', hive_partitioning=True)`).
+  - **OHLCV deduplication** — every bundle that references the same `BTC/EUR:1h` data shares one `<sha256>.parquet` blob on disk; reclaim orphans with `store.garbage_collect_ohlcv()`.
+  - **Migration target** for archival / production pipelines.
+
+Move a whole collection between store kinds with a single command:
+
+```bash
+iaf migrate-store --from local-dir    --src ./my-backtests/ \
+                  --to   local-tiered --dst ./tiered/
+```
+
+## End-to-end runnable example
+
+A complete worked example (seed bundles → build index → rank → load winners → render dashboard) lives in the repo at [`examples/storage_layer_demo/`](https://github.com/coding-kitties/investing-algorithm-framework/tree/main/examples/storage_layer_demo). Run it from a checkout:
+
+```bash
+source .venv/bin/activate
+python examples/storage_layer_demo/demo.py
+```
+
+It prints each step, leaves the bundles + index + dashboard in a temp directory, and shows you the exact `iaf` CLI commands you could run by hand against the same data.
+
+## Reference
+
+- CLI: `iaf index`, `iaf list`, `iaf rank`, `iaf migrate-store` (see `iaf <cmd> --help`)
+- Python: `investing_algorithm_framework.cli.index_command.{build_index, list_index, rank_index}`
+- Stores: `investing_algorithm_framework.services.backtest_store.{LocalDirStore, LocalTieredStore}`
+- Bundle format: see [Backtest Data](../Data/backtest_data.md)
+- Report API: see [Backtest Reports](./backtest-reports.md)

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -59,6 +59,10 @@ const sidebars = {
                 },
                 {
                     type: 'doc',
+                    id: 'Getting Started/backtest-storage',
+                },
+                {
+                    type: 'doc',
                     id: 'Getting Started/metrics',
                 },
                 {

--- a/examples/storage_layer_demo/README.md
+++ b/examples/storage_layer_demo/README.md
@@ -45,12 +45,21 @@ The script will:
 3. Print the equivalent `iaf` CLI commands you could run by hand.
 4. Run `list_index` / `rank_index` / a raw SQL query and print
    the formatted tables.
-5. Open the top-ranked bundle and print its full backtest report
+5. Open the top-ranked bundle and print its compact backtest report
    (this is the only step that decodes per-run Parquet metric blobs).
-6. Walk the index in rank order and print a one-line summary per
+6. Render an _expanded_ report for the same winning bundle —
+   per-run breakdown, end-of-backtest positions, the first few
+   trades, and a richer slice of per-run risk / return metrics.
+7. Walk the index in rank order and print a one-line summary per
    bundle straight out of the SQLite index — no bundle is opened.
-7. Iterate every bundle in rank order and print a full per-bundle
+8. Iterate every bundle in rank order and print a full per-bundle
    report so you can scan _all_ backtests at a glance.
+9. Tie the storage layer end-to-end into the **HTML dashboard**:
+   pick the top-N bundles via `rank_index` (Tier-1 SQLite only),
+   load each one through `LocalDirStore.open(handle)` (the
+   `BacktestStore` protocol), and feed the resulting list straight
+   into `BacktestReport(...).save(...)`. Open the generated
+   `dashboard.html` to see all selected backtests side-by-side.
 
 ## CLI cheatsheet
 

--- a/examples/storage_layer_demo/README.md
+++ b/examples/storage_layer_demo/README.md
@@ -1,0 +1,91 @@
+# Storage layer demo — `iaf index`, `iaf list`, `iaf rank`
+
+End-to-end demo of the new tiered backtest storage layer
+(epic [#540](https://github.com/coding-kitties/investing-algorithm-framework/issues/540) — phase 2).
+
+It shows how to:
+
+1. Save a directory of `.iafbt` backtest bundles.
+2. Build a SQLite Tier-1 index over them with `iaf index` (or
+   `build_index` from Python).
+3. Query / sort / filter the index with `iaf list` and `iaf rank`
+   (or the equivalent `list_index` / `rank_index` Python helpers)
+   without ever decoding the per-run Parquet metric blobs.
+4. Drop into raw SQL when you need a custom report.
+
+## Why this matters
+
+Previously, comparing 50 walk-forward backtest variants meant
+opening every `.iafbt` bundle (each with multi-MB Parquet metric
+blobs) just to read scalar headline metrics like `sharpe_ratio` or
+`max_drawdown`.
+
+The new Tier-1 SQLite index gives you a single file (`index.sqlite`)
+with one row per bundle and every scalar from
+`BacktestSummaryMetrics` promoted to its own column. Filtering and
+ranking 12,500 bundles becomes a sub-100 ms SQL query.
+
+The `.iafbt` bundles themselves remain the source of truth — the
+index can always be rebuilt from them with `iaf index`.
+
+## Run it
+
+From the repo root:
+
+```bash
+source .venv/bin/activate
+python examples/storage_layer_demo/demo.py
+```
+
+The script will:
+
+1. Create a temp directory and write 6 `.iafbt` bundles with
+   varying synthetic Sharpe / Sortino / drawdown values.
+2. Build `index.sqlite` over them.
+3. Print the equivalent `iaf` CLI commands you could run by hand.
+4. Run `list_index` / `rank_index` / a raw SQL query and print
+   the formatted tables.
+5. Open the top-ranked bundle and print its full backtest report
+   (this is the only step that decodes per-run Parquet metric blobs).
+6. Walk the index in rank order and print a one-line summary per
+   bundle straight out of the SQLite index — no bundle is opened.
+7. Iterate every bundle in rank order and print a full per-bundle
+   report so you can scan _all_ backtests at a glance.
+
+## CLI cheatsheet
+
+```bash
+# Build the index
+iaf index ./my-backtests/
+
+# Top 5 by Sharpe
+iaf rank ./my-backtests/ --by sharpe_ratio -n 5
+
+# Same, but only among bundles with > 50 trades
+iaf rank ./my-backtests/ \
+    --by sortino_ratio \
+    --where "summary_number_of_trades > 50" \
+    -n 10
+
+# Full listing with custom columns + JSON output
+iaf list ./my-backtests/ \
+    --sort calmar_ratio \
+    --columns "algorithm_id,tag,summary_calmar_ratio,summary_max_drawdown" \
+    --json
+
+# Raw SQL — anything sqlite3 can do
+sqlite3 ./my-backtests/index.sqlite \
+    "SELECT algorithm_id, summary_sharpe_ratio
+       FROM backtest_index
+      WHERE summary_max_drawdown > -0.1
+      ORDER BY summary_sharpe_ratio DESC LIMIT 5;"
+```
+
+## Where this is going
+
+Phase 3 of #540 introduces a `BacktestStore` Protocol with two
+implementations: `LocalDirStore` (the current behavior) and
+`LocalTieredStore` (Tier-1 SQLite + Tier-2 Parquet datasets +
+Tier-3 content-addressed chunks). The `iaf list` / `iaf rank`
+commands shown here are forward-compatible — they will work
+unchanged against any store backing the same Tier-1 schema.

--- a/examples/storage_layer_demo/demo.py
+++ b/examples/storage_layer_demo/demo.py
@@ -32,6 +32,10 @@ from investing_algorithm_framework.cli.index_command import (
     rank_index,
     format_table,
 )
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+)
+from investing_algorithm_framework import BacktestReport
 
 
 # Directory-format fixture shipped with the test suite. We use it
@@ -107,6 +111,103 @@ def _print_backtest_report(bt: Backtest) -> None:
         None if s.win_rate is None else s.win_rate * 100,
         ".2f",
     )
+
+
+def _print_backtest_full_report(bt: Backtest) -> None:
+    """Render a detailed multi-section report for a single backtest.
+
+    Goes beyond :func:`_print_backtest_report` by walking the
+    per-run breakdown, listing positions, and showing the first few
+    trades/orders so the demo's "open the winner" step actually
+    looks like a backtest report and not just a summary row.
+    """
+    _print_backtest_report(bt)
+
+    runs = bt.backtest_runs or []
+    if not runs:
+        return
+
+    # ------------------- per-run breakdown -------------------
+    print("\n  --- per-run breakdown ---")
+    header = (
+        f"  {'#':>2} {'window':<20} {'days':>5} {'orders':>7} "
+        f"{'trades':>7} {'positions':>10} {'final_value':>14}"
+    )
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for i, r in enumerate(runs, start=1):
+        window = (
+            r.backtest_date_range_name
+            if r.backtest_date_range_name
+            else f"{r.backtest_start_date.date()}..{r.backtest_end_date.date()}"
+        )[:20]
+        m = r.backtest_metrics
+        final = (
+            f"{float(m.final_value):.2f}"
+            if m is not None and getattr(m, "final_value", None) is not None
+            else "n/a"
+        )
+        print(
+            f"  {i:>2} {window:<20} {r.number_of_days:>5} "
+            f"{r.number_of_orders:>7} {r.number_of_trades:>7} "
+            f"{r.number_of_positions:>10} {final:>14}"
+        )
+
+    # ------------------- positions snapshot -------------------
+    last = runs[-1]
+    positions = list(getattr(last, "positions", None) or [])
+    if positions:
+        print(f"\n  --- positions (last run, {len(positions)}) ---")
+        for p in positions[:10]:
+            symbol = getattr(p, "symbol", None) or "?"
+            amount = getattr(p, "amount", None)
+            cost = getattr(p, "cost", None)
+            print(
+                f"  {symbol:<14} amount={amount}  cost={cost}"
+            )
+        if len(positions) > 10:
+            print(f"  ... and {len(positions) - 10} more")
+
+    # ------------------- trades preview -------------------
+    trades = list(getattr(last, "trades", None) or [])
+    if trades:
+        print(f"\n  --- trades (last run, {len(trades)} total, first 5) ---")
+        for t in trades[:5]:
+            print(
+                f"  {getattr(t, 'symbol', '?'):<10} "
+                f"opened={getattr(t, 'opened_at', None)} "
+                f"net_gain={getattr(t, 'net_gain', None)}"
+            )
+
+    # ------------------- richer metrics from first run -------------------
+    m = runs[0].backtest_metrics
+    if m is None:
+        return
+    print("\n  --- additional risk / return metrics (first run) ---")
+    extras = [
+        ("cagr", "cagr", ".4f"),
+        ("annual_volatility", "annual_volatility", ".4f"),
+        ("max_drawdown_abs", "max_drawdown_absolute", ".2f"),
+        ("max_drawdown_dur", "max_drawdown_duration", ""),
+        ("gross_profit", "gross_profit", ".2f"),
+        ("gross_loss", "gross_loss", ".2f"),
+        ("best_trade", "best_trade", ".2f"),
+        ("max_consec_wins", "max_consecutive_wins", ""),
+        ("max_consec_losses", "max_consecutive_losses", ""),
+    ]
+    for label, attr, fmt in extras:
+        val = getattr(m, attr, None)
+        if val is None:
+            rendered = "n/a"
+        elif fmt:
+            try:
+                rendered = format(float(val), fmt)
+            except (TypeError, ValueError):
+                rendered = str(val)
+        else:
+            rendered = str(val)
+        print(f"  {label:<22}: {rendered}")
+
 
 
 def _seed_bundles(out_dir: Path, n: int = 6) -> None:
@@ -241,6 +342,20 @@ def main() -> None:
     _print_backtest_report(winner_bt)
 
     # ------------------------------------------------------------------
+    # 6b. Full backtest report — per-run breakdown, positions, trades
+    # ------------------------------------------------------------------
+    _print_section(
+        "6b. Full backtest report for the winner "
+        "(runs / positions / trades)"
+    )
+    print(
+        "Same bundle, expanded view: per-run breakdown, end-of-backtest "
+        "positions, the first few trades, and a richer slice of "
+        "per-run risk/return metrics.\n"
+    )
+    _print_backtest_full_report(winner_bt)
+
+    # ------------------------------------------------------------------
     # 7. Iterate the index and print a one-line report per backtest
     # ------------------------------------------------------------------
     _print_section(
@@ -273,15 +388,63 @@ def main() -> None:
         _print_backtest_report(bt)
 
     # ------------------------------------------------------------------
+    # 9. Storage layer -> HTML dashboard
+    # ------------------------------------------------------------------
+    _print_section(
+        "9. Storage layer -> HTML dashboard "
+        "(rank in SQLite, load via store, render report)"
+    )
+    print(
+        "Wire the Tier-1 SQLite index, the Tier-2 LocalDirStore and the\n"
+        "BacktestReport HTML dashboard end-to-end:\n"
+        "  1. rank_index() picks the top-N bundles from SQLite alone\n"
+        "     (no Parquet metric blob is decoded yet).\n"
+        "  2. LocalDirStore.open(handle) materialises just those\n"
+        "     bundles through the BacktestStore protocol.\n"
+        "  3. BacktestReport(backtests=[...]).save(path) renders the\n"
+        "     interactive HTML dashboard with every loaded bundle.\n"
+    )
+    store = LocalDirStore(work)
+    print(f"  store          : {type(store).__name__}({work})")
+    print(f"  bundles in store: {len(store)}")
+
+    top = rank_index(str(work), by="sharpe_ratio", limit=3)
+    print(f"  top-3 by sharpe: {[r['algorithm_id'] for r in top]}")
+
+    loaded: list[Backtest] = []
+    for r in top:
+        # The Tier-1 row's bundle_path is relative to the store root,
+        # which is exactly what LocalDirStore uses as a handle.
+        handle = r["bundle_path"]
+        bt = store.open(handle)
+        loaded.append(bt)
+        print(
+            f"    store.open({handle!r}) -> {bt.algorithm_id} "
+            f"({len(bt.backtest_runs)} run(s))"
+        )
+
+    report = BacktestReport(backtests=loaded)
+    html_path = work / "dashboard.html"
+    report.save(str(html_path))
+    html_size_kb = os.path.getsize(html_path) / 1024.0
+    print(
+        f"\n  wrote HTML dashboard -> {html_path}\n"
+        f"  size: {html_size_kb:.1f} KB "
+        f"(self-contained: CSS + JS + data inlined)\n"
+        f"  open it with:  open {html_path}"
+    )
+
+    # ------------------------------------------------------------------
     # Wrap up
     # ------------------------------------------------------------------
     _print_section("Done")
     print(
-        "Bundles + index left in:\n"
+        "Bundles + index + dashboard left in:\n"
         f"  {work}\n"
         "Try the CLI directly:\n"
         f"  iaf list {work} --sort calmar_ratio --json\n"
         f"  iaf rank {work} --by sharpe_ratio -n 3\n"
+        f"  open {work / 'dashboard.html'}\n"
     )
 
 

--- a/examples/storage_layer_demo/demo.py
+++ b/examples/storage_layer_demo/demo.py
@@ -1,0 +1,289 @@
+"""End-to-end demo of the new tiered backtest storage layer.
+
+Epic #540 phase 2:
+
+* save a directory of ``.iafbt`` bundles
+* build a SQLite Tier-1 index over them (``iaf index``)
+* query / sort / filter the index (``iaf list`` / ``iaf rank``)
+  without ever decoding the per-run Parquet metric blobs
+* drop into raw SQL when needed
+
+Run from the repo root::
+
+    source .venv/bin/activate
+    python examples/storage_layer_demo/demo.py
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+from investing_algorithm_framework.domain import Backtest, BUNDLE_EXT
+from investing_algorithm_framework.domain.backtesting.bundle import (
+    save_bundle,
+)
+from investing_algorithm_framework.cli.index_command import (
+    build_index,
+    list_index,
+    rank_index,
+    format_table,
+)
+
+
+# Directory-format fixture shipped with the test suite. We use it
+# only as a *template* — we re-save N copies under different
+# algorithm_ids and Sharpe / Sortino / drawdown values so the demo
+# has something interesting to rank.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = (
+    REPO_ROOT
+    / "tests"
+    / "resources"
+    / "backtest_reports_for_testing"
+    / "test_algorithm_backtest"
+)
+
+
+def _print_section(title: str) -> None:
+    bar = "=" * 72
+    print(f"\n{bar}\n {title}\n{bar}")
+
+
+def _print_backtest_report(bt: Backtest) -> None:
+    """Render a compact, fixture-tolerant report for a backtest.
+
+    We deliberately read fields that exist on every ``.iafbt`` bundle
+    (identity, run dates, summary metrics) instead of relying on the
+    full :func:`pretty_print_backtest` helper, which assumes a
+    populated :class:`BacktestMetrics` per run.
+    """
+    s = bt.backtest_summary
+    runs = bt.backtest_runs or []
+    print(f"  algorithm_id   : {bt.algorithm_id}")
+    print(f"  tag            : {bt.tag}")
+    if runs:
+        first, last = runs[0], runs[-1]
+        print(
+            f"  date range     : {first.backtest_start_date} -> "
+            f"{last.backtest_end_date}"
+        )
+        print(f"  number of runs : {len(runs)}")
+
+    if s is None:
+        print("  (no summary metrics available)")
+        return
+
+    def _row(label: str, value, fmt: str = "") -> None:
+        if value is None:
+            rendered = "n/a"
+        elif fmt:
+            rendered = format(value, fmt)
+        else:
+            rendered = str(value)
+        print(f"  {label:<22}: {rendered}")
+
+    print("  --- summary metrics ---")
+    _row("sharpe_ratio", s.sharpe_ratio, ".4f")
+    _row("sortino_ratio", s.sortino_ratio, ".4f")
+    _row("calmar_ratio", s.calmar_ratio, ".4f")
+    _row(
+        "total_net_gain_pct",
+        None if s.total_net_gain_percentage is None
+        else s.total_net_gain_percentage * 100,
+        ".2f",
+    )
+    _row(
+        "max_drawdown_pct",
+        None if s.max_drawdown is None else s.max_drawdown * 100,
+        ".2f",
+    )
+    _row("number_of_trades", s.number_of_trades)
+    _row(
+        "win_rate_pct",
+        None if s.win_rate is None else s.win_rate * 100,
+        ".2f",
+    )
+
+
+def _seed_bundles(out_dir: Path, n: int = 6) -> None:
+    """Write ``n`` synthetic ``.iafbt`` bundles into *out_dir*."""
+    if not TEMPLATE.is_dir():
+        sys.exit(
+            f"Could not find the template fixture at {TEMPLATE}. "
+            "Run this demo from inside a git checkout of the "
+            "investing-algorithm-framework repository."
+        )
+
+    template = Backtest.open(str(TEMPLATE))
+
+    # Three "strategy families", two variants each, with distinct
+    # risk-adjusted profiles so ranking is meaningful.
+    profiles = [
+        ("momentum_v1", 1.85, 2.40, -0.08, 145, 0.61),
+        ("momentum_v2", 1.42, 1.91, -0.12, 132, 0.58),
+        ("mean_revert_v1", 0.95, 1.20, -0.18, 88, 0.54),
+        ("mean_revert_v2", 1.10, 1.45, -0.15, 102, 0.55),
+        ("breakout_v1", 0.42, 0.55, -0.31, 41, 0.48),
+        ("breakout_v2", -0.20, -0.25, -0.42, 27, 0.39),
+    ][:n]
+
+    for algo_id, sharpe, sortino, mdd, n_trades, win_rate in profiles:
+        bt = Backtest.from_dict(template.to_dict())
+        bt.algorithm_id = algo_id
+        bt.tag = "demo"
+        if bt.backtest_summary is not None:
+            s = bt.backtest_summary
+            s.sharpe_ratio = sharpe
+            s.sortino_ratio = sortino
+            s.max_drawdown = mdd
+            s.number_of_trades = n_trades
+            s.win_rate = win_rate
+            # Calmar = CAGR / |max_drawdown|; fake it for the demo.
+            s.calmar_ratio = round(abs(sharpe / mdd), 3)
+            s.total_net_gain_percentage = round(sharpe * 0.12, 4)
+        save_bundle(
+            bt, str(out_dir / f"{algo_id}{BUNDLE_EXT}"),
+        )
+
+
+def main() -> None:
+    work = Path(tempfile.mkdtemp(prefix="iaf-storage-demo-"))
+    print(f"Working directory: {work}")
+
+    # ------------------------------------------------------------------
+    # 1. Save bundles
+    # ------------------------------------------------------------------
+    _print_section("1. Save synthetic .iafbt bundles")
+    _seed_bundles(work)
+    for p in sorted(work.glob(f"*{BUNDLE_EXT}")):
+        print(f"  {p.name}")
+
+    # ------------------------------------------------------------------
+    # 2. Build the Tier-1 SQLite index
+    # ------------------------------------------------------------------
+    _print_section("2. Build the SQLite Tier-1 index")
+    print(f"$ iaf index {work}")
+    index_path = build_index(str(work), show_progress=False)
+    print(f"  -> wrote {index_path}")
+    print(f"  -> file size: {os.path.getsize(index_path)} bytes")
+
+    # ------------------------------------------------------------------
+    # 3. iaf list — sort by Sharpe, top 4
+    # ------------------------------------------------------------------
+    _print_section("3. iaf list — sort by sharpe_ratio (top 4)")
+    print(f"$ iaf list {work} --sort sharpe_ratio -n 4\n")
+    rows = list_index(
+        str(work), sort_by="sharpe_ratio", limit=4,
+    )
+    print(format_table(rows))
+
+    # ------------------------------------------------------------------
+    # 4. iaf rank — risk-adjusted, filtered
+    # ------------------------------------------------------------------
+    _print_section(
+        "4. iaf rank — by sortino_ratio, with WHERE filter"
+    )
+    print(
+        f'$ iaf rank {work} --by sortino_ratio '
+        f'--where "summary_number_of_trades > 50" -n 5\n'
+    )
+    rows = rank_index(
+        str(work),
+        by="sortino_ratio",
+        where="summary_number_of_trades > 50",
+        limit=5,
+    )
+    print(format_table(rows))
+
+    # ------------------------------------------------------------------
+    # 5. Raw SQL — anything sqlite3 can do
+    # ------------------------------------------------------------------
+    _print_section("5. Raw SQL — custom report")
+    sql = """
+        SELECT algorithm_id,
+               summary_sharpe_ratio   AS sharpe,
+               summary_max_drawdown   AS max_dd,
+               summary_calmar_ratio   AS calmar
+          FROM backtest_index
+         WHERE summary_max_drawdown > -0.20
+         ORDER BY summary_calmar_ratio DESC
+         LIMIT 5
+    """
+    print(f"$ sqlite3 {index_path} '<query>'\n{sql.strip()}\n")
+    conn = sqlite3.connect(index_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.execute(sql)
+    rows = [dict(r) for r in cur.fetchall()]
+    conn.close()
+    print(format_table(rows))
+
+    # ------------------------------------------------------------------
+    # 6. Open the winner's full backtest report
+    # ------------------------------------------------------------------
+    _print_section(
+        "6. Open the top-ranked bundle and print its full report"
+    )
+    top = rank_index(str(work), by="sharpe_ratio", limit=1)[0]
+    winner_path = work / top["bundle_path"]
+    print(
+        f"Top by sharpe_ratio: {top['algorithm_id']} "
+        f"(sharpe={top['summary_sharpe_ratio']})\n"
+        f"Loading full bundle: {winner_path}\n"
+    )
+    # The index gave us a scalar-only view; for the full report we
+    # open the .iafbt bundle (this is the only step that decodes the
+    # per-run Parquet metric blobs).
+    winner_bt = Backtest.open(str(winner_path))
+    _print_backtest_report(winner_bt)
+
+    # ------------------------------------------------------------------
+    # 7. Iterate the index and print a one-line report per backtest
+    # ------------------------------------------------------------------
+    _print_section(
+        "7. Iterate the index and print a one-line summary per bundle"
+    )
+    print(
+        "Walking the SQLite index in rank order — no bundle is opened "
+        "for these summaries.\n"
+    )
+    all_rows = list_index(str(work), sort_by="sharpe_ratio")
+    for i, r in enumerate(all_rows, start=1):
+        print(
+            f"  {i}. {r['algorithm_id']:<14}  "
+            f"sharpe={r['summary_sharpe_ratio']:>6.2f}  "
+            f"return={r['summary_total_net_gain_percentage'] * 100:>6.2f}%  "
+            f"max_dd={r['summary_max_drawdown']:>6.2%}  "
+            f"trades={r['summary_number_of_trades']:>3}"
+        )
+
+    # ------------------------------------------------------------------
+    # 8. Full report for every backtest in rank order
+    # ------------------------------------------------------------------
+    _print_section(
+        "8. Full report per backtest (open each bundle in rank order)"
+    )
+    for i, r in enumerate(all_rows, start=1):
+        bundle_path = work / r["bundle_path"]
+        bt = Backtest.open(str(bundle_path))
+        print(f"\n--- [{i}] {r['algorithm_id']} ".ljust(72, "-"))
+        _print_backtest_report(bt)
+
+    # ------------------------------------------------------------------
+    # Wrap up
+    # ------------------------------------------------------------------
+    _print_section("Done")
+    print(
+        "Bundles + index left in:\n"
+        f"  {work}\n"
+        "Try the CLI directly:\n"
+        f"  iaf list {work} --sort calmar_ratio --json\n"
+        f"  iaf rank {work} --by sharpe_ratio -n 3\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/investing_algorithm_framework/cli/cli.py
+++ b/investing_algorithm_framework/cli/cli.py
@@ -343,7 +343,13 @@ cli.add_command(migrate_backtests_cmd)
     "--no-progress", is_flag=True, default=False,
     help="Suppress the progress bar.",
 )
-def index_cmd(directory, output, absolute_paths, no_progress):
+@click.option(
+    "--rebuild", is_flag=True, default=False,
+    help="Force a full rebuild instead of incremental refresh "
+         "(default: skip bundles whose mtime+size match an existing "
+         "row).",
+)
+def index_cmd(directory, output, absolute_paths, no_progress, rebuild):
     """Build a SQLite Tier-1 index over a folder of ``.iafbt`` bundles.
 
     The resulting ``index.sqlite`` file holds one row per bundle with
@@ -364,8 +370,150 @@ def index_cmd(directory, output, absolute_paths, no_progress):
         output=output,
         relative_paths=not absolute_paths,
         show_progress=not no_progress,
+        incremental=not rebuild,
     )
     click.echo(f"Wrote SQLite index to {out}")
 
 
 cli.add_command(index_cmd)
+
+
+@click.command(name="list")
+@click.argument(
+    "index_path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+)
+@click.option(
+    "--sort", "sort_by", default=None,
+    help="Metric / column to sort by (e.g. sharpe_ratio, "
+         "summary_total_net_gain_percentage, algorithm_id). "
+         "Bare metric names are auto-prefixed with 'summary_'.",
+)
+@click.option(
+    "--asc", "ascending", is_flag=True, default=False,
+    help="Sort ascending (default: descending / best-first).",
+)
+@click.option(
+    "--limit", "-n", type=int, default=None,
+    help="Maximum number of rows to print.",
+)
+@click.option(
+    "--where", default=None,
+    help='Raw SQL WHERE fragment (no leading WHERE). '
+         'Example: --where "summary_sharpe_ratio > 1.0 AND tag = \'demo\'"',
+)
+@click.option(
+    "--columns", default=None,
+    help="Comma-separated list of columns to print "
+         "(default: a curated set of identity + summary metrics).",
+)
+@click.option(
+    "--json", "as_json", is_flag=True, default=False,
+    help="Emit JSON instead of a text table.",
+)
+def list_cmd(
+    index_path, sort_by, ascending, limit, where, columns, as_json,
+):
+    """List rows from a SQLite Tier-1 index built by ``iaf index``.
+
+    ``INDEX_PATH`` may be either an ``index.sqlite`` file or the
+    directory it lives in.
+
+    Examples:
+
+        iaf list ./backtests --sort sharpe_ratio -n 20
+
+        iaf list index.sqlite --where "summary_max_drawdown > -0.1" \\
+            --sort sortino_ratio
+    """
+    from .index_command import list_index, format_table
+    cols = (
+        [c.strip() for c in columns.split(",")] if columns else None
+    )
+    rows = list_index(
+        index_path=index_path,
+        sort_by=sort_by,
+        ascending=ascending,
+        limit=limit,
+        where=where,
+        columns=cols,
+    )
+    if as_json:
+        import json as _json
+        click.echo(_json.dumps(rows, indent=2, default=str))
+    else:
+        click.echo(format_table(rows, columns=cols))
+
+
+cli.add_command(list_cmd)
+
+
+@click.command(name="rank")
+@click.argument(
+    "index_path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+)
+@click.option(
+    "--by", "by", required=True,
+    help="Metric to rank by (e.g. sharpe_ratio, sortino_ratio, "
+         "calmar_ratio, profit_factor). Bare metric names are "
+         "auto-prefixed with 'summary_'.",
+)
+@click.option(
+    "--limit", "-n", type=int, default=10,
+    help="Number of rows to return (default: 10).",
+)
+@click.option(
+    "--asc", "ascending", is_flag=True, default=False,
+    help="Rank ascending (e.g. for max_drawdown where smaller is "
+         "better the user typically wants ascending order on the "
+         "magnitude). Default: descending / best-first.",
+)
+@click.option(
+    "--where", default=None,
+    help='Optional SQL WHERE fragment to filter candidates before '
+         'ranking. Example: --where "tag = \'walk-forward\'".',
+)
+@click.option(
+    "--columns", default=None,
+    help="Comma-separated list of columns to print "
+         "(default: identity + key risk-adjusted metrics).",
+)
+@click.option(
+    "--json", "as_json", is_flag=True, default=False,
+    help="Emit JSON instead of a text table.",
+)
+def rank_cmd(index_path, by, limit, ascending, where, columns, as_json):
+    """Rank backtests in a Tier-1 index by a single metric.
+
+    Sugar over ``iaf list --sort <by> --limit <n>`` with a column set
+    geared toward strategy comparison (Sharpe / Sortino / Calmar /
+    return / drawdown).
+
+    Examples:
+
+        iaf rank ./backtests --by sharpe_ratio -n 5
+
+        iaf rank index.sqlite --by profit_factor \\
+            --where "summary_number_of_trades > 50"
+    """
+    from .index_command import rank_index, format_table
+    cols = (
+        [c.strip() for c in columns.split(",")] if columns else None
+    )
+    rows = rank_index(
+        index_path=index_path,
+        by=by,
+        limit=limit,
+        where=where,
+        columns=cols,
+        ascending=ascending,
+    )
+    if as_json:
+        import json as _json
+        click.echo(_json.dumps(rows, indent=2, default=str))
+    else:
+        click.echo(format_table(rows, columns=cols))
+
+
+cli.add_command(rank_cmd)

--- a/investing_algorithm_framework/cli/cli.py
+++ b/investing_algorithm_framework/cli/cli.py
@@ -322,6 +322,78 @@ def migrate_backtests_cmd(
 cli.add_command(migrate_backtests_cmd)
 
 
+_STORE_KINDS = ["local-dir", "local-tiered"]
+
+
+@click.command(name="migrate-store")
+@click.option(
+    "--from", "src_kind",
+    type=click.Choice(_STORE_KINDS),
+    required=True,
+    help="Source store kind.",
+)
+@click.option(
+    "--src",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    required=True,
+    help="Path to the source store root.",
+)
+@click.option(
+    "--to", "dst_kind",
+    type=click.Choice(_STORE_KINDS),
+    required=True,
+    help="Destination store kind.",
+)
+@click.option(
+    "--dst",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=True,
+    help="Path to the destination store root (created if missing).",
+)
+@click.option(
+    "--handles",
+    default=None,
+    help=(
+        "Optional comma-separated subset of source handles to copy. "
+        "When omitted, every handle is copied."
+    ),
+)
+def migrate_store_cmd(src_kind, src, dst_kind, dst, handles):
+    """Copy backtests between two :class:`BacktestStore` implementations.
+
+    Uses the destination's :class:`SupportsCopyFrom` capability so the
+    operation is incremental, restartable, and tier-aware: when copying
+    into a ``local-tiered`` store, identical OHLCV chunks are written
+    exactly once across the entire destination, regardless of how many
+    bundles reference them (epic #540 phase 3c).
+
+    Example::
+
+        iaf migrate-store --from local-dir --src ./bt-old \\
+                          --to local-tiered --dst ./bt-new
+    """
+    from .migrate_store_command import migrate_store
+
+    handle_list = (
+        [h.strip() for h in handles.split(",") if h.strip()]
+        if handles else None
+    )
+    n = migrate_store(
+        src_kind=src_kind,
+        src_root=src,
+        dst_kind=dst_kind,
+        dst_root=dst,
+        handles=handle_list,
+    )
+    click.echo(
+        f"Migrated {n} backtest(s) from {src_kind}:{src} "
+        f"to {dst_kind}:{dst}"
+    )
+
+
+cli.add_command(migrate_store_cmd)
+
+
 @click.command(name="index")
 @click.argument(
     "directory",

--- a/investing_algorithm_framework/cli/index_command.py
+++ b/investing_algorithm_framework/cli/index_command.py
@@ -10,13 +10,16 @@ Parquet metric-blob decode), derives a :class:`BacktestIndexRow` via
 from __future__ import annotations
 
 import logging
+from dataclasses import fields as dc_fields
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from investing_algorithm_framework.domain import (
     Backtest,
     BUNDLE_EXT,
 )
+from investing_algorithm_framework.domain.backtesting \
+    .backtest_summary_metrics import BacktestSummaryMetrics
 from investing_algorithm_framework.services.backtest_index import (
     SqliteBacktestIndex,
 )
@@ -37,6 +40,7 @@ def build_index(
     output: Optional[str] = None,
     relative_paths: bool = True,
     show_progress: bool = False,
+    incremental: bool = True,
 ) -> str:
     """Build (or refresh) a SQLite Tier-1 index over *directory*.
 
@@ -48,6 +52,10 @@ def build_index(
             *directory* so the index file stays portable when the
             folder is moved/renamed.
         show_progress: emit a tqdm progress bar.
+        incremental: if True (default), open the existing index (if
+            any) and skip bundles whose ``(mtime, size)`` already
+            match the on-disk file. Pass ``False`` to force a full
+            rebuild.
 
     Returns:
         Absolute path of the SQLite file that was written.
@@ -67,21 +75,36 @@ def build_index(
         except ImportError:  # pragma: no cover - tqdm is a dep
             pbar = None
 
-    index = SqliteBacktestIndex.create(out)
+    if incremental and out.is_file():
+        index = SqliteBacktestIndex.open(out)
+    else:
+        index = SqliteBacktestIndex.create(out)
     n_ok = 0
     n_err = 0
+    n_skipped = 0
     try:
         for path in paths:
             try:
-                bt = Backtest.open(str(path), summary_only=True)
+                stat = path.stat()
                 bundle_path = (
                     str(path.relative_to(src)) if relative_paths
                     else str(path)
                 )
+                if incremental and index.is_up_to_date(
+                    bundle_path, stat.st_mtime_ns, stat.st_size,
+                ):
+                    n_skipped += 1
+                    continue
+
+                bt = Backtest.open(str(path), summary_only=True)
                 row = bt.index_row(bundle_path=bundle_path)
-                index.upsert(row)
+                index.upsert(
+                    row,
+                    bundle_mtime_ns=stat.st_mtime_ns,
+                    bundle_size=stat.st_size,
+                )
                 n_ok += 1
-            except Exception as exc:  # noqa: BLE001 \u2014 best-effort scan
+            except Exception as exc:  # noqa: BLE001 — best-effort scan
                 logger.warning("failed to index %s: %s", path, exc)
                 n_err += 1
             finally:
@@ -93,6 +116,181 @@ def build_index(
         index.close()
 
     logger.info(
-        "Indexed %d bundle(s) into %s (%d failed)", n_ok, out, n_err,
+        "Indexed %d bundle(s) into %s (%d skipped, %d failed)",
+        n_ok, out, n_skipped, n_err,
     )
     return str(out)
+
+
+# ---------------------------------------------------------------------------
+# list / rank helpers
+# ---------------------------------------------------------------------------
+DEFAULT_LIST_COLUMNS: Sequence[str] = (
+    "algorithm_id",
+    "tag",
+    "summary_sharpe_ratio",
+    "summary_total_net_gain_percentage",
+    "summary_max_drawdown",
+    "summary_number_of_trades",
+    "bundle_path",
+)
+
+DEFAULT_RANK_COLUMNS: Sequence[str] = (
+    "algorithm_id",
+    "tag",
+    "summary_sharpe_ratio",
+    "summary_sortino_ratio",
+    "summary_calmar_ratio",
+    "summary_total_net_gain_percentage",
+    "summary_max_drawdown",
+    "bundle_path",
+)
+
+_SUMMARY_FIELD_NAMES = frozenset(
+    f.name for f in dc_fields(BacktestSummaryMetrics)
+)
+
+
+def _resolve_index_path(path: str) -> Path:
+    """Accept either a directory (look for ``index.sqlite`` inside) or
+    a SQLite file path; return the resolved file path."""
+    p = Path(path)
+    if p.is_dir():
+        candidate = p / DEFAULT_INDEX_NAME
+        if not candidate.is_file():
+            raise FileNotFoundError(
+                f"No {DEFAULT_INDEX_NAME} in {p}. Run `iaf index {p}` "
+                f"first or pass the SQLite file directly."
+            )
+        return candidate
+    if not p.is_file():
+        raise FileNotFoundError(f"Index file not found: {p}")
+    return p
+
+
+def _resolve_metric_column(name: str) -> str:
+    """Map a user-friendly metric name to a real SQL column.
+
+    Accepts both ``sharpe_ratio`` and ``summary_sharpe_ratio``; bare
+    column names (``algorithm_id``, ``tag``, ...) are returned as-is.
+    """
+    if name.startswith("summary_"):
+        return name
+    if name in _SUMMARY_FIELD_NAMES:
+        return f"summary_{name}"
+    return name
+
+
+def _row_to_flat_dict(row, columns: Sequence[str]) -> Dict[str, Any]:
+    """Project a :class:`BacktestIndexRow` onto the requested columns."""
+    out: Dict[str, Any] = {}
+    summary = row.summary_metrics
+    for col in columns:
+        if col.startswith("summary_"):
+            field = col[len("summary_"):]
+            out[col] = (
+                getattr(summary, field, None) if summary is not None
+                else None
+            )
+        else:
+            out[col] = getattr(row, col, None)
+    return out
+
+
+def list_index(
+    index_path: str,
+    sort_by: Optional[str] = None,
+    ascending: bool = False,
+    limit: Optional[int] = None,
+    where: Optional[str] = None,
+    columns: Optional[Sequence[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Query an index file and return matching rows as plain dicts.
+
+    Args:
+        index_path: Path to ``index.sqlite`` or a directory holding it.
+        sort_by: Column to sort by (e.g. ``"sharpe_ratio"`` or
+            ``"summary_sharpe_ratio"``). ``None`` keeps insertion order.
+        ascending: Sort direction; default descending (best-first).
+        limit: Maximum number of rows to return.
+        where: Optional raw SQL ``WHERE`` fragment (no leading
+            ``WHERE`` keyword). Use ``?`` placeholders only via
+            :meth:`SqliteBacktestIndex.query` directly if you need
+            bind parameters.
+        columns: Columns to project; defaults to
+            :data:`DEFAULT_LIST_COLUMNS`.
+
+    Returns:
+        A list of column-name → value dicts, ready for tabulation.
+    """
+    cols = list(columns) if columns else list(DEFAULT_LIST_COLUMNS)
+    resolved = _resolve_index_path(index_path)
+
+    base_where = f"({where})" if where else "1=1"
+    fragment = base_where
+    if sort_by:
+        sort_col = _resolve_metric_column(sort_by)
+        direction = "ASC" if ascending else "DESC"
+        # NULLs always come last regardless of direction so the table
+        # is useful even when some bundles are missing the metric.
+        fragment += (
+            f' ORDER BY "{sort_col}" IS NULL, "{sort_col}" {direction}'
+        )
+    if limit is not None:
+        fragment += f" LIMIT {int(limit)}"
+
+    with SqliteBacktestIndex.open(resolved) as idx:
+        rows = idx.query(where=fragment)
+    return [_row_to_flat_dict(r, cols) for r in rows]
+
+
+def rank_index(
+    index_path: str,
+    by: str,
+    limit: int = 10,
+    where: Optional[str] = None,
+    columns: Optional[Sequence[str]] = None,
+    ascending: bool = False,
+) -> List[Dict[str, Any]]:
+    """Rank bundles by a metric. Thin wrapper around :func:`list_index`
+    with a different default column set and a required ``by`` arg."""
+    cols = list(columns) if columns else list(DEFAULT_RANK_COLUMNS)
+    return list_index(
+        index_path,
+        sort_by=by,
+        ascending=ascending,
+        limit=limit,
+        where=where,
+        columns=cols,
+    )
+
+
+def format_table(
+    rows: List[Dict[str, Any]],
+    columns: Optional[Sequence[str]] = None,
+) -> str:
+    """Render rows as a fixed-width text table (no external deps)."""
+    if not rows:
+        return "(no rows)"
+    cols = list(columns) if columns else list(rows[0].keys())
+
+    def _fmt(v: Any) -> str:
+        if v is None:
+            return ""
+        if isinstance(v, float):
+            return f"{v:.4f}"
+        return str(v)
+
+    cells = [[_fmt(r.get(c)) for c in cols] for r in rows]
+    widths = [
+        max(len(c), *(len(row[i]) for row in cells))
+        for i, c in enumerate(cols)
+    ]
+    sep = "  "
+    header = sep.join(c.ljust(widths[i]) for i, c in enumerate(cols))
+    rule = sep.join("-" * w for w in widths)
+    body = "\n".join(
+        sep.join(row[i].ljust(widths[i]) for i in range(len(cols)))
+        for row in cells
+    )
+    return f"{header}\n{rule}\n{body}"

--- a/investing_algorithm_framework/cli/migrate_store_command.py
+++ b/investing_algorithm_framework/cli/migrate_store_command.py
@@ -1,0 +1,67 @@
+"""``iaf migrate-store`` — copy backtests between :class:`BacktestStore`
+implementations using the :class:`SupportsCopyFrom` capability.
+
+Phase 3d of epic #540.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from investing_algorithm_framework.services.backtest_store import (
+    BacktestStore,
+    LocalDirStore,
+    LocalTieredStore,
+    SupportsCopyFrom,
+)
+
+
+_STORE_FACTORIES = {
+    "local-dir": lambda root: LocalDirStore(root),
+    "local-tiered": lambda root: LocalTieredStore(root),
+}
+
+
+def _build_store(kind: str, root: str) -> BacktestStore:
+    if kind not in _STORE_FACTORIES:
+        raise ValueError(
+            f"unknown store kind {kind!r}; expected one of "
+            f"{sorted(_STORE_FACTORIES)}"
+        )
+    return _STORE_FACTORIES[kind](root)
+
+
+def migrate_store(
+    *,
+    src_kind: str,
+    src_root: str,
+    dst_kind: str,
+    dst_root: str,
+    handles: Optional[list] = None,
+) -> int:
+    """Copy backtests from one store to another.
+
+    Args:
+        src_kind: One of ``"local-dir"``, ``"local-tiered"``.
+        src_root: Path to the source store root.
+        dst_kind: Same vocabulary as ``src_kind``.
+        dst_root: Path to the destination store root.
+        handles: Optional subset of source handles to copy. When
+            ``None`` every handle in the source is copied.
+
+    Returns:
+        The number of backtests written to the destination.
+
+    Raises:
+        TypeError: When the destination store does not implement
+            :class:`SupportsCopyFrom`.
+    """
+    src = _build_store(src_kind, src_root)
+    Path(dst_root).mkdir(parents=True, exist_ok=True)
+    dst = _build_store(dst_kind, dst_root)
+    if not isinstance(dst, SupportsCopyFrom):
+        raise TypeError(
+            f"destination store {dst_kind!r} does not implement "
+            f"SupportsCopyFrom"
+        )
+    return dst.copy_from(src, handles=handles)

--- a/investing_algorithm_framework/domain/backtesting/backtest.py
+++ b/investing_algorithm_framework/domain/backtesting/backtest.py
@@ -263,6 +263,22 @@ class Backtest:
         """
         return self.backtest_summary
 
+    def scalar_summary(self) -> Union[BacktestSummaryMetrics, None]:
+        """Alias for :meth:`get_backtest_summary` — the typed scalar
+        roll-up named per epic #540 phase 1.
+
+        The Tier-1 storage layer (``BacktestIndexRow`` and the SQLite
+        index) builds on this scalar view: it can be obtained from a
+        bundle opened with ``summary_only=True`` without decoding any
+        Parquet metric blobs, making list / rank workloads cheap.
+
+        Returns:
+            Union[BacktestSummaryMetrics, None]: The cross-window
+                scalar metrics, or ``None`` if they were never
+                computed for this backtest.
+        """
+        return self.backtest_summary
+
     def to_dict(self) -> dict:
         """
         Convert the Backtest instance to a dictionary.

--- a/investing_algorithm_framework/domain/backtesting/bundle.py
+++ b/investing_algorithm_framework/domain/backtesting/bundle.py
@@ -318,6 +318,14 @@ class LazyOhlcvDict(Dict[str, Any]):
     def keys(self):  # type: ignore[override]
         return self._manifest.keys()
 
+    def values(self):  # type: ignore[override]
+        for k in self._manifest:
+            yield self[k]
+
+    def items(self):  # type: ignore[override]
+        for k in self._manifest:
+            yield k, self[k]
+
     def __getitem__(self, key: str):
         if key in self._cache:
             return self._cache[key]

--- a/investing_algorithm_framework/services/backtest_index/sqlite_index.py
+++ b/investing_algorithm_framework/services/backtest_index/sqlite_index.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 # Bumped on any additive schema change. Old files are upgraded
 # in-place by :meth:`SqliteBacktestIndex._migrate`.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # Columns of BacktestIndexRow that map 1:1 to typed SQL columns.
 # (parameters / strategy_ids are emitted as JSON text columns; the
@@ -68,6 +68,10 @@ _IDENTITY_COLUMNS: Tuple[Tuple[str, str], ...] = (
     ("strategy_ids_json", "TEXT"),
     ("extras_json", "TEXT"),
     ("summary_extras_json", "TEXT"),
+    # Provenance for incremental indexing — skip bundles whose
+    # mtime + size match an existing row (epic #540 phase 2).
+    ("bundle_mtime_ns", "INTEGER"),
+    ("bundle_size", "INTEGER"),
 )
 
 
@@ -190,8 +194,21 @@ class SqliteBacktestIndex:
     # ------------------------------------------------------------------
     # Writes
     # ------------------------------------------------------------------
-    def upsert(self, row: BacktestIndexRow) -> None:
+    def upsert(
+        self,
+        row: BacktestIndexRow,
+        bundle_mtime_ns: Optional[int] = None,
+        bundle_size: Optional[int] = None,
+    ) -> None:
         """Insert or replace a single row, keyed by ``bundle_path``.
+
+        Args:
+            row: the typed row to write.
+            bundle_mtime_ns: optional file mtime in nanoseconds; used
+                by :meth:`is_up_to_date` to support incremental
+                indexing (epic #540 phase 2).
+            bundle_size: optional file size in bytes, used together
+                with ``bundle_mtime_ns`` for the freshness check.
 
         Raises:
             ValueError: if ``row.bundle_path`` is None (it is the PK).
@@ -202,6 +219,8 @@ class SqliteBacktestIndex:
                 "upsert (used as the primary key)."
             )
         record = self._row_to_record(row)
+        record["bundle_mtime_ns"] = bundle_mtime_ns
+        record["bundle_size"] = bundle_size
         cols = list(record.keys())
         placeholders = ", ".join("?" for _ in cols)
         col_list = ", ".join(f'"{c}"' for c in cols)
@@ -211,6 +230,28 @@ class SqliteBacktestIndex:
             [record[c] for c in cols],
         )
         self._conn.commit()
+
+    def is_up_to_date(
+        self, bundle_path: str, mtime_ns: int, size: int,
+    ) -> bool:
+        """Return True if the index already has a row for *bundle_path*
+        whose ``(mtime_ns, size)`` matches the on-disk file.
+
+        Used by :func:`build_index` to skip bundles that have not
+        changed since the last index build (epic #540 phase 2).
+        """
+        cur = self._conn.execute(
+            f'SELECT bundle_mtime_ns, bundle_size '
+            f'FROM "{_TABLE}" WHERE bundle_path = ?',
+            (bundle_path,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return False
+        return (
+            row["bundle_mtime_ns"] == mtime_ns
+            and row["bundle_size"] == size
+        )
 
     def upsert_many(self, rows: Iterable[BacktestIndexRow]) -> int:
         """Bulk insert/replace; returns the number of rows written."""

--- a/investing_algorithm_framework/services/backtest_store/__init__.py
+++ b/investing_algorithm_framework/services/backtest_store/__init__.py
@@ -1,0 +1,30 @@
+"""Storage abstraction for backtests (epic #540 phase 3).
+
+A :class:`BacktestStore` is the single seam between the framework and
+*where* backtest results actually live. Phase 3a ships the Protocol
+and a thin :class:`LocalDirStore` adapter over the existing ``.iafbt``
+layout, so every consumer (HTML report, ``iaf list/rank``, the MCP
+server, future ``FinterionStore``) can be written against one
+interface.
+
+See ``docs/design/tiered-backtest-storage.md`` §7 and the Phase 3
+plan in epic #540 for the full architecture.
+"""
+
+from .base import (
+    BacktestStore,
+    StoreHandle,
+    StoreError,
+    StoreHandleNotFoundError,
+    SupportsCopyFrom,
+)
+from .local_dir_store import LocalDirStore
+
+__all__ = [
+    "BacktestStore",
+    "StoreHandle",
+    "StoreError",
+    "StoreHandleNotFoundError",
+    "SupportsCopyFrom",
+    "LocalDirStore",
+]

--- a/investing_algorithm_framework/services/backtest_store/__init__.py
+++ b/investing_algorithm_framework/services/backtest_store/__init__.py
@@ -19,6 +19,7 @@ from .base import (
     SupportsCopyFrom,
 )
 from .local_dir_store import LocalDirStore
+from .local_tiered_store import LocalTieredStore
 
 __all__ = [
     "BacktestStore",
@@ -27,4 +28,5 @@ __all__ = [
     "StoreHandleNotFoundError",
     "SupportsCopyFrom",
     "LocalDirStore",
+    "LocalTieredStore",
 ]

--- a/investing_algorithm_framework/services/backtest_store/base.py
+++ b/investing_algorithm_framework/services/backtest_store/base.py
@@ -1,0 +1,157 @@
+"""``BacktestStore`` Protocol + capability mixins (epic #540 phase 3a).
+
+A :class:`BacktestStore` decouples *where* a backtest is persisted
+from the rest of the framework. Three concrete implementations are
+planned:
+
+* :class:`LocalDirStore` (this PR) — directory of ``.iafbt`` bundles.
+  Adapter over today's :meth:`Backtest.save_bundle` /
+  :meth:`Backtest.open` so existing layouts keep working unchanged.
+* ``LocalTieredStore`` (Phase 3b/3c) — SQLite Tier-1 + per-project
+  Parquet datasets (Tier-2) + content-addressed chunks (Tier-3).
+* ``FinterionStore`` (closed-source) — HTTP adapter over Finterion's
+  hosted tiered backend, with the optional :class:`SupportsRelations`
+  capability for strategy-version / report linkage.
+
+The Protocol stays deliberately small. Capabilities that not every
+store can or should implement (efficient bulk migration, relational
+graph queries, …) are declared as separate Protocols so callers can
+``isinstance(store, SupportsCopyFrom)``-test for them at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    Iterable,
+    Iterator,
+    Optional,
+    Protocol,
+    runtime_checkable,
+)
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+)
+
+
+# A handle is an opaque, store-scoped, stable string identifier for a
+# single backtest record. For ``LocalDirStore`` it is the bundle path
+# relative to the store root; for ``LocalTieredStore`` it will be the
+# ``run_id`` (uuid7); for ``FinterionStore`` a remote URI. Callers
+# should treat handles as opaque tokens — never parse them.
+StoreHandle = str
+
+
+class StoreError(Exception):
+    """Base class for all :class:`BacktestStore` errors."""
+
+
+class StoreHandleNotFoundError(StoreError, KeyError):
+    """Raised when an operation references a handle that does not exist."""
+
+
+@runtime_checkable
+class BacktestStore(Protocol):
+    """Minimal write/read/list/delete contract for backtest storage.
+
+    All implementations must be safe for concurrent reads. Concurrent
+    writes are implementation-specific (``LocalDirStore`` allows
+    them; tiered stores will document their guarantees).
+
+    The contract intentionally mirrors today's
+    :meth:`Backtest.save_bundle` / :meth:`Backtest.open` semantics so
+    :class:`LocalDirStore` is a 1:1 adapter and existing tests keep
+    passing without behavioural drift.
+    """
+
+    def write(
+        self,
+        backtest: Backtest,
+        *,
+        handle: Optional[StoreHandle] = None,
+    ) -> StoreHandle:
+        """Persist *backtest* and return its handle.
+
+        If *handle* is supplied the store should write to (or replace)
+        that exact location; otherwise the store picks a deterministic
+        handle from the backtest's identity (e.g. ``algorithm_id`` for
+        local stores, ``run_id`` for tiered stores).
+        """
+        ...
+
+    def open(
+        self,
+        handle: StoreHandle,
+        *,
+        summary_only: bool = False,
+    ) -> Backtest:
+        """Materialise the backtest at *handle*.
+
+        ``summary_only`` mirrors :meth:`Backtest.open`: when True the
+        store should avoid decoding heavy time-series payloads (the
+        Tier-2 Parquet bodies, in tiered terminology).
+        """
+        ...
+
+    def exists(self, handle: StoreHandle) -> bool:
+        """Return True if *handle* refers to a stored backtest."""
+        ...
+
+    def delete(self, handle: StoreHandle) -> None:
+        """Remove the backtest at *handle*. No-op if absent."""
+        ...
+
+    def iter_handles(self) -> Iterator[StoreHandle]:
+        """Yield every handle currently in the store, in stable order."""
+        ...
+
+    def iter_index_rows(self) -> Iterator[BacktestIndexRow]:
+        """Yield a :class:`BacktestIndexRow` for every stored backtest.
+
+        Implementations that have a Tier-1 index should serve this
+        from the index (no bulk decode); :class:`LocalDirStore`
+        falls back to ``Backtest.open(..., summary_only=True)`` per
+        bundle when no sidecar index is present.
+        """
+        ...
+
+    def __len__(self) -> int:
+        """Number of backtests currently in the store."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Optional capabilities — declared as separate Protocols so callers can
+# feature-test with isinstance(store, SupportsXxx).
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SupportsCopyFrom(Protocol):
+    """Stores that can ingest from another :class:`BacktestStore`.
+
+    Used by ``iaf migrate-store`` (Phase 3d) to move bundles between
+    a :class:`LocalDirStore` and a ``LocalTieredStore`` (or to push
+    to ``FinterionStore``). Implementations may optimise — e.g. a
+    tiered store can dedup chunks during ingest — but the default
+    fallback is a per-handle ``write(src.open(h))`` loop.
+    """
+
+    def copy_from(
+        self,
+        src: "BacktestStore",
+        *,
+        handles: Optional[Iterable[StoreHandle]] = None,
+    ) -> int:
+        """Copy backtests from *src* into this store.
+
+        Args:
+            src: source store to read from.
+            handles: optional subset of handles to copy. If None, all
+                handles in *src* are copied.
+
+        Returns:
+            Number of backtests successfully copied.
+        """
+        ...

--- a/investing_algorithm_framework/services/backtest_store/decompose.py
+++ b/investing_algorithm_framework/services/backtest_store/decompose.py
@@ -1,0 +1,70 @@
+"""Backtest → flat-records decomposer for Tier-2 Parquet writes
+(epic #540 phase 3b).
+
+Given a :class:`Backtest`, yields flat record lists for each Tier-2
+dataset (``portfolio_snapshots`` / ``trades`` / ``orders``). The
+output is shaped for direct ingestion by
+:func:`pyarrow.dataset.write_dataset` with hive partitioning on
+``run_id``.
+
+The bundle (``.iafbt``) remains the canonical source of truth in
+Phase 3b; these Parquet datasets are *auxiliary* — they make
+DuckDB / Polars analytics work across thousands of runs without
+re-decoding bundles. Round-tripping Tier-2 back to a Backtest is
+Phase 3d territory.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List
+
+from investing_algorithm_framework.domain import Backtest
+
+
+def _windowed_records(
+    backtest: Backtest, attr: str, run_id: str,
+) -> Iterator[Dict[str, Any]]:
+    """Yield ``to_dict()``-shaped records from every BacktestRun.
+
+    Adds ``run_id`` and ``window_name`` columns so downstream
+    columnar tools can group / partition cleanly across a Backtest's
+    walk-forward windows.
+    """
+    if not backtest.backtest_runs:
+        return
+    for window in backtest.backtest_runs:
+        items = getattr(window, attr, None) or []
+        window_name = getattr(window, "backtest_date_range_name", None) or (
+            window.create_directory_name()
+            if hasattr(window, "create_directory_name") else ""
+        )
+        for obj in items:
+            d = obj.to_dict() if hasattr(obj, "to_dict") else dict(obj)
+            d["run_id"] = run_id
+            d["window_name"] = window_name
+            yield d
+
+
+def snapshots(backtest: Backtest, run_id: str) -> List[Dict[str, Any]]:
+    """Flat portfolio_snapshots records, one per BacktestRun timestep."""
+    return list(_windowed_records(backtest, "portfolio_snapshots", run_id))
+
+
+def trades(backtest: Backtest, run_id: str) -> List[Dict[str, Any]]:
+    """Flat trades records (one per trade across all windows)."""
+    return list(_windowed_records(backtest, "trades", run_id))
+
+
+def orders(backtest: Backtest, run_id: str) -> List[Dict[str, Any]]:
+    """Flat orders records (one per order across all windows)."""
+    return list(_windowed_records(backtest, "orders", run_id))
+
+
+# Datasets exposed by LocalTieredStore. Each entry is
+# (dataset_name, decomposer_fn). Add new kinds here (e.g.
+# metric_series) once their decomposer is in place.
+DATASETS = (
+    ("portfolio_snapshots", snapshots),
+    ("trades", trades),
+    ("orders", orders),
+)

--- a/investing_algorithm_framework/services/backtest_store/local_dir_store.py
+++ b/investing_algorithm_framework/services/backtest_store/local_dir_store.py
@@ -1,0 +1,270 @@
+"""``LocalDirStore`` — directory-of-bundles :class:`BacktestStore`.
+
+Thin adapter over the existing ``.iafbt`` storage layout. Every
+backtest is one bundle file under the store's *root* directory.
+Optionally maintains a sidecar :class:`SqliteBacktestIndex` to serve
+:meth:`iter_index_rows` without re-decoding bundles on every call.
+
+This is the Phase-3a default; it preserves today's on-disk layout
+exactly so existing consumers (HTML report, ``iaf list/rank``, the
+MCP server) work unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Iterable, Iterator, Optional, Union
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_index import (
+    SqliteBacktestIndex,
+)
+
+from .base import (
+    BacktestStore,
+    StoreError,
+    StoreHandle,
+    StoreHandleNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+SIDECAR_INDEX_NAME = "index.sqlite"
+
+
+class LocalDirStore(BacktestStore):
+    """A directory of ``.iafbt`` bundles, addressable by relative path.
+
+    Handles are bundle paths *relative to the store root* — e.g.
+    ``"my_strategy.iafbt"`` or ``"sweep_a/run_03.iafbt"``. Relative
+    handles keep the store portable: moving the root directory does
+    not invalidate any handle.
+
+    The store optionally maintains a sidecar
+    ``<root>/index.sqlite`` (built lazily on the first call to
+    :meth:`iter_index_rows` when ``use_index=True``) so listing /
+    ranking does not have to re-open every bundle.
+    """
+
+    def __init__(
+        self,
+        root: Union[str, Path],
+        *,
+        use_index: bool = True,
+    ) -> None:
+        """
+        Args:
+            root: directory that holds (or will hold) the bundles.
+                Created if it does not exist.
+            use_index: when True, :meth:`iter_index_rows` is served
+                from a sidecar :class:`SqliteBacktestIndex`. Disable
+                for one-shot scripts that never list.
+        """
+        self.root = Path(root).resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._use_index = use_index
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    def _resolve(self, handle: StoreHandle) -> Path:
+        """Map *handle* to an absolute path under :attr:`root`.
+
+        Rejects handles that escape the store root (path traversal).
+        """
+        candidate = (self.root / handle).resolve()
+        try:
+            candidate.relative_to(self.root)
+        except ValueError as exc:
+            raise StoreError(
+                f"handle {handle!r} resolves outside the store root "
+                f"{self.root}"
+            ) from exc
+        return candidate
+
+    @staticmethod
+    def _ensure_bundle_suffix(handle: StoreHandle) -> StoreHandle:
+        if handle.endswith(BUNDLE_EXT):
+            return handle
+        return handle + BUNDLE_EXT
+
+    def _default_handle(self, backtest: Backtest) -> StoreHandle:
+        """Pick a deterministic handle when the caller didn't supply one.
+
+        Uses ``algorithm_id`` if set, otherwise falls back to a
+        timestamp-derived name. The choice is deliberate: the
+        Phase 3a contract is "behaves like ``Backtest.save_bundle``";
+        callers who need stronger identity (``run_id``, content
+        hash, …) should pass an explicit handle.
+        """
+        if backtest.algorithm_id:
+            stem = str(backtest.algorithm_id)
+        else:
+            from datetime import datetime, timezone
+            stem = "backtest_" + datetime.now(timezone.utc).strftime(
+                "%Y%m%dT%H%M%S%f"
+            )
+        return self._ensure_bundle_suffix(stem)
+
+    def _iter_bundle_paths(self) -> Iterator[Path]:
+        for p in sorted(self.root.rglob(f"*{BUNDLE_EXT}")):
+            if p.is_file():
+                yield p
+
+    # ------------------------------------------------------------------
+    # BacktestStore API
+    # ------------------------------------------------------------------
+    def write(
+        self,
+        backtest: Backtest,
+        *,
+        handle: Optional[StoreHandle] = None,
+    ) -> StoreHandle:
+        if handle is None:
+            handle = self._default_handle(backtest)
+        else:
+            handle = self._ensure_bundle_suffix(handle)
+        target = self._resolve(handle)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        backtest.save_bundle(target)
+        return handle
+
+    def open(
+        self,
+        handle: StoreHandle,
+        *,
+        summary_only: bool = False,
+    ) -> Backtest:
+        handle = self._ensure_bundle_suffix(handle)
+        target = self._resolve(handle)
+        if not target.is_file():
+            raise StoreHandleNotFoundError(handle)
+        return Backtest.open(str(target), summary_only=summary_only)
+
+    def exists(self, handle: StoreHandle) -> bool:
+        try:
+            target = self._resolve(self._ensure_bundle_suffix(handle))
+        except StoreError:
+            return False
+        return target.is_file()
+
+    def delete(self, handle: StoreHandle) -> None:
+        handle = self._ensure_bundle_suffix(handle)
+        try:
+            target = self._resolve(handle)
+        except StoreError:
+            return
+        if target.is_file():
+            target.unlink()
+        elif target.is_dir():
+            # Shouldn't happen for .iafbt, but tolerate legacy
+            # directory-style bundles for symmetry.
+            shutil.rmtree(target)
+
+    def iter_handles(self) -> Iterator[StoreHandle]:
+        for p in self._iter_bundle_paths():
+            yield str(p.relative_to(self.root))
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self._iter_bundle_paths())
+
+    def __contains__(self, handle: object) -> bool:
+        if not isinstance(handle, str):
+            return False
+        return self.exists(handle)
+
+    # ------------------------------------------------------------------
+    # iter_index_rows — backed by a sidecar SqliteBacktestIndex when
+    # ``use_index=True`` (the default), otherwise a per-call decode.
+    # ------------------------------------------------------------------
+    def iter_index_rows(self) -> Iterator[BacktestIndexRow]:
+        if not self._use_index:
+            yield from self._iter_index_rows_decoded()
+            return
+
+        index_path = self.root / SIDECAR_INDEX_NAME
+        # Build or refresh incrementally — same machinery as `iaf index`.
+        index = (
+            SqliteBacktestIndex.open(index_path)
+            if index_path.is_file()
+            else SqliteBacktestIndex.create(index_path)
+        )
+        try:
+            for path in self._iter_bundle_paths():
+                stat = path.stat()
+                rel = str(path.relative_to(self.root))
+                if not index.is_up_to_date(
+                    rel, stat.st_mtime_ns, stat.st_size,
+                ):
+                    try:
+                        bt = Backtest.open(str(path), summary_only=True)
+                        row = bt.index_row(bundle_path=rel)
+                        index.upsert(
+                            row,
+                            bundle_mtime_ns=stat.st_mtime_ns,
+                            bundle_size=stat.st_size,
+                        )
+                    except Exception as exc:  # pragma: no cover - logged
+                        logger.warning(
+                            "Skipping bundle %s while building index: %s",
+                            path, exc,
+                        )
+                        continue
+            yield from index.iter_rows()
+        finally:
+            index.close()
+
+    def _iter_index_rows_decoded(self) -> Iterator[BacktestIndexRow]:
+        for path in self._iter_bundle_paths():
+            rel = str(path.relative_to(self.root))
+            try:
+                bt = Backtest.open(str(path), summary_only=True)
+            except Exception as exc:  # pragma: no cover - logged
+                logger.warning(
+                    "Skipping bundle %s while listing: %s", path, exc,
+                )
+                continue
+            yield bt.index_row(bundle_path=rel)
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom
+    # ------------------------------------------------------------------
+    def copy_from(
+        self,
+        src: BacktestStore,
+        *,
+        handles: Optional[Iterable[StoreHandle]] = None,
+    ) -> int:
+        n = 0
+        chosen = list(handles) if handles is not None else list(
+            src.iter_handles()
+        )
+        for h in chosen:
+            try:
+                bt = src.open(h)
+            except StoreHandleNotFoundError:
+                logger.warning("copy_from: handle %r not in source", h)
+                continue
+            self.write(bt, handle=h)
+            n += 1
+        return n
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+    def __repr__(self) -> str:
+        return (
+            f"LocalDirStore(root={str(self.root)!r}, "
+            f"use_index={self._use_index})"
+        )
+
+    def __fspath__(self) -> str:
+        return os.fspath(self.root)

--- a/investing_algorithm_framework/services/backtest_store/local_tiered_store.py
+++ b/investing_algorithm_framework/services/backtest_store/local_tiered_store.py
@@ -1,0 +1,410 @@
+"""``LocalTieredStore`` — Tier-1 SQLite + Tier-2 Parquet + canonical
+``.iafbt`` bundles on a local filesystem (epic #540 phase 3b).
+
+Layout under *root*::
+
+    <root>/
+        index.sqlite               # Tier-1, kept in sync on every write
+        bundles/<handle>.iafbt     # canonical bytes (source of truth)
+        parquet/
+            portfolio_snapshots/run_id=<handle>/part-0.parquet
+            trades/run_id=<handle>/part-0.parquet
+            orders/run_id=<handle>/part-0.parquet
+
+The bundle file is the canonical representation. The Tier-1 index and
+the Tier-2 Parquet datasets are derived, eagerly maintained, and
+best-effort: a malformed sidecar never blocks a write or read against
+the bundle. This keeps Phase 3b's invariants simple and trivially
+preserves byte-identical round-trips through ``Backtest.save_bundle``
+/ ``Backtest.open``. Byte-identical *Tier-2 → Backtest* reassembly is
+Phase 3d.
+
+The Parquet datasets are hive-partitioned on ``run_id`` (which is the
+store handle), so cross-run analytics is one DuckDB / Polars scan::
+
+    duckdb.sql(\"\"\"
+        SELECT run_id, total_value
+        FROM read_parquet('store/parquet/portfolio_snapshots/**/*.parquet',
+                          hive_partitioning=True)
+        WHERE run_id IN (SELECT bundle_path FROM
+                         read_csv('top20.csv'))
+    \"\"\")
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Any, Iterable, Iterator, List, Optional, Union
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_index import (
+    SqliteBacktestIndex,
+)
+
+from .base import (
+    BacktestStore,
+    StoreError,
+    StoreHandle,
+    StoreHandleNotFoundError,
+)
+from . import decompose as _decompose
+
+logger = logging.getLogger(__name__)
+
+
+INDEX_FILENAME = "index.sqlite"
+BUNDLES_SUBDIR = "bundles"
+PARQUET_SUBDIR = "parquet"
+
+
+def _records_to_table(records: List[dict]) -> Optional[Any]:
+    """Convert ``to_dict()``-shaped records to a pyarrow Table.
+
+    Returns ``None`` when there are no records, the table cannot be
+    built (heterogeneous schema, unsupported types, …), or pyarrow is
+    not importable. Callers must treat the absence of a sidecar as
+    valid — the bundle is canonical.
+    """
+    if not records:
+        return None
+    try:
+        import pyarrow as pa
+        import pandas as pd
+    except ImportError:  # pragma: no cover - dependency missing
+        return None
+    try:
+        df = pd.DataFrame.from_records(records)
+        # Object columns containing dicts/lists can blow up Parquet
+        # schema inference. Stringify them so the analytics path stays
+        # usable; the bundle still has the original structured data.
+        for col in df.columns:
+            if df[col].dtype == object:
+                df[col] = df[col].map(
+                    lambda v: (
+                        v if v is None
+                        or isinstance(v, (str, int, float, bool))
+                        else str(v)
+                    )
+                )
+        return pa.Table.from_pandas(df, preserve_index=False)
+    except Exception as exc:  # pragma: no cover - logged
+        logger.warning(
+            "Tier-2 Parquet table build failed: %s", exc,
+        )
+        return None
+
+
+class LocalTieredStore(BacktestStore):
+    """Tier-1 + Tier-2 + canonical-bundle store on a local filesystem.
+
+    The store is fully self-contained: a single root directory holds
+    every artefact, so it can be copied, symlinked, or rsync'd with
+    a single ``cp -r``. Concurrent readers are safe; concurrent
+    writers from different processes may race on the SQLite index
+    (WAL handles it) but per-handle write atomicity is the caller's
+    responsibility.
+
+    Phase 3b deliberately keeps the .iafbt bundle as the canonical
+    representation. Reads always go through the bundle so the
+    Backtest round-trip is bit-for-bit identical to today's
+    behaviour. Tier-2 sidecars are *auxiliary* — used only for
+    cross-run analytics — and are rebuilt from the bundle on demand.
+    """
+
+    def __init__(self, root: Union[str, Path]) -> None:
+        self.root = Path(root).resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._bundles_dir = self.root / BUNDLES_SUBDIR
+        self._parquet_dir = self.root / PARQUET_SUBDIR
+        self._index_path = self.root / INDEX_FILENAME
+        self._bundles_dir.mkdir(parents=True, exist_ok=True)
+        self._parquet_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_handle(handle: StoreHandle) -> str:
+        """Strip the .iafbt suffix; handles are stored bare in Tier-1."""
+        if handle.endswith(BUNDLE_EXT):
+            return handle[: -len(BUNDLE_EXT)]
+        return handle
+
+    def _bundle_path(self, handle: StoreHandle) -> Path:
+        bare = self._normalize_handle(handle)
+        candidate = (self._bundles_dir / (bare + BUNDLE_EXT)).resolve()
+        try:
+            candidate.relative_to(self._bundles_dir)
+        except ValueError as exc:
+            raise StoreError(
+                f"handle {handle!r} resolves outside the bundles "
+                f"directory {self._bundles_dir}"
+            ) from exc
+        return candidate
+
+    def _partition_dir(self, dataset: str, handle: StoreHandle) -> Path:
+        bare = self._normalize_handle(handle)
+        return self._parquet_dir / dataset / f"run_id={bare}"
+
+    def _default_handle(self, backtest: Backtest) -> StoreHandle:
+        if backtest.algorithm_id:
+            return str(backtest.algorithm_id)
+        from datetime import datetime, timezone
+        return "backtest_" + datetime.now(timezone.utc).strftime(
+            "%Y%m%dT%H%M%S%f"
+        )
+
+    def _open_index(self) -> SqliteBacktestIndex:
+        if self._index_path.is_file():
+            return SqliteBacktestIndex.open(self._index_path)
+        return SqliteBacktestIndex.create(self._index_path)
+
+    # ------------------------------------------------------------------
+    # BacktestStore: write / open / exists / delete
+    # ------------------------------------------------------------------
+    def write(
+        self,
+        backtest: Backtest,
+        *,
+        handle: Optional[StoreHandle] = None,
+    ) -> StoreHandle:
+        if handle is None:
+            handle = self._default_handle(backtest)
+        bare = self._normalize_handle(handle)
+        bundle_path = self._bundle_path(bare)
+        bundle_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # 1. Canonical bytes — bundle.
+        backtest.save_bundle(bundle_path)
+
+        # 2. Tier-1 — SQLite row.
+        stat = bundle_path.stat()
+        row = backtest.index_row(bundle_path=bare)
+        index = self._open_index()
+        try:
+            index.upsert(
+                row,
+                bundle_mtime_ns=stat.st_mtime_ns,
+                bundle_size=stat.st_size,
+            )
+        finally:
+            index.close()
+
+        # 3. Tier-2 — Parquet sidecars (best-effort).
+        self._write_parquet_sidecars(backtest, bare)
+
+        return bare
+
+    def _write_parquet_sidecars(
+        self, backtest: Backtest, handle: str,
+    ) -> None:
+        try:
+            import pyarrow.parquet as pq
+        except ImportError:  # pragma: no cover - pyarrow missing
+            logger.debug("pyarrow unavailable, skipping Tier-2 sidecars")
+            return
+        for name, decomposer in _decompose.DATASETS:
+            try:
+                records = decomposer(backtest, handle)
+                table = _records_to_table(records)
+                if table is None:
+                    # Always overwrite empties so deletion of all
+                    # snapshots leaves no stale data.
+                    target_dir = self._partition_dir(name, handle)
+                    if target_dir.exists():
+                        shutil.rmtree(target_dir)
+                    continue
+                target_dir = self._partition_dir(name, handle)
+                target_dir.mkdir(parents=True, exist_ok=True)
+                pq.write_table(
+                    table,
+                    target_dir / "part-0.parquet",
+                    compression="zstd",
+                )
+            except Exception as exc:  # pragma: no cover - logged
+                logger.warning(
+                    "Tier-2 sidecar write failed for %s/%s: %s",
+                    name, handle, exc,
+                )
+
+    def open(
+        self,
+        handle: StoreHandle,
+        *,
+        summary_only: bool = False,
+    ) -> Backtest:
+        path = self._bundle_path(handle)
+        if not path.is_file():
+            raise StoreHandleNotFoundError(handle)
+        return Backtest.open(str(path), summary_only=summary_only)
+
+    def exists(self, handle: StoreHandle) -> bool:
+        try:
+            return self._bundle_path(handle).is_file()
+        except StoreError:
+            return False
+
+    def delete(self, handle: StoreHandle) -> None:
+        bare = self._normalize_handle(handle)
+        try:
+            path = self._bundle_path(bare)
+        except StoreError:
+            return
+        if path.is_file():
+            path.unlink()
+        # Tier-2 partitions.
+        for name, _ in _decompose.DATASETS:
+            part = self._partition_dir(name, bare)
+            if part.exists():
+                shutil.rmtree(part, ignore_errors=True)
+        # Tier-1 row.
+        if self._index_path.is_file():
+            index = self._open_index()
+            try:
+                index._conn.execute(
+                    'DELETE FROM "backtest_index" WHERE bundle_path = ?',
+                    (bare,),
+                )
+                index._conn.commit()
+            finally:
+                index.close()
+
+    # ------------------------------------------------------------------
+    # BacktestStore: listing
+    # ------------------------------------------------------------------
+    def iter_handles(self) -> Iterator[StoreHandle]:
+        if not self._bundles_dir.is_dir():
+            return
+        for p in sorted(self._bundles_dir.rglob(f"*{BUNDLE_EXT}")):
+            if p.is_file():
+                yield p.stem  # handle is the bare basename
+
+    def iter_index_rows(self) -> Iterator[BacktestIndexRow]:
+        if not self._index_path.is_file():
+            return
+        index = self._open_index()
+        try:
+            yield from index.iter_rows()
+        finally:
+            index.close()
+
+    def __len__(self) -> int:
+        if not self._index_path.is_file():
+            return sum(1 for _ in self.iter_handles())
+        index = self._open_index()
+        try:
+            return len(index)
+        finally:
+            index.close()
+
+    def __contains__(self, handle: object) -> bool:
+        if not isinstance(handle, str):
+            return False
+        return self.exists(handle)
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom
+    # ------------------------------------------------------------------
+    def copy_from(
+        self,
+        src: BacktestStore,
+        *,
+        handles: Optional[Iterable[StoreHandle]] = None,
+    ) -> int:
+        chosen = list(handles) if handles is not None else list(
+            src.iter_handles()
+        )
+        n = 0
+        for h in chosen:
+            try:
+                bt = src.open(h)
+            except StoreHandleNotFoundError:
+                logger.warning("copy_from: handle %r missing in src", h)
+                continue
+            self.write(bt, handle=h)
+            n += 1
+        return n
+
+    # ------------------------------------------------------------------
+    # Tier-2 cross-run analytics helpers
+    # ------------------------------------------------------------------
+    def scan(self, dataset: str) -> Any:
+        """Return a :class:`pyarrow.dataset.Dataset` over *dataset*.
+
+        ``dataset`` must be one of ``"portfolio_snapshots"``,
+        ``"trades"``, ``"orders"``. The returned object is
+        hive-partitioned on ``run_id`` and can be filtered /
+        materialised with the standard Arrow / DuckDB APIs.
+
+        Example::
+
+            ds = store.scan("trades")
+            df = ds.to_table(filter=ds.field("run_id") == "abc").to_pandas()
+
+        Returns ``None`` if the dataset directory does not exist yet.
+        """
+        known = {name for name, _ in _decompose.DATASETS}
+        if dataset not in known:
+            raise ValueError(
+                f"unknown dataset {dataset!r}; expected one of {sorted(known)}"
+            )
+        root = self._parquet_dir / dataset
+        if not root.is_dir():
+            return None
+        import pyarrow.dataset as ds  # local import: pyarrow optional
+        return ds.dataset(
+            str(root), format="parquet", partitioning="hive",
+        )
+
+    def scan_snapshots(self) -> Any:
+        return self.scan("portfolio_snapshots")
+
+    def scan_trades(self) -> Any:
+        return self.scan("trades")
+
+    def scan_orders(self) -> Any:
+        return self.scan("orders")
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+    def rebuild_index(self) -> int:
+        """Drop the Tier-1 SQLite and rebuild it from the bundles.
+
+        Useful when sidecars were edited out-of-band or after a
+        software upgrade adds new index columns. Returns the number of
+        rows written.
+        """
+        if self._index_path.is_file():
+            self._index_path.unlink()
+        n = 0
+        index = self._open_index()
+        try:
+            for handle in self.iter_handles():
+                bundle = self._bundle_path(handle)
+                stat = bundle.stat()
+                try:
+                    bt = Backtest.open(str(bundle), summary_only=True)
+                except Exception as exc:  # pragma: no cover - logged
+                    logger.warning(
+                        "rebuild_index: skipping %s: %s", handle, exc,
+                    )
+                    continue
+                index.upsert(
+                    bt.index_row(bundle_path=handle),
+                    bundle_mtime_ns=stat.st_mtime_ns,
+                    bundle_size=stat.st_size,
+                )
+                n += 1
+        finally:
+            index.close()
+        return n
+
+    def __repr__(self) -> str:
+        return f"LocalTieredStore(root={str(self.root)!r})"

--- a/investing_algorithm_framework/services/backtest_store/local_tiered_store.py
+++ b/investing_algorithm_framework/services/backtest_store/local_tiered_store.py
@@ -1,5 +1,6 @@
-"""``LocalTieredStore`` — Tier-1 SQLite + Tier-2 Parquet + canonical
-``.iafbt`` bundles on a local filesystem (epic #540 phase 3b).
+"""``LocalTieredStore`` — Tier-1 SQLite + Tier-2 Parquet + Tier-3
+content-addressed OHLCV chunks + canonical ``.iafbt`` bundles on a
+local filesystem (epic #540 phases 3b + 3c).
 
 Layout under *root*::
 
@@ -10,6 +11,8 @@ Layout under *root*::
             portfolio_snapshots/run_id=<handle>/part-0.parquet
             trades/run_id=<handle>/part-0.parquet
             orders/run_id=<handle>/part-0.parquet
+        ohlcv/                     # Tier-3, content-addressed by SHA-256
+            <sha256>.parquet       # shared across every bundle in the store
 
 The bundle file is the canonical representation. The Tier-1 index and
 the Tier-2 Parquet datasets are derived, eagerly maintained, and
@@ -61,6 +64,7 @@ logger = logging.getLogger(__name__)
 INDEX_FILENAME = "index.sqlite"
 BUNDLES_SUBDIR = "bundles"
 PARQUET_SUBDIR = "parquet"
+OHLCV_SUBDIR = "ohlcv"
 
 
 def _records_to_table(records: List[dict]) -> Optional[Any]:
@@ -122,9 +126,12 @@ class LocalTieredStore(BacktestStore):
         self.root.mkdir(parents=True, exist_ok=True)
         self._bundles_dir = self.root / BUNDLES_SUBDIR
         self._parquet_dir = self.root / PARQUET_SUBDIR
+        self._ohlcv_dir = self.root / OHLCV_SUBDIR
         self._index_path = self.root / INDEX_FILENAME
         self._bundles_dir.mkdir(parents=True, exist_ok=True)
         self._parquet_dir.mkdir(parents=True, exist_ok=True)
+        # Tier-3 dir is created lazily on first OHLCV-bearing write so
+        # bundles without attached price data leave no empty subdir.
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -180,8 +187,19 @@ class LocalTieredStore(BacktestStore):
         bundle_path = self._bundle_path(bare)
         bundle_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # 1. Canonical bytes — bundle.
-        backtest.save_bundle(bundle_path)
+        # 1. Canonical bytes — bundle. When the backtest has OHLCV
+        # attached, route the side-store to the shared Tier-3 chunk
+        # directory so identical (symbol, timeframe) Parquet bytes are
+        # written once and referenced by every bundle that needs them.
+        has_ohlcv = bool(getattr(backtest, "ohlcv", None))
+        if has_ohlcv:
+            backtest.save_bundle(
+                bundle_path,
+                include_ohlcv=True,
+                ohlcv_store=self._ohlcv_dir,
+            )
+        else:
+            backtest.save_bundle(bundle_path)
 
         # 2. Tier-1 — SQLite row.
         stat = bundle_path.stat()
@@ -242,7 +260,16 @@ class LocalTieredStore(BacktestStore):
         path = self._bundle_path(handle)
         if not path.is_file():
             raise StoreHandleNotFoundError(handle)
-        return Backtest.open(str(path), summary_only=summary_only)
+        # Route OHLCV resolution through the shared Tier-3 chunk
+        # directory regardless of what path the bundle was written
+        # with. Bundles without OHLCV ignore the override.
+        from investing_algorithm_framework.domain.backtesting.bundle \
+            import open_bundle as _open_bundle
+        return _open_bundle(
+            str(path),
+            ohlcv_store=self._ohlcv_dir,
+            summary_only=summary_only,
+        )
 
     def exists(self, handle: StoreHandle) -> bool:
         try:
@@ -380,6 +407,10 @@ class LocalTieredStore(BacktestStore):
         Useful when sidecars were edited out-of-band or after a
         software upgrade adds new index columns. Returns the number of
         rows written.
+
+        Tier-3 OHLCV chunks are *not* touched \u2014 they are
+        content-addressed and globally shared. Use
+        :meth:`garbage_collect_ohlcv` to reclaim orphans.
         """
         if self._index_path.is_file():
             self._index_path.unlink()
@@ -408,3 +439,118 @@ class LocalTieredStore(BacktestStore):
 
     def __repr__(self) -> str:
         return f"LocalTieredStore(root={str(self.root)!r})"
+
+    # ------------------------------------------------------------------
+    # Tier-3 — content-addressed OHLCV chunks
+    # ------------------------------------------------------------------
+    def _read_ohlcv_manifest(self, handle: StoreHandle) -> dict:
+        """Return the ``{key: <sha>.parquet}`` manifest stored in the
+        bundle envelope, or an empty dict if the bundle has no OHLCV.
+
+        Decodes the envelope directly so we avoid the cost of
+        instantiating a full :class:`Backtest`.
+        """
+        from investing_algorithm_framework.domain.backtesting.bundle \
+            import _decode_payload  # noqa: WPS437 — internal helper
+        path = self._bundle_path(handle)
+        if not path.is_file():
+            raise StoreHandleNotFoundError(handle)
+        try:
+            _, doc = _decode_payload(path.read_bytes())
+        except Exception as exc:
+            logger.warning(
+                "Tier-3 manifest read failed for %s: %s", handle, exc,
+            )
+            return {}
+        meta = doc.get("ohlcv") or {}
+        return dict(meta.get("manifest") or {})
+
+    def iter_ohlcv_hashes(self) -> Iterator[str]:
+        """Yield every OHLCV chunk hash referenced by any bundle.
+
+        Hashes are emitted with possible duplicates (one per
+        ``(handle, key)`` reference); de-duplicate in the caller if
+        needed. Useful as the input for the dedup-upload negotiate
+        step in ``docs/design/ohlcv-dedup-protocol.md``.
+        """
+        for handle in self.iter_handles():
+            for rel in self._read_ohlcv_manifest(handle).values():
+                if rel.endswith(".parquet"):
+                    yield rel[: -len(".parquet")]
+                else:
+                    yield rel
+
+    def ohlcv_referenced_hashes(self) -> set:
+        """Return the de-duplicated set of OHLCV hashes referenced
+        across all bundles in the store.
+        """
+        return set(self.iter_ohlcv_hashes())
+
+    def ohlcv_stored_hashes(self) -> set:
+        """Return the set of OHLCV hashes physically present on disk
+        under ``<root>/ohlcv/``.
+        """
+        if not self._ohlcv_dir.is_dir():
+            return set()
+        out: set = set()
+        for p in self._ohlcv_dir.iterdir():
+            if p.is_file() and p.suffix == ".parquet":
+                out.add(p.stem)
+        return out
+
+    def ohlcv_stats(self) -> dict:
+        """Return a snapshot of the Tier-3 store.
+
+        Keys: ``stored_blobs`` (int), ``stored_bytes`` (int),
+        ``referenced_blobs`` (int), ``orphan_blobs`` (int),
+        ``missing_blobs`` (int — referenced but absent on disk,
+        should be 0 in a healthy store).
+        """
+        stored = self.ohlcv_stored_hashes()
+        referenced = self.ohlcv_referenced_hashes()
+        stored_bytes = 0
+        if self._ohlcv_dir.is_dir():
+            for p in self._ohlcv_dir.iterdir():
+                if p.is_file() and p.suffix == ".parquet":
+                    try:
+                        stored_bytes += p.stat().st_size
+                    except OSError:  # pragma: no cover
+                        pass
+        return {
+            "stored_blobs": len(stored),
+            "stored_bytes": stored_bytes,
+            "referenced_blobs": len(referenced),
+            "orphan_blobs": len(stored - referenced),
+            "missing_blobs": len(referenced - stored),
+        }
+
+    def garbage_collect_ohlcv(
+        self, *, dry_run: bool = False,
+    ) -> List[str]:
+        """Remove OHLCV chunks that no bundle in the store references.
+
+        Args:
+            dry_run: When True, no files are deleted; the list of
+                orphans is returned so callers can audit before
+                committing.
+
+        Returns:
+            The list of hashes that were (or would be) removed.
+        """
+        stored = self.ohlcv_stored_hashes()
+        referenced = self.ohlcv_referenced_hashes()
+        orphans = sorted(stored - referenced)
+        if dry_run:
+            return orphans
+        for digest in orphans:
+            path = self._ohlcv_dir / f"{digest}.parquet"
+            try:
+                path.unlink()
+            except FileNotFoundError:  # pragma: no cover - race
+                pass
+            except OSError as exc:  # pragma: no cover - logged
+                logger.warning(
+                    "garbage_collect_ohlcv: failed to remove %s: %s",
+                    path, exc,
+                )
+        return orphans

--- a/scripts/bench_540_phase2.py
+++ b/scripts/bench_540_phase2.py
@@ -1,0 +1,129 @@
+"""Acceptance benchmark for epic #540 phase 2.
+
+Generates a configurable number of synthetic ``.iafbt`` bundles
+based on the test-suite fixture and measures:
+
+* full index build time (``iaf index``)
+* incremental re-index time (mtime/size skip path)
+* query latency for ``iaf list --sort sharpe_ratio --limit 20``
+
+Run with::
+
+    source .venv/bin/activate
+    python scripts/bench_540_phase2.py            # default: 1,000 bundles
+    python scripts/bench_540_phase2.py --count 12500
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from investing_algorithm_framework.domain import Backtest, BUNDLE_EXT
+from investing_algorithm_framework.domain.backtesting.bundle import (
+    save_bundle,
+)
+from investing_algorithm_framework.cli.index_command import (
+    build_index, list_index,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = (
+    REPO_ROOT
+    / "tests" / "resources" / "backtest_reports_for_testing"
+    / "test_algorithm_backtest"
+)
+
+
+def _seed(out_dir: Path, n: int) -> None:
+    """Write *n* bundles into *out_dir* by re-saving the template."""
+    template = Backtest.open(str(TEMPLATE))
+    base = template.to_dict()
+    digits = max(5, len(str(n)))
+    for i in range(n):
+        bt = Backtest.from_dict(base)
+        bt.algorithm_id = f"algo_{i:0{digits}d}"
+        bt.tag = "bench"
+        if bt.backtest_summary is not None:
+            # Vary sharpe so sorting actually does work.
+            bt.backtest_summary.sharpe_ratio = (i % 100) / 50.0 - 1.0
+        save_bundle(
+            bt, str(out_dir / f"{bt.algorithm_id}{BUNDLE_EXT}"),
+        )
+
+
+def _time(label: str, fn, *a, **kw):
+    t0 = time.perf_counter()
+    result = fn(*a, **kw)
+    dt = time.perf_counter() - t0
+    print(f"  {label:<40s} {dt * 1000:8.1f} ms")
+    return result, dt
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--count", type=int, default=1000)
+    ap.add_argument("--keep", action="store_true")
+    args = ap.parse_args()
+
+    work = Path(tempfile.mkdtemp(prefix="iaf-bench-540-"))
+    print(f"Working directory: {work}")
+    print(f"Seeding {args.count} .iafbt bundles...")
+    t0 = time.perf_counter()
+    _seed(work, args.count)
+    print(f"  seeded in {time.perf_counter() - t0:.2f} s")
+
+    print(f"\nBenchmark — {args.count} bundles")
+    print("=" * 60)
+    out, dt_build = _time(
+        "build_index (cold)",
+        build_index, str(work), show_progress=False,
+    )
+    _, dt_incr = _time(
+        "build_index (incremental, all unchanged)",
+        build_index, str(work), show_progress=False,
+    )
+    _, dt_list = _time(
+        "list_index --sort sharpe_ratio --limit 20",
+        list_index, str(work),
+        sort_by="sharpe_ratio", limit=20,
+    )
+    _, dt_full = _time(
+        "list_index --sort sharpe_ratio (no limit)",
+        list_index, str(work), sort_by="sharpe_ratio",
+    )
+
+    index_path = work / "index.sqlite"
+    size_mb = os.path.getsize(index_path) / (1024 * 1024)
+    bundles_size = sum(
+        p.stat().st_size for p in work.glob(f"*{BUNDLE_EXT}")
+    ) / (1024 * 1024)
+    print("\nFootprint")
+    print("=" * 60)
+    print(f"  bundle directory : {bundles_size:8.2f} MiB")
+    print(f"  index.sqlite     : {size_mb:8.2f} MiB")
+    print(f"  per-bundle index : {size_mb * 1024 / args.count:8.2f} KiB")
+
+    print("\nProjection to 12,500 bundles (linear extrapolation)")
+    print("=" * 60)
+    scale = 12500 / args.count
+    print(f"  build (cold)        : ~{dt_build * scale:.1f} s")
+    print(f"  build (incremental) : ~{dt_incr * scale:.1f} s")
+    print(
+        f"  list top-20         :  {dt_list * 1000:.1f} ms "
+        "(does not scale with bundle count)"
+    )
+
+    if not args.keep:
+        shutil.rmtree(work, ignore_errors=True)
+    else:
+        print(f"\nLeft data in: {work}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/test_index_command.py
+++ b/tests/cli/test_index_command.py
@@ -1,4 +1,5 @@
 """Integration tests for the ``iaf index`` CLI (epic #540 phase 2)."""
+import json
 import os
 import shutil
 import tempfile
@@ -10,8 +11,12 @@ from investing_algorithm_framework.domain import Backtest, BUNDLE_EXT
 from investing_algorithm_framework.domain.backtesting.bundle import (
     save_bundle,
 )
-from investing_algorithm_framework.cli.cli import index_cmd
-from investing_algorithm_framework.cli.index_command import build_index
+from investing_algorithm_framework.cli.cli import (
+    index_cmd, list_cmd, rank_cmd,
+)
+from investing_algorithm_framework.cli.index_command import (
+    build_index, list_index, rank_index, format_table,
+)
 from investing_algorithm_framework.services.backtest_index import (
     SqliteBacktestIndex,
 )
@@ -91,3 +96,189 @@ class TestIndexCommand(TestCase):
         self.assertTrue(os.path.isfile(out))
         with SqliteBacktestIndex.open(out) as idx:
             self.assertEqual(len(idx), 3)
+
+    # ------------------------------------------------------------------
+    # list / rank helpers
+    # ------------------------------------------------------------------
+    def _build_index_with_metrics(self):
+        """Build an index where each bundle has a distinct sharpe."""
+        # Re-save with sharpe ratios 0.5 / 1.5 / 1.0 for ranking tests.
+        sharpes = [0.5, 1.5, 1.0]
+        for i, s in enumerate(sharpes):
+            bt = Backtest.from_dict(self.fixture.to_dict())
+            bt.algorithm_id = f"algo_{i}"
+            bt.tag = "demo"
+            if bt.backtest_summary is not None:
+                bt.backtest_summary.sharpe_ratio = s
+            save_bundle(
+                bt, os.path.join(self.tmp, f"algo_{i}{BUNDLE_EXT}"),
+            )
+        return build_index(self.tmp, show_progress=False)
+
+    def test_list_index_returns_dicts_with_default_columns(self):
+        out = self._build_index_with_metrics()
+        rows = list_index(out)
+        self.assertEqual(len(rows), 3)
+        self.assertIn("algorithm_id", rows[0])
+        self.assertIn("summary_sharpe_ratio", rows[0])
+
+    def test_list_index_sorts_descending_by_metric(self):
+        out = self._build_index_with_metrics()
+        rows = list_index(out, sort_by="sharpe_ratio")
+        sharpes = [r["summary_sharpe_ratio"] for r in rows]
+        self.assertEqual(sharpes, sorted(sharpes, reverse=True))
+
+    def test_list_index_accepts_summary_prefixed_metric(self):
+        out = self._build_index_with_metrics()
+        rows = list_index(out, sort_by="summary_sharpe_ratio", limit=2)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["algorithm_id"], "algo_1")  # 1.5 highest
+
+    def test_list_index_accepts_directory_argument(self):
+        self._build_index_with_metrics()
+        rows = list_index(self.tmp, sort_by="sharpe_ratio", limit=1)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["algorithm_id"], "algo_1")
+
+    def test_list_index_where_filter(self):
+        out = self._build_index_with_metrics()
+        rows = list_index(
+            out,
+            where="summary_sharpe_ratio >= 1.0",
+            sort_by="sharpe_ratio",
+        )
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(
+            [r["algorithm_id"] for r in rows], ["algo_1", "algo_2"],
+        )
+
+    def test_rank_index_returns_top_n(self):
+        out = self._build_index_with_metrics()
+        rows = rank_index(out, by="sharpe_ratio", limit=2)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["algorithm_id"], "algo_1")
+        self.assertEqual(rows[1]["algorithm_id"], "algo_2")
+
+    def test_format_table_renders_header_and_rows(self):
+        out = self._build_index_with_metrics()
+        rows = rank_index(out, by="sharpe_ratio", limit=2)
+        text = format_table(rows)
+        self.assertIn("algorithm_id", text)
+        self.assertIn("algo_1", text)
+        # First data line should be algo_1 (highest sharpe).
+        body = text.splitlines()[2]
+        self.assertTrue(body.startswith("algo_1"))
+
+    def test_cli_list_invocation(self):
+        out = self._build_index_with_metrics()
+        runner = CliRunner()
+        result = runner.invoke(
+            list_cmd, [out, "--sort", "sharpe_ratio", "-n", "2"],
+        )
+        self.assertEqual(
+            result.exit_code, 0,
+            msg=f"stdout={result.output!r} exc={result.exception!r}",
+        )
+        self.assertIn("algo_1", result.output)
+        self.assertIn("algorithm_id", result.output)
+
+    def test_cli_list_json_output(self):
+        out = self._build_index_with_metrics()
+        runner = CliRunner()
+        result = runner.invoke(
+            list_cmd, [out, "--sort", "sharpe_ratio", "--json"],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(len(payload), 3)
+        self.assertEqual(payload[0]["algorithm_id"], "algo_1")
+
+    def test_cli_rank_invocation(self):
+        out = self._build_index_with_metrics()
+        runner = CliRunner()
+        result = runner.invoke(
+            rank_cmd, [out, "--by", "sharpe_ratio", "-n", "1"],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("algo_1", result.output)
+        self.assertNotIn("algo_0", result.output)
+
+    def test_cli_rank_requires_by_flag(self):
+        out = self._build_index_with_metrics()
+        runner = CliRunner()
+        result = runner.invoke(rank_cmd, [out])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--by", result.output)
+
+    def test_list_on_directory_without_index_raises(self):
+        # No index built yet in self.tmp.
+        with self.assertRaises(FileNotFoundError):
+            list_index(self.tmp)
+
+    # ------------------------------------------------------------------
+    # Incremental indexing (epic #540 phase 2)
+    # ------------------------------------------------------------------
+    def test_incremental_index_skips_unchanged_bundles(self):
+        # First build — all bundles ingested.
+        out = build_index(self.tmp, show_progress=False)
+        with SqliteBacktestIndex.open(out) as idx:
+            first_rows = list(idx.iter_rows())
+        self.assertEqual(len(first_rows), 3)
+
+        # Second build over an untouched directory — should skip
+        # every bundle (we observe this via logging counters, but
+        # the row count must stay stable and equal to 3).
+        out2 = build_index(self.tmp, show_progress=False)
+        self.assertEqual(out, out2)
+        with SqliteBacktestIndex.open(out) as idx:
+            second_rows = list(idx.iter_rows())
+        self.assertEqual(len(second_rows), 3)
+
+    def test_incremental_index_reingests_modified_bundle(self):
+        out = build_index(self.tmp, show_progress=False)
+        modified = os.path.join(self.tmp, f"algo_1{BUNDLE_EXT}")
+
+        # Rewrite the bundle with a different algorithm_id + bump
+        # mtime to force reingestion.
+        bt = Backtest.from_dict(self.fixture.to_dict())
+        bt.algorithm_id = "algo_1_modified"
+        bt.tag = "demo"
+        save_bundle(bt, modified)
+        # Ensure mtime actually changes on fast filesystems.
+        future = os.stat(modified).st_mtime + 5
+        os.utime(modified, (future, future))
+
+        build_index(self.tmp, show_progress=False)
+        with SqliteBacktestIndex.open(out) as idx:
+            algos = sorted(r.algorithm_id for r in idx.iter_rows())
+        self.assertEqual(
+            algos, ["algo_0", "algo_1_modified", "algo_2"],
+        )
+
+    def test_full_rebuild_flag_disables_incremental(self):
+        out = build_index(self.tmp, show_progress=False)
+        # Simulate a stale entry by manually modifying the bundle on
+        # disk without bumping mtime, then rebuild without incremental.
+        modified = os.path.join(self.tmp, f"algo_2{BUNDLE_EXT}")
+        original_stat = os.stat(modified)
+        bt = Backtest.from_dict(self.fixture.to_dict())
+        bt.algorithm_id = "algo_2_changed"
+        bt.tag = "demo"
+        save_bundle(bt, modified)
+        # Restore the original mtime so incremental would skip it.
+        os.utime(
+            modified,
+            (original_stat.st_atime, original_stat.st_mtime),
+        )
+
+        # Incremental would (incorrectly) skip; force a rebuild.
+        build_index(self.tmp, show_progress=False, incremental=False)
+        with SqliteBacktestIndex.open(out) as idx:
+            algos = sorted(r.algorithm_id for r in idx.iter_rows())
+        self.assertIn("algo_2_changed", algos)
+
+    def test_scalar_summary_alias_matches_get_backtest_summary(self):
+        self.assertIs(
+            self.fixture.scalar_summary(),
+            self.fixture.get_backtest_summary(),
+        )

--- a/tests/cli/test_migrate_store_command.py
+++ b/tests/cli/test_migrate_store_command.py
@@ -1,0 +1,184 @@
+"""Tests for ``iaf migrate-store`` (epic #540 phase 3d)."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from unittest import TestCase
+
+import pandas as pd
+from click.testing import CliRunner
+
+from investing_algorithm_framework.cli.cli import migrate_store_cmd
+from investing_algorithm_framework.cli.migrate_store_command import (
+    migrate_store,
+)
+from investing_algorithm_framework.domain import Backtest
+from investing_algorithm_framework.services.backtest_store import (
+    LocalDirStore,
+    LocalTieredStore,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+def _make_ohlcv(symbol: str, *, n: int = 4, base: float = 100.0) -> dict:
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    df = pd.DataFrame(
+        {
+            "Datetime": idx,
+            "Open": [base + i for i in range(n)],
+            "High": [base + i + 0.5 for i in range(n)],
+            "Low": [base + i - 0.5 for i in range(n)],
+            "Close": [base + i + 0.25 for i in range(n)],
+            "Volume": [1000 + i for i in range(n)],
+        }
+    )
+    return {f"{symbol}:1h": df}
+
+
+class TestMigrateStore(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.src_dir = tempfile.mkdtemp()
+        self.dst_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.src_dir, ignore_errors=True)
+        shutil.rmtree(self.dst_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Programmatic API
+    # ------------------------------------------------------------------
+    def test_local_dir_to_local_tiered(self):
+        src = LocalDirStore(self.src_dir)
+        src.write(self.fixture, handle="a")
+        src.write(self.fixture, handle="b")
+
+        n = migrate_store(
+            src_kind="local-dir", src_root=self.src_dir,
+            dst_kind="local-tiered", dst_root=self.dst_dir,
+        )
+        self.assertEqual(n, 2)
+
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertEqual(len(dst), 2)
+        self.assertTrue(dst.exists("a"))
+        self.assertTrue(dst.exists("b"))
+        # Tier-1 was populated.
+        self.assertTrue((Path(self.dst_dir) / "index.sqlite").is_file())
+
+    def test_handles_subset(self):
+        src = LocalDirStore(self.src_dir)
+        src.write(self.fixture, handle="a")
+        src.write(self.fixture, handle="b")
+        src.write(self.fixture, handle="c")
+
+        n = migrate_store(
+            src_kind="local-dir", src_root=self.src_dir,
+            dst_kind="local-tiered", dst_root=self.dst_dir,
+            handles=["a", "c"],
+        )
+        self.assertEqual(n, 2)
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertSetEqual(
+            set(dst.iter_handles()), {"a", "c"},
+        )
+
+    def test_ohlcv_dedup_during_migration(self):
+        # Source is a tiered store (preserves OHLCV); destination is
+        # a fresh tiered store. After migration, identical OHLCV must
+        # collapse to a single chunk on the destination too.
+        src = LocalTieredStore(self.src_dir)
+        bt1 = deepcopy(self.fixture)
+        bt1.ohlcv = _make_ohlcv("BTC/EUR")
+        bt2 = deepcopy(self.fixture)
+        bt2.ohlcv = _make_ohlcv("BTC/EUR")
+        src.write(bt1, handle="a")
+        src.write(bt2, handle="b")
+        # Sanity: src already deduped to one chunk.
+        self.assertEqual(src.ohlcv_stats()["stored_blobs"], 1)
+
+        n = migrate_store(
+            src_kind="local-tiered", src_root=self.src_dir,
+            dst_kind="local-tiered", dst_root=self.dst_dir,
+        )
+        self.assertEqual(n, 2)
+
+        # Phase 3c invariant: identical OHLCV stored once even though
+        # two bundles reference it.
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertEqual(dst.ohlcv_stats()["stored_blobs"], 1)
+        self.assertEqual(dst.ohlcv_stats()["referenced_blobs"], 1)
+
+    def test_unknown_kind_raises(self):
+        with self.assertRaises(ValueError):
+            migrate_store(
+                src_kind="local-dir", src_root=self.src_dir,
+                dst_kind="bogus", dst_root=self.dst_dir,
+            )
+
+    # ------------------------------------------------------------------
+    # CLI
+    # ------------------------------------------------------------------
+    def test_cli_round_trip(self):
+        src = LocalDirStore(self.src_dir)
+        src.write(self.fixture, handle="cli_a")
+        src.write(self.fixture, handle="cli_b")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            migrate_store_cmd,
+            [
+                "--from", "local-dir", "--src", self.src_dir,
+                "--to", "local-tiered", "--dst", self.dst_dir,
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Migrated 2 backtest(s)", result.output)
+
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertEqual(len(dst), 2)
+
+    def test_cli_handles_subset(self):
+        src = LocalDirStore(self.src_dir)
+        for h in ("h1", "h2", "h3"):
+            src.write(self.fixture, handle=h)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            migrate_store_cmd,
+            [
+                "--from", "local-dir", "--src", self.src_dir,
+                "--to", "local-tiered", "--dst", self.dst_dir,
+                "--handles", "h1,h3",
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Migrated 2 backtest(s)", result.output)
+        dst = LocalTieredStore(self.dst_dir)
+        self.assertSetEqual(set(dst.iter_handles()), {"h1", "h3"})
+
+    def test_cli_rejects_unknown_kind(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            migrate_store_cmd,
+            [
+                "--from", "bogus", "--src", self.src_dir,
+                "--to", "local-tiered", "--dst", self.dst_dir,
+            ],
+        )
+        # Click choice validation rejects with non-zero exit.
+        self.assertNotEqual(result.exit_code, 0)

--- a/tests/services/backtest_store/test_local_dir_store.py
+++ b/tests/services/backtest_store/test_local_dir_store.py
@@ -1,0 +1,186 @@
+"""Tests for the :class:`BacktestStore` Protocol and :class:`LocalDirStore`
+adapter (epic #540 phase 3a)."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_store import (
+    BacktestStore,
+    LocalDirStore,
+    StoreError,
+    StoreHandleNotFoundError,
+    SupportsCopyFrom,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+class TestLocalDirStore(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = LocalDirStore(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Protocol conformance
+    # ------------------------------------------------------------------
+    def test_implements_protocol(self):
+        self.assertIsInstance(self.store, BacktestStore)
+
+    def test_implements_supports_copy_from(self):
+        self.assertIsInstance(self.store, SupportsCopyFrom)
+
+    # ------------------------------------------------------------------
+    # write / open / exists / delete
+    # ------------------------------------------------------------------
+    def test_write_returns_handle_and_creates_bundle_file(self):
+        handle = self.store.write(self.fixture, handle="run_a")
+        self.assertEqual(handle, "run_a" + BUNDLE_EXT)
+        self.assertTrue((Path(self.tmp) / handle).is_file())
+
+    def test_write_default_handle_uses_algorithm_id_when_set(self):
+        handle = self.store.write(self.fixture)
+        # Fixture has an algorithm_id; the handle must derive from it.
+        self.assertTrue(handle.endswith(BUNDLE_EXT))
+        if self.fixture.algorithm_id:
+            self.assertIn(str(self.fixture.algorithm_id), handle)
+
+    def test_open_round_trip_matches_algorithm_id(self):
+        handle = self.store.write(self.fixture, handle="rt")
+        loaded = self.store.open(handle)
+        self.assertEqual(loaded.algorithm_id, self.fixture.algorithm_id)
+
+    def test_open_summary_only_skips_bulk_decode(self):
+        handle = self.store.write(self.fixture, handle="so")
+        loaded = self.store.open(handle, summary_only=True)
+        self.assertEqual(loaded.algorithm_id, self.fixture.algorithm_id)
+
+    def test_exists_true_after_write_false_after_delete(self):
+        handle = self.store.write(self.fixture, handle="ed")
+        self.assertTrue(self.store.exists(handle))
+        self.assertIn(handle, self.store)
+        self.store.delete(handle)
+        self.assertFalse(self.store.exists(handle))
+        self.assertNotIn(handle, self.store)
+
+    def test_open_missing_handle_raises(self):
+        with self.assertRaises(StoreHandleNotFoundError):
+            self.store.open("nope.iafbt")
+
+    def test_delete_missing_handle_is_noop(self):
+        # Must not raise.
+        self.store.delete("never_existed.iafbt")
+
+    # ------------------------------------------------------------------
+    # iter_handles / __len__ / iter_index_rows
+    # ------------------------------------------------------------------
+    def test_iter_handles_and_len(self):
+        self.assertEqual(len(self.store), 0)
+        self.store.write(self.fixture, handle="a")
+        self.store.write(self.fixture, handle="sub/b")
+        self.assertEqual(len(self.store), 2)
+        handles = sorted(self.store.iter_handles())
+        self.assertIn("a" + BUNDLE_EXT, handles)
+        self.assertIn(os.path.join("sub", "b" + BUNDLE_EXT), handles)
+
+    def test_iter_index_rows_yields_typed_rows_with_relative_paths(self):
+        self.store.write(self.fixture, handle="r1")
+        self.store.write(self.fixture, handle="r2")
+        rows = list(self.store.iter_index_rows())
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertIsInstance(row, BacktestIndexRow)
+            self.assertIsNotNone(row.bundle_path)
+            # bundle_path is relative to root, so it must not be absolute.
+            self.assertFalse(os.path.isabs(row.bundle_path))
+
+    def test_iter_index_rows_creates_sidecar_index(self):
+        self.store.write(self.fixture, handle="cached")
+        list(self.store.iter_index_rows())
+        sidecar = Path(self.tmp) / "index.sqlite"
+        self.assertTrue(sidecar.is_file())
+
+    def test_iter_index_rows_without_index_works(self):
+        nostore = LocalDirStore(self.tmp, use_index=False)
+        nostore.write(self.fixture, handle="nox")
+        rows = list(nostore.iter_index_rows())
+        self.assertEqual(len(rows), 1)
+        self.assertFalse((Path(self.tmp) / "index.sqlite").is_file())
+
+    # ------------------------------------------------------------------
+    # security: handle escape attempts
+    # ------------------------------------------------------------------
+    def test_handle_escape_rejected(self):
+        with self.assertRaises(StoreError):
+            self.store.write(self.fixture, handle="../escape")
+
+    def test_absolute_handle_rejected(self):
+        # Absolute paths get re-anchored by Path() to the abs root and
+        # then escape the store root, so they must be rejected.
+        with self.assertRaises(StoreError):
+            self.store.write(self.fixture, handle="/etc/passwd")
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom
+    # ------------------------------------------------------------------
+    def test_copy_from_other_store(self):
+        src = LocalDirStore(tempfile.mkdtemp())
+        try:
+            src.write(self.fixture, handle="x")
+            src.write(self.fixture, handle="y")
+            n = self.store.copy_from(src)
+            self.assertEqual(n, 2)
+            self.assertEqual(len(self.store), 2)
+            self.assertTrue(self.store.exists("x"))
+            self.assertTrue(self.store.exists("y"))
+        finally:
+            shutil.rmtree(src.root, ignore_errors=True)
+
+    def test_copy_from_with_handle_subset(self):
+        src = LocalDirStore(tempfile.mkdtemp())
+        try:
+            src.write(self.fixture, handle="keep")
+            src.write(self.fixture, handle="skip")
+            n = self.store.copy_from(src, handles=["keep"])
+            self.assertEqual(n, 1)
+            self.assertTrue(self.store.exists("keep"))
+            self.assertFalse(self.store.exists("skip"))
+        finally:
+            shutil.rmtree(src.root, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # ergonomics
+    # ------------------------------------------------------------------
+    def test_handle_normalization_adds_bundle_suffix(self):
+        # Caller may omit the .iafbt suffix and the store adds it.
+        self.store.write(self.fixture, handle="no_suffix")
+        self.assertTrue(self.store.exists("no_suffix"))
+        self.assertTrue(self.store.exists("no_suffix" + BUNDLE_EXT))
+
+    def test_root_is_created_if_missing(self):
+        new_root = os.path.join(self.tmp, "deep", "nested", "store")
+        s = LocalDirStore(new_root)
+        self.assertTrue(Path(new_root).is_dir())
+        self.assertEqual(len(s), 0)

--- a/tests/services/backtest_store/test_local_tiered_store.py
+++ b/tests/services/backtest_store/test_local_tiered_store.py
@@ -1,0 +1,241 @@
+"""Tests for :class:`LocalTieredStore` (epic #540 phase 3b)."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BacktestIndexRow,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_store import (
+    BacktestStore,
+    LocalDirStore,
+    LocalTieredStore,
+    StoreHandleNotFoundError,
+    SupportsCopyFrom,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+class TestLocalTieredStore(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = LocalTieredStore(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Protocol conformance
+    # ------------------------------------------------------------------
+    def test_implements_protocol(self):
+        self.assertIsInstance(self.store, BacktestStore)
+
+    def test_implements_supports_copy_from(self):
+        self.assertIsInstance(self.store, SupportsCopyFrom)
+
+    # ------------------------------------------------------------------
+    # Layout
+    # ------------------------------------------------------------------
+    def test_write_creates_three_tiers(self):
+        handle = self.store.write(self.fixture, handle="r1")
+        root = Path(self.tmp)
+        # Tier-0: canonical bundle.
+        self.assertTrue((root / "bundles" / (handle + BUNDLE_EXT)).is_file())
+        # Tier-1: SQLite index.
+        self.assertTrue((root / "index.sqlite").is_file())
+        # Tier-2: parquet root exists; per-dataset partitions are only
+        # created when there is at least one record to write (the
+        # fixture may have empty snapshots/trades/orders).
+        self.assertTrue((root / "parquet").is_dir())
+
+    def test_handle_normalization_strips_bundle_suffix(self):
+        h1 = self.store.write(self.fixture, handle="with" + BUNDLE_EXT)
+        # Stored bare; iter_handles returns bare names.
+        self.assertNotIn(BUNDLE_EXT, h1)
+        self.assertIn("with", list(self.store.iter_handles()))
+
+    # ------------------------------------------------------------------
+    # Round-trip via canonical bundle
+    # ------------------------------------------------------------------
+    def test_round_trip_preserves_algorithm_id(self):
+        self.store.write(self.fixture, handle="rt")
+        loaded = self.store.open("rt")
+        self.assertEqual(loaded.algorithm_id, self.fixture.algorithm_id)
+
+    def test_summary_only_open(self):
+        self.store.write(self.fixture, handle="so")
+        bt = self.store.open("so", summary_only=True)
+        self.assertEqual(bt.algorithm_id, self.fixture.algorithm_id)
+
+    # ------------------------------------------------------------------
+    # Tier-1: index is always in sync
+    # ------------------------------------------------------------------
+    def test_iter_index_rows_after_write(self):
+        self.store.write(self.fixture, handle="a")
+        self.store.write(self.fixture, handle="b")
+        rows = list(self.store.iter_index_rows())
+        self.assertEqual(len(rows), 2)
+        handles = {row.bundle_path for row in rows}
+        self.assertSetEqual(handles, {"a", "b"})
+        for row in rows:
+            self.assertIsInstance(row, BacktestIndexRow)
+
+    def test_delete_removes_all_tiers(self):
+        self.store.write(self.fixture, handle="gone")
+        self.store.delete("gone")
+        self.assertFalse(self.store.exists("gone"))
+        rows = list(self.store.iter_index_rows())
+        self.assertEqual(len(rows), 0)
+        # Tier-2 partitions for this handle are removed.
+        root = Path(self.tmp)
+        for name in ("portfolio_snapshots", "trades", "orders"):
+            self.assertFalse(
+                (root / "parquet" / name / "run_id=gone").exists()
+            )
+
+    def test_len_uses_index(self):
+        self.assertEqual(len(self.store), 0)
+        self.store.write(self.fixture, handle="x")
+        self.store.write(self.fixture, handle="y")
+        self.assertEqual(len(self.store), 2)
+
+    # ------------------------------------------------------------------
+    # Tier-2: cross-run analytics
+    # ------------------------------------------------------------------
+    def test_scan_returns_arrow_dataset_when_available(self):
+        try:
+            import pyarrow  # noqa: F401
+            import pyarrow.dataset  # noqa: F401
+        except ImportError:
+            self.skipTest("pyarrow not installed")
+        self.store.write(self.fixture, handle="a")
+        self.store.write(self.fixture, handle="b")
+        ds = self.store.scan("portfolio_snapshots")
+        # Fixture may have empty snapshots; dataset may be None if no
+        # sidecar was written. Tolerate both — what we are asserting
+        # is that the scan API works when sidecars are present.
+        if ds is None:
+            return
+        table = ds.to_table()
+        self.assertIn("run_id", table.column_names)
+        # If any rows were written, run_id values are a subset of our
+        # two handles.
+        if table.num_rows:
+            unique = set(table.column("run_id").to_pylist())
+            self.assertTrue(unique.issubset({"a", "b"}))
+
+    def test_scan_unknown_dataset_raises(self):
+        with self.assertRaises(ValueError):
+            self.store.scan("nope")
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom — interop with LocalDirStore
+    # ------------------------------------------------------------------
+    def test_copy_from_local_dir_store(self):
+        src = LocalDirStore(tempfile.mkdtemp())
+        try:
+            src.write(self.fixture, handle="alpha")
+            src.write(self.fixture, handle="beta")
+            n = self.store.copy_from(src)
+            self.assertEqual(n, 2)
+            self.assertEqual(len(self.store), 2)
+            self.assertTrue(self.store.exists("alpha"))
+            self.assertTrue(self.store.exists("beta"))
+        finally:
+            shutil.rmtree(src.root, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Maintenance
+    # ------------------------------------------------------------------
+    def test_rebuild_index_recreates_tier1(self):
+        self.store.write(self.fixture, handle="rebuild_me")
+        # Drop the sqlite file and rebuild from the bundles.
+        (Path(self.tmp) / "index.sqlite").unlink()
+        n = self.store.rebuild_index()
+        self.assertEqual(n, 1)
+        rows = list(self.store.iter_index_rows())
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].bundle_path, "rebuild_me")
+
+    # ------------------------------------------------------------------
+    # Errors
+    # ------------------------------------------------------------------
+    def test_open_missing_handle_raises(self):
+        with self.assertRaises(StoreHandleNotFoundError):
+            self.store.open("nope")
+
+    # ------------------------------------------------------------------
+    # Tier-2 with real rows (synthetic, not the fixture)
+    # ------------------------------------------------------------------
+    def test_tier2_partition_written_when_records_present(self):
+        try:
+            import pyarrow  # noqa: F401
+            import pyarrow.dataset as ds
+        except ImportError:
+            self.skipTest("pyarrow not installed")
+
+        # Patch decomposers to yield deterministic synthetic records.
+        from investing_algorithm_framework.services.backtest_store \
+            import decompose
+
+        original = decompose.DATASETS
+
+        def fake_snaps(_bt, run_id):
+            return [
+                {"ts": 1, "total_value": 100.0, "run_id": run_id},
+                {"ts": 2, "total_value": 110.0, "run_id": run_id},
+            ]
+
+        def fake_trades(_bt, run_id):
+            return [{"trade_id": "t1", "net_gain": 5.0, "run_id": run_id}]
+
+        def fake_orders(_bt, _run_id):
+            return []  # exercise the empty branch too
+
+        decompose.DATASETS = (
+            ("portfolio_snapshots", fake_snaps),
+            ("trades", fake_trades),
+            ("orders", fake_orders),
+        )
+        try:
+            self.store.write(self.fixture, handle="synthetic")
+            root = Path(self.tmp) / "parquet"
+            self.assertTrue(
+                (root / "portfolio_snapshots" / "run_id=synthetic").is_dir()
+            )
+            self.assertTrue(
+                (root / "trades" / "run_id=synthetic").is_dir()
+            )
+            # Empty orders => no partition directory.
+            self.assertFalse(
+                (root / "orders" / "run_id=synthetic").exists()
+            )
+
+            scan = self.store.scan("portfolio_snapshots")
+            self.assertIsNotNone(scan)
+            tbl = scan.to_table()
+            self.assertEqual(tbl.num_rows, 2)
+            self.assertIn("run_id", tbl.column_names)
+            self.assertEqual(
+                set(tbl.column("run_id").to_pylist()), {"synthetic"}
+            )
+        finally:
+            decompose.DATASETS = original

--- a/tests/services/backtest_store/test_local_tiered_store_ohlcv.py
+++ b/tests/services/backtest_store/test_local_tiered_store_ohlcv.py
@@ -1,0 +1,182 @@
+"""Tests for Tier-3 content-addressed OHLCV chunks in
+:class:`LocalTieredStore` (epic #540 phase 3c)."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from unittest import TestCase
+
+import pandas as pd
+
+from investing_algorithm_framework.domain import Backtest, BUNDLE_EXT
+from investing_algorithm_framework.services.backtest_store import (
+    LocalTieredStore,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+def _make_ohlcv(symbol: str, *, n: int = 4, base: float = 100.0) -> dict:
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    df = pd.DataFrame(
+        {
+            "Datetime": idx,
+            "Open": [base + i for i in range(n)],
+            "High": [base + i + 0.5 for i in range(n)],
+            "Low": [base + i - 0.5 for i in range(n)],
+            "Close": [base + i + 0.25 for i in range(n)],
+            "Volume": [1000 + i for i in range(n)],
+        }
+    )
+    return {f"{symbol}:1h": df}
+
+
+class TestLocalTieredStoreOhlcv(TestCase):
+    """OHLCV content-addressed chunk store (Tier-3)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = LocalTieredStore(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _backtest_with_ohlcv(self, symbol: str) -> Backtest:
+        # Deep-copy the fixture and attach a synthetic OHLCV blob.
+        bt = deepcopy(self.fixture)
+        bt.ohlcv = _make_ohlcv(symbol)
+        return bt
+
+    # ------------------------------------------------------------------
+    # Bundles without OHLCV must not create the chunk dir.
+    # ------------------------------------------------------------------
+    def test_no_ohlcv_no_chunk_dir(self):
+        self.store.write(self.fixture, handle="plain")
+        self.assertFalse((Path(self.tmp) / "ohlcv").is_dir())
+        self.assertEqual(self.store.ohlcv_stats()["stored_blobs"], 0)
+
+    # ------------------------------------------------------------------
+    # Tier-3 layout & dedup
+    # ------------------------------------------------------------------
+    def test_ohlcv_chunks_written_to_shared_store(self):
+        bt = self._backtest_with_ohlcv("BTC/EUR")
+        self.store.write(bt, handle="r1")
+        chunks = list((Path(self.tmp) / "ohlcv").iterdir())
+        self.assertEqual(len(chunks), 1)
+        # Filename is <sha256>.parquet — 64 hex chars + .parquet.
+        name = chunks[0].name
+        self.assertTrue(name.endswith(".parquet"))
+        self.assertEqual(len(name) - len(".parquet"), 64)
+
+    def test_identical_ohlcv_is_deduplicated_across_handles(self):
+        bt1 = self._backtest_with_ohlcv("BTC/EUR")
+        # Different algorithm_id but identical OHLCV bytes.
+        bt2 = self._backtest_with_ohlcv("BTC/EUR")
+        self.store.write(bt1, handle="a")
+        self.store.write(bt2, handle="b")
+        chunks = sorted((Path(self.tmp) / "ohlcv").iterdir())
+        self.assertEqual(
+            len(chunks), 1,
+            "identical OHLCV must be stored exactly once",
+        )
+        stats = self.store.ohlcv_stats()
+        self.assertEqual(stats["stored_blobs"], 1)
+        self.assertEqual(stats["referenced_blobs"], 1)
+        self.assertEqual(stats["orphan_blobs"], 0)
+        self.assertEqual(stats["missing_blobs"], 0)
+
+    def test_different_ohlcv_yields_separate_chunks(self):
+        self.store.write(
+            self._backtest_with_ohlcv("BTC/EUR"), handle="btc",
+        )
+        # Different base price -> different bytes -> different hash.
+        bt2 = self._backtest_with_ohlcv("ETH/EUR")
+        bt2.ohlcv = _make_ohlcv("ETH/EUR", base=2000.0)
+        self.store.write(bt2, handle="eth")
+        chunks = sorted((Path(self.tmp) / "ohlcv").iterdir())
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(self.store.ohlcv_stats()["stored_blobs"], 2)
+
+    # ------------------------------------------------------------------
+    # Round-trip via canonical bundle still resolves OHLCV.
+    # ------------------------------------------------------------------
+    def test_open_resolves_ohlcv_from_shared_store(self):
+        bt = self._backtest_with_ohlcv("BTC/EUR")
+        self.store.write(bt, handle="rt")
+        loaded = self.store.open("rt")
+        self.assertIn("BTC/EUR:1h", loaded.ohlcv)
+        df = loaded.ohlcv["BTC/EUR:1h"]
+        self.assertEqual(len(df), 4)
+
+    # ------------------------------------------------------------------
+    # Garbage collection
+    # ------------------------------------------------------------------
+    def test_delete_keeps_shared_ohlcv_until_gc(self):
+        bt1 = self._backtest_with_ohlcv("BTC/EUR")
+        bt2 = self._backtest_with_ohlcv("BTC/EUR")
+        self.store.write(bt1, handle="a")
+        self.store.write(bt2, handle="b")
+        self.store.delete("a")
+        # The chunk is still referenced by handle 'b' -> must stay.
+        self.assertEqual(
+            self.store.ohlcv_stats()["stored_blobs"], 1,
+        )
+        self.assertEqual(self.store.ohlcv_stats()["orphan_blobs"], 0)
+
+    def test_garbage_collect_ohlcv_removes_orphans(self):
+        bt = self._backtest_with_ohlcv("BTC/EUR")
+        self.store.write(bt, handle="solo")
+        # Delete the only referencing bundle.
+        self.store.delete("solo")
+        stats = self.store.ohlcv_stats()
+        self.assertEqual(stats["stored_blobs"], 1)
+        self.assertEqual(stats["orphan_blobs"], 1)
+
+        # Dry-run lists but does not delete.
+        orphans = self.store.garbage_collect_ohlcv(dry_run=True)
+        self.assertEqual(len(orphans), 1)
+        self.assertEqual(self.store.ohlcv_stats()["stored_blobs"], 1)
+
+        removed = self.store.garbage_collect_ohlcv()
+        self.assertEqual(len(removed), 1)
+        self.assertEqual(self.store.ohlcv_stats()["stored_blobs"], 0)
+        self.assertEqual(self.store.ohlcv_stats()["orphan_blobs"], 0)
+
+    # ------------------------------------------------------------------
+    # iter_ohlcv_hashes / ohlcv_referenced_hashes — input for the
+    # dedup-upload negotiate step (docs/design/ohlcv-dedup-protocol.md).
+    # ------------------------------------------------------------------
+    def test_iter_ohlcv_hashes_lists_referenced_chunks(self):
+        self.store.write(
+            self._backtest_with_ohlcv("BTC/EUR"), handle="a",
+        )
+        self.store.write(
+            self._backtest_with_ohlcv("BTC/EUR"), handle="b",
+        )
+        hashes = list(self.store.iter_ohlcv_hashes())
+        # Two references to the same hash (one per bundle).
+        self.assertEqual(len(hashes), 2)
+        self.assertEqual(len(set(hashes)), 1)
+        # Hashes are bare hex digests.
+        for h in hashes:
+            self.assertEqual(len(h), 64)
+            self.assertTrue(all(c in "0123456789abcdef" for c in h))
+
+    def test_referenced_hashes_set_dedups(self):
+        bt = self._backtest_with_ohlcv("BTC/EUR")
+        self.store.write(bt, handle="a")
+        self.store.write(bt, handle="b")
+        self.assertEqual(len(self.store.ohlcv_referenced_hashes()), 1)

--- a/tests/services/backtest_store/test_store_contract.py
+++ b/tests/services/backtest_store/test_store_contract.py
@@ -1,0 +1,178 @@
+"""Parameterised conformance tests that run identical scenarios against
+every concrete :class:`BacktestStore` implementation.
+
+The point is to catch divergence early: any future store
+(``LocalDirStore``, ``LocalTieredStore``, future remote stores) must
+satisfy the exact same behavioural contract here. Any divergence
+shows up as a failing subTest with the store class name in the label.
+
+Phase 3d of epic #540.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from typing import Callable, List
+from unittest import TestCase
+
+from investing_algorithm_framework.domain import (
+    Backtest,
+    BUNDLE_EXT,
+)
+from investing_algorithm_framework.services.backtest_store import (
+    BacktestStore,
+    LocalDirStore,
+    LocalTieredStore,
+    StoreHandleNotFoundError,
+    SupportsCopyFrom,
+)
+
+
+_FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "resources",
+    "backtest_reports_for_testing",
+    "test_algorithm_backtest",
+)
+
+
+# (label, factory) pairs — every store kind exercised by the contract.
+_STORES: List[tuple] = [
+    ("LocalDirStore", lambda root: LocalDirStore(root)),
+    ("LocalTieredStore", lambda root: LocalTieredStore(root)),
+]
+
+
+class BacktestStoreContractTest(TestCase):
+    """Behavioural contract every :class:`BacktestStore` must satisfy."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Backtest.open(_FIXTURE)
+
+    def _each_store(self, body: Callable[[BacktestStore, str], None]):
+        for label, factory in _STORES:
+            with self.subTest(store=label):
+                root = tempfile.mkdtemp()
+                try:
+                    body(factory(root), root)
+                finally:
+                    shutil.rmtree(root, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Protocol conformance
+    # ------------------------------------------------------------------
+    def test_implements_protocol(self):
+        def body(store, _root):
+            self.assertIsInstance(store, BacktestStore)
+            self.assertIsInstance(store, SupportsCopyFrom)
+        self._each_store(body)
+
+    # ------------------------------------------------------------------
+    # write / open / exists / delete
+    # ------------------------------------------------------------------
+    def test_write_then_open_round_trips_algorithm_id(self):
+        def body(store, _root):
+            handle = store.write(self.fixture, handle="rt")
+            loaded = store.open(handle)
+            self.assertEqual(loaded.algorithm_id, self.fixture.algorithm_id)
+        self._each_store(body)
+
+    def test_summary_only_open(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="so")
+            bt = store.open("so", summary_only=True)
+            self.assertEqual(bt.algorithm_id, self.fixture.algorithm_id)
+        self._each_store(body)
+
+    def test_exists_reflects_writes(self):
+        def body(store, _root):
+            self.assertFalse(store.exists("nope"))
+            store.write(self.fixture, handle="x")
+            self.assertTrue(store.exists("x"))
+        self._each_store(body)
+
+    def test_delete_is_idempotent_and_removes_handle(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="gone")
+            store.delete("gone")
+            self.assertFalse(store.exists("gone"))
+            # Second delete is a no-op, not an error.
+            store.delete("gone")
+        self._each_store(body)
+
+    def test_open_missing_handle_raises(self):
+        def body(store, _root):
+            with self.assertRaises(StoreHandleNotFoundError):
+                store.open("nope")
+        self._each_store(body)
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+    def test_iter_handles_returns_written_set(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="a")
+            store.write(self.fixture, handle="b")
+            handles = set(store.iter_handles())
+            # LocalDirStore returns the relative bundle path; both
+            # representations include the bare stem.
+            stems = {
+                h[: -len(BUNDLE_EXT)] if h.endswith(BUNDLE_EXT) else h
+                for h in handles
+            }
+            self.assertSetEqual(stems, {"a", "b"})
+        self._each_store(body)
+
+    def test_len_matches_written_count(self):
+        def body(store, _root):
+            self.assertEqual(len(store), 0)
+            store.write(self.fixture, handle="a")
+            store.write(self.fixture, handle="b")
+            self.assertEqual(len(store), 2)
+        self._each_store(body)
+
+    def test_iter_index_rows_yields_one_per_bundle(self):
+        def body(store, _root):
+            store.write(self.fixture, handle="a")
+            store.write(self.fixture, handle="b")
+            rows = list(store.iter_index_rows())
+            self.assertEqual(len(rows), 2)
+        self._each_store(body)
+
+    # ------------------------------------------------------------------
+    # SupportsCopyFrom — every store can act as a copy destination.
+    # ------------------------------------------------------------------
+    def test_copy_from_local_dir_store(self):
+        def body(store, _root):
+            src_root = tempfile.mkdtemp()
+            try:
+                src = LocalDirStore(src_root)
+                src.write(self.fixture, handle="alpha")
+                src.write(self.fixture, handle="beta")
+                n = store.copy_from(src)
+                self.assertEqual(n, 2)
+                self.assertEqual(len(store), 2)
+            finally:
+                shutil.rmtree(src_root, ignore_errors=True)
+        self._each_store(body)
+
+    def test_copy_from_subset_of_handles(self):
+        def body(store, _root):
+            src_root = tempfile.mkdtemp()
+            try:
+                src = LocalDirStore(src_root)
+                src.write(self.fixture, handle="x")
+                src.write(self.fixture, handle="y")
+                src.write(self.fixture, handle="z")
+                # Pick a subset using whatever handle vocabulary src
+                # exposes for these stems.
+                src_handles = list(src.iter_handles())
+                pick = [h for h in src_handles if "x" in h or "z" in h]
+                n = store.copy_from(src, handles=pick)
+                self.assertEqual(n, 2)
+                self.assertEqual(len(store), 2)
+            finally:
+                shutil.rmtree(src_root, ignore_errors=True)
+        self._each_store(body)


### PR DESCRIPTION
Brings epic #540 phases 3a-3d (plus the docs, demo, and README updates) onto `dev`.

## What happened

PRs #543, #544, #545, #546 and #547 were all marked merged on GitHub but their
commits never reached `dev`. The stack was opened with each PR's base set to
the previous branch in the chain (`#543 -> feature/bundle-format-v2`,
`#544 -> feature/iaf-index-cli`, …). When `#537 -> dev` merged first,
GitHub did not auto-retarget the rest of the stack, so each subsequent
"merge" landed on an intermediate branch that was already a dead end.

Net result: only `#537` and `#541` are actually on `dev`. This PR carries
the rest across in a single squash-friendly delivery.

## What's in this PR

The 9 commits already reviewed and merged via #543–#547:

- `65a50258` feat(index): incremental indexing + scalar_summary alias + benchmark
- `13d8a58f` feat(store): BacktestStore Protocol + LocalDirStore (phase 3a, was #544)
- `f4072bb4` feat(store): LocalTieredStore — Tier-1 SQLite + Tier-2 Parquet (phase 3b, was #545)
- `0950f1b0` feat(store): Tier-3 content-addressed OHLCV chunks (phase 3c, was #546)
- `b6ebab0f` feat(store): iaf migrate-store + dual-store contract suite (phase 3d, was #547)
- `1655a44b` docs(demo): expand storage_layer_demo with full backtest report + HTML dashboard
- `c6cce6a4` docs(readme): add Backtest Storage Layer feature + workflow example
- `f8239916` docs(readme): show vector/event backtest -> report workflow
- `adfeaa0f` docs(site): add Backtest Storage Layer page + report-scaling guidance

No code changes versus what was already approved on the original PRs — this
is purely a re-targeting of the merge.

## Verification

- Targeted suite (`backtest_store + backtest_index + cli`): 128 / 128 passing + 26 subTests
- Full non-scenario suite: 1705 / 1705 passing
- `examples/storage_layer_demo/demo.py` runs end-to-end (sections 1-9, including the HTML dashboard render)

Closes the gap left by the dead-ended stack merges; epic #540 phase 3 is then
fully landed on `dev`.
