### PR TITLE
test(scenarios): optimize vectorized_backtests for CI (#386)

### DIFF
--- a/investing_algorithm_framework/infrastructure/services/backtesting/backtest_service.py
+++ b/investing_algorithm_framework/infrastructure/services/backtesting/backtest_service.py
@@ -1672,9 +1672,61 @@ class BacktestService:
         if len(backtests) == 0:
             return
 
+        # When iterating across multiple date ranges, a bundle for the
+        # same ``algorithm_id`` may already exist on disk from a previous
+        # iteration. ``save_bundle`` keys solely on ``algorithm_id``, so
+        # a naive save would overwrite the prior bundle and lose its
+        # backtest_runs. Merge with the existing bundle so all date
+        # ranges' runs end up in the single per-algorithm bundle.
+        backtests_to_save: List[Backtest] = []
+        for bt in backtests:
+            existing_path = resolve_backtest_path(
+                storage_directory, bt.algorithm_id
+            )
+            if existing_path is None:
+                backtests_to_save.append(bt)
+                continue
+
+            try:
+                existing = Backtest.open(existing_path)
+            except Exception as e:
+                logger.warning(
+                    f"Could not open existing bundle for "
+                    f"{bt.algorithm_id} at {existing_path}: {e}; "
+                    "overwriting."
+                )
+                backtests_to_save.append(bt)
+                continue
+
+            # If the existing bundle already contains a run for one of
+            # the new date ranges (e.g. a forced rerun), drop the
+            # overlapping runs from the existing bundle before merging
+            # so we don't end up with duplicates.
+            new_ranges = {
+                (run.backtest_start_date, run.backtest_end_date)
+                for run in bt.get_all_backtest_runs()
+            }
+            kept_runs = [
+                run for run in existing.get_all_backtest_runs()
+                if (run.backtest_start_date, run.backtest_end_date)
+                not in new_ranges
+            ]
+            existing.backtest_runs = kept_runs
+
+            if kept_runs:
+                merged = combine_backtests([existing, bt])
+                # Preserve the freshly produced backtest's metadata /
+                # parameters by letting the new backtest's values win
+                # on key conflicts (combine_backtests uses dict update
+                # in iteration order — ``bt`` is second so its values
+                # already win).
+                backtests_to_save.append(merged)
+            else:
+                backtests_to_save.append(bt)
+
         # Save backtests to disk
         save_backtests_to_directory(
-            backtests=backtests,
+            backtests=backtests_to_save,
             directory_path=storage_directory,
             show_progress=show_progress
         )

--- a/tests/scenarios/vectorized_backtests/test_metadata_preservation.py
+++ b/tests/scenarios/vectorized_backtests/test_metadata_preservation.py
@@ -205,7 +205,6 @@ class RSIEMACrossoverStrategy(TradingStrategy):
         return signals
 
 
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class Test(TestCase):
 
     def setUp(self):
@@ -228,8 +227,8 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
         date_range_1 = BacktestDateRange(
@@ -311,8 +310,8 @@ class Test(TestCase):
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR",
                        initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
         date_range_1 = BacktestDateRange(

--- a/tests/scenarios/vectorized_backtests/test_run_vector_backtest.py
+++ b/tests/scenarios/vectorized_backtests/test_run_vector_backtest.py
@@ -198,7 +198,6 @@ class RSIEMACrossoverStrategy(TradingStrategy):
             signals[symbol] = sell_signal
         return signals
 
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class Test(TestCase):
 
     def test_run(self):
@@ -244,11 +243,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -342,8 +341,8 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
         date_range_1 = BacktestDateRange(

--- a/tests/scenarios/vectorized_backtests/test_run_vector_backtests.py
+++ b/tests/scenarios/vectorized_backtests/test_run_vector_backtests.py
@@ -200,7 +200,6 @@ class RSIEMACrossoverStrategy(TradingStrategy):
             signals[symbol] = sell_signal
         return signals
 
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class Test(TestCase):
 
     def test_run(self):
@@ -255,11 +254,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -379,11 +378,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )

--- a/tests/scenarios/vectorized_backtests/test_use_backtest_storage_directory.py
+++ b/tests/scenarios/vectorized_backtests/test_use_backtest_storage_directory.py
@@ -200,7 +200,6 @@ class RSIEMACrossoverStrategy(TradingStrategy):
             signals[symbol] = sell_signal
         return signals
 
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class Test(TestCase):
 
     def test_run_with_backtest_storage_directory(self):
@@ -261,11 +260,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -353,7 +352,7 @@ class Test(TestCase):
         param_grid = {
             "rsi_time_frame": ["2h"],
             "rsi_period": [14],
-            "rsi_overbought_threshold": [70, 80],
+            "rsi_overbought_threshold": [70],
             "rsi_oversold_threshold": [30],
             "ema_time_frame": ["2h"],
             "ema_short_period": [100],
@@ -376,11 +375,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -418,7 +417,7 @@ class Test(TestCase):
                 )
             )
 
-        self.assertEqual(len(strategies), 4)
+        self.assertEqual(len(strategies), 2)
 
         # Create backtest storage directory
         backtest_storage_dir = os.path.join(
@@ -441,15 +440,14 @@ class Test(TestCase):
             market="BITVAVO",
             backtest_storage_directory=backtest_storage_dir,
             use_checkpoints=True,
-            show_progress=False,
-            n_workers=4
+            show_progress=False
         )
         end_time = time.time()
         duration = end_time - start_time
 
-        # There should be 4 backtests
+        # There should be 2 backtests
         self.assertEqual(
-            len(backtests), 4, "There should be 4 backtests returned"
+            len(backtests), 2, "There should be 2 backtests returned"
         )
 
         # Each backtest should have atleast 2 backtest runs (one for each date range)
@@ -501,9 +499,9 @@ class Test(TestCase):
         )
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
 
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
-        mid_date = start_date + timedelta(days=180)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
+        mid_date = start_date + timedelta(days=30)
 
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
@@ -525,7 +523,7 @@ class Test(TestCase):
         app1 = create_app(name="FirstRun", config=config)
         app1.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
 
-        # Create first set of strategies (4 strategies)
+        # Create first set of strategies (1 strategy)
         first_param_grid = {
             "rsi_time_frame": ["2h"],
             "rsi_period": [14],
@@ -533,8 +531,8 @@ class Test(TestCase):
             "rsi_oversold_threshold": [30],
             "ema_time_frame": ["2h"],
             "ema_short_period": [100],
-            "ema_long_period": [150, 200],  # 2 variations
-            "ema_cross_lookback_window": [4]  # 2 variations = 4 total
+            "ema_long_period": [150],
+            "ema_cross_lookback_window": [4]
         }
         first_variations = [
             dict(zip(first_param_grid.keys(), values))
@@ -564,7 +562,7 @@ class Test(TestCase):
                 )
             )
 
-        self.assertEqual(len(first_strategies), 2)
+        self.assertEqual(len(first_strategies), 1)
         first_algorithm_ids = set(s.algorithm_id for s in first_strategies)
 
         # Run first batch
@@ -582,16 +580,17 @@ class Test(TestCase):
         )
 
         # Verify first run results
-        self.assertEqual(len(first_backtests), 2)
+        self.assertEqual(len(first_backtests), 1)
         first_result_ids = set(b.algorithm_id for b in first_backtests)
         self.assertEqual(first_result_ids, first_algorithm_ids)
 
-        # Verify backtests were saved to storage
-        saved_dirs_after_first = set(
+        # Verify backtests were saved to storage (one bundle per
+        # algorithm_id in the default ``.iafbt`` bundle format)
+        saved_bundles_after_first = set(
             d for d in os.listdir(backtest_storage_dir)
-            if os.path.isdir(os.path.join(backtest_storage_dir, d))
+            if d.endswith(".iafbt")
         )
-        self.assertEqual(len(saved_dirs_after_first), 2)
+        self.assertEqual(len(saved_bundles_after_first), 1)
 
         # ===== SECOND RUN: Run backtests for DIFFERENT set of strategies =====
         app2 = create_app(name="SecondRun", config=config)
@@ -605,8 +604,8 @@ class Test(TestCase):
             "rsi_oversold_threshold": [20],    # Different from first run
             "ema_time_frame": ["2h"],
             "ema_short_period": [100],
-            "ema_long_period": [150, 200],  # 2 variations
-            "ema_cross_lookback_window": [4]  # 2 variations = 4 total
+            "ema_long_period": [150],
+            "ema_cross_lookback_window": [4]
         }
         second_variations = [
             dict(zip(second_param_grid.keys(), values))
@@ -636,7 +635,7 @@ class Test(TestCase):
                 )
             )
 
-        self.assertEqual(len(second_strategies), 2)
+        self.assertEqual(len(second_strategies), 1)
         second_algorithm_ids = set(s.algorithm_id for s in second_strategies)
 
         # Ensure the two sets of strategies are completely different
@@ -663,8 +662,8 @@ class Test(TestCase):
         # The second run should ONLY return backtests for the second strategies
         # It should NOT include backtests from the first run
         self.assertEqual(
-            len(second_backtests), 2,
-            "Second run should return exactly 2 backtests (one per second strategy)"
+            len(second_backtests), 1,
+            "Second run should return exactly 1 backtest (one per second strategy)"
         )
 
         second_result_ids = set(b.algorithm_id for b in second_backtests)
@@ -681,14 +680,14 @@ class Test(TestCase):
                 "be in second run results"
             )
 
-        # Storage should now contain 8 backtests total (4 from each run)
-        saved_dirs_after_second = set(
+        # Storage should now contain 2 backtests total (1 from each run)
+        saved_bundles_after_second = set(
             d for d in os.listdir(backtest_storage_dir)
-            if os.path.isdir(os.path.join(backtest_storage_dir, d))
+            if d.endswith(".iafbt")
         )
         self.assertEqual(
-            len(saved_dirs_after_second), 4,
-            "Storage should contain 4 backtest directories (2 from each run)"
+            len(saved_bundles_after_second), 2,
+            "Storage should contain 2 backtest bundles (1 from each run)"
         )
 
         # Clean up
@@ -719,9 +718,9 @@ class Test(TestCase):
         )
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
 
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
-        mid_date = start_date + timedelta(days=180)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
+        mid_date = start_date + timedelta(days=30)
 
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
@@ -784,7 +783,7 @@ class Test(TestCase):
 
         first_backtests = app1.run_vector_backtests(
             initial_amount=1000,
-            backtest_date_ranges=[date_range_1, date_range_2],
+            backtest_date_ranges=[date_range_1],
             strategies=first_strategies,
             snapshot_interval=SnapshotInterval.DAILY,
             risk_free_rate=0.027,
@@ -859,7 +858,7 @@ class Test(TestCase):
 
         second_backtests = app2.run_vector_backtests(
             initial_amount=1000,
-            backtest_date_ranges=[date_range_1, date_range_2],
+            backtest_date_ranges=[date_range_1],
             strategies=second_strategies,
             snapshot_interval=SnapshotInterval.DAILY,
             risk_free_rate=0.027,

--- a/tests/scenarios/vectorized_backtests/test_use_checkpoints.py
+++ b/tests/scenarios/vectorized_backtests/test_use_checkpoints.py
@@ -201,7 +201,6 @@ class RSIEMACrossoverStrategy(TradingStrategy):
             signals[symbol] = sell_signal
         return signals
 
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class Test(TestCase):
 
     @staticmethod
@@ -227,7 +226,7 @@ class Test(TestCase):
         param_grid = {
             "rsi_time_frame": ["2h"],
             "rsi_period": [14],
-            "rsi_overbought_threshold": [70, 80],
+            "rsi_overbought_threshold": [70],
             "rsi_oversold_threshold": [30],
             "ema_time_frame": ["2h"],
             "ema_short_period": [100],
@@ -250,11 +249,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -292,7 +291,7 @@ class Test(TestCase):
                 )
             )
 
-        self.assertEqual(len(strategies), 4)
+        self.assertEqual(len(strategies), 2)
         checkpoint_dir = tempfile.mkdtemp()
         try:
             backtests = app.run_vector_backtests(
@@ -308,9 +307,9 @@ class Test(TestCase):
                 show_progress=False
             )
 
-            # There should be 4 backtests returned
+            # There should be 2 backtests returned
             self.assertEqual(
-                len(backtests), 4, "There should be 4 backtests returned"
+                len(backtests), 2, "There should be 2 backtests returned"
             )
 
             # Each backtest should have atleast 2 backtest runs (one for each date range)
@@ -356,11 +355,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -443,7 +442,7 @@ class Test(TestCase):
         param_grid = {
             "rsi_time_frame": ["2h"],
             "rsi_period": [14],
-            "rsi_overbought_threshold": [70, 80],
+            "rsi_overbought_threshold": [70],
             "rsi_oversold_threshold": [30],
             "ema_time_frame": ["2h"],
             "ema_short_period": [100],
@@ -466,11 +465,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -508,7 +507,7 @@ class Test(TestCase):
                 )
             )
 
-        self.assertEqual(len(strategies), 4)
+        self.assertEqual(len(strategies), 2)
         checkpoint_dir = tempfile.mkdtemp()
         try:
             backtests = app.run_vector_backtests(
@@ -521,13 +520,12 @@ class Test(TestCase):
                 market="BITVAVO",
                 backtest_storage_directory=checkpoint_dir,
                 use_checkpoints=True,
-                show_progress=False,
-                n_workers=4
+                show_progress=False
             )
 
-            # There should be 4 backtests returned
+            # There should be 2 backtests returned
             self.assertEqual(
-                len(backtests), 4, "There should be 4 backtests returned"
+                len(backtests), 2, "There should be 2 backtests returned"
             )
 
             # Each backtest should have atleast 2 backtest runs (one for each date range)

--- a/tests/scenarios/vectorized_backtests/test_vector_backtest_fixes.py
+++ b/tests/scenarios/vectorized_backtests/test_vector_backtest_fixes.py
@@ -17,7 +17,7 @@ import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Any
-from unittest import TestCase, skip
+from unittest import TestCase
 
 import pandas as pd
 from pyindicators import ema, rsi, crossover, crossunder
@@ -255,7 +255,6 @@ def _run_backtest(app, strategy, days=730, **kwargs):
 # ===================================================================
 # Issue 3 — number_of_days bug (end_date - start_date, not end - end)
 # ===================================================================
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class TestNumberOfDaysFix(TestCase):
 
     def test_number_of_days_is_nonzero(self):
@@ -280,7 +279,6 @@ class TestNumberOfDaysFix(TestCase):
 # Verifies that more trades are produced from the same signals
 # and that trades open on the signal bar (no 1-bar delay).
 # ===================================================================
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class TestFfillAndShiftRemoval(TestCase):
 
     def test_trades_are_produced(self):
@@ -301,7 +299,7 @@ class TestFfillAndShiftRemoval(TestCase):
         """
         app = _make_app()
         strategy = _make_strategy()
-        run = _run_backtest(app, strategy, days=365)
+        run = _run_backtest(app, strategy, days=730)
         self.assertIsNotNone(run)
 
         # Count closed trades — with the old ffill logic most symbols
@@ -320,7 +318,6 @@ class TestFfillAndShiftRemoval(TestCase):
 # ===================================================================
 # Issue 5 — Buy+sell on same bar: sell takes priority
 # ===================================================================
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class TestBuySellSameBarPriority(TestCase):
 
     def test_sell_priority_over_buy(self):
@@ -358,7 +355,6 @@ class TestBuySellSameBarPriority(TestCase):
 # ===================================================================
 # Issue 6 — Static position sizing capital guard
 # ===================================================================
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class TestStaticPositionSizingCapitalGuard(TestCase):
 
     def test_total_allocation_does_not_exceed_initial_amount(self):
@@ -394,7 +390,6 @@ class TestStaticPositionSizingCapitalGuard(TestCase):
 # ===================================================================
 # Issue 8 — Raw signals exposed on BacktestRun.signals
 # ===================================================================
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class TestRawSignalsExposed(TestCase):
 
     def test_signals_field_present_and_populated(self):
@@ -462,7 +457,6 @@ class TestRawSignalsExposed(TestCase):
             "symbols over 3 years"
         )
 
-    @skip("Known bug: signals dict present in to_dict output")
     def test_signals_not_in_to_dict(self):
         """
         The signals field should appear in to_dict() as serialized
@@ -481,7 +475,6 @@ class TestRawSignalsExposed(TestCase):
 # ===================================================================
 # Signal Events — execution/rejection log for every fired signal
 # ===================================================================
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class TestSignalEvents(TestCase):
 
     def test_signal_events_present(self):

--- a/tests/scenarios/vectorized_backtests/test_with_show_progress.py
+++ b/tests/scenarios/vectorized_backtests/test_with_show_progress.py
@@ -203,7 +203,6 @@ class RSIEMACrossoverStrategy(TradingStrategy):
             signals[symbol] = sell_signal
         return signals
 
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class Test(TestCase):
 
     @staticmethod
@@ -241,7 +240,7 @@ class Test(TestCase):
         param_grid = {
             "rsi_time_frame": ["2h"],
             "rsi_period": [14],
-            "rsi_overbought_threshold": [70, 80],
+            "rsi_overbought_threshold": [70],
             "rsi_oversold_threshold": [30],
             "ema_time_frame": ["2h"],
             "ema_short_period": [100],
@@ -263,11 +262,11 @@ class Test(TestCase):
         config = {RESOURCE_DIRECTORY: resource_directory, DATA_DIRECTORY: "test_data/ohlcv"}
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
-        end_date = datetime(2025, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=365)
+        end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
+        start_date = end_date - timedelta(days=60)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=180)
+        mid_date = start_date + timedelta(days=30)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )

--- a/tests/scenarios/vectorized_backtests/test_with_window_filter_function.py
+++ b/tests/scenarios/vectorized_backtests/test_with_window_filter_function.py
@@ -200,7 +200,6 @@ class RSIEMACrossoverStrategy(TradingStrategy):
             signals[symbol] = sell_signal
         return signals
 
-@unittest.skip("Scenario tests skipped pending optimization — see GitHub issue")
 class Test(TestCase):
 
     @staticmethod
@@ -316,10 +315,10 @@ class Test(TestCase):
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
         end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=730)
+        start_date = end_date - timedelta(days=90)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=365)
+        mid_date = start_date + timedelta(days=60)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -418,10 +417,10 @@ class Test(TestCase):
         param_grid = {
             "rsi_time_frame": ["2h"],
             "rsi_period": [14],
-            "rsi_overbought_threshold": [55, 60],
-            "rsi_oversold_threshold": [40, 50],
+            "rsi_overbought_threshold": [55],
+            "rsi_oversold_threshold": [40],
             "ema_time_frame": ["2h"],
-            "ema_short_period": [12, 20],
+            "ema_short_period": [12],
             "ema_long_period": [26, 50],
             "ema_cross_lookback_window": [6, 10]
         }
@@ -441,10 +440,10 @@ class Test(TestCase):
         app = create_app(name="GoldenCrossStrategy", config=config)
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
         end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=730)
+        start_date = end_date - timedelta(days=90)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=365)
+        mid_date = start_date + timedelta(days=60)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )
@@ -563,10 +562,10 @@ class Test(TestCase):
         app.add_market(market="BITVAVO", trading_symbol="EUR", initial_balance=400)
 
         end_date = datetime(2024, 12, 2, tzinfo=timezone.utc)
-        start_date = end_date - timedelta(days=730)
+        start_date = end_date - timedelta(days=90)
 
         # Split into multiple date ranges to test progressive filtering
-        mid_date = start_date + timedelta(days=365)
+        mid_date = start_date + timedelta(days=60)
         date_range_1 = BacktestDateRange(
             start_date=start_date, end_date=end_date, name="Period 1"
         )


### PR DESCRIPTION
Closes #386.

## Changes

### Framework fix
- Fix bundle-overwrite bug in `BacktestService._batch_save_and_checkpoint`: when `backtest_storage_directory` was set and multiple `backtest_date_ranges` were given, the per-iteration save would overwrite the per-algorithm bundle, leaving only the last range's runs on disk. The save path now opens any existing bundle for the same `algorithm_id`, drops overlapping date-range runs, and merges via `combine_backtests` before writing, so multi-range runs correctly accumulate.
- Un-skip the 5 multi-range / storage-directory tests that this limitation was masking.
- Un-skip `test_signals_not_in_to_dict` — the assertion (`'signals' in d`) matches current framework behavior; the skip was stale.

### CI optimization (#386)
- Remove `@unittest.skip` decorators that gated the entire vectorized backtest scenario suite.
- Shorten `end_date` to `2024-12-02` so tests use only the CSV data committed under `tests/resources/test_data/ohlcv/`.
- Replace `timedelta(days=730/365/180)` with `90/60/30` so each test runs in < 30 s.
- Reduce param-grid size for the slow filter/show-progress tests.
- Bump `test_multiple_buy_sell_cycles` to `days=730` so the strategy has enough bars to close at least one trade.
- Use a single date range for `test_preexisting_backtests_not_included_with_final_filter` to halve its runtime.
- Update assertions in `test_preexisting_backtests_not_included_in_new_run` to count `.iafbt` bundle files (current default) instead of legacy per-backtest directories.
- Drop `n_workers=4` from small multi-strategy tests on macOS — spawn overhead exceeds parallelism benefit for ≤ 2 strategies.

## Results
```
================== 44 passed, 1 warning in 286.86s (0:04:46) ===================
```
All tests pass, no skips, each under 30 s.
