### PR TITLE
feat(context): order convenience functions (#440)

### DIFF
--- a/investing_algorithm_framework/app/context.py
+++ b/investing_algorithm_framework/app/context.py
@@ -673,6 +673,245 @@ class Context:
             market=market,
         )
 
+    def order_value(
+        self,
+        target_symbol,
+        value,
+        order_side,
+        price,
+        market=None,
+        precision=None,
+        metadata=None,
+    ) -> Order:
+        """
+        Place a LIMIT order for a fixed currency amount.
+
+        The order amount is computed as ``value / price``.
+
+        Args:
+            target_symbol: The symbol of the asset to trade.
+            value: Currency amount to spend (BUY) or to sell (SELL).
+            order_side: ``OrderSide.BUY`` or ``OrderSide.SELL``.
+            price: Limit price.
+            market: Optional market identifier.
+            precision: Optional decimal precision to round the
+              computed amount down.
+            metadata: Optional order metadata.
+
+        Returns:
+            Order: The created order.
+        """
+        if value is None or value <= 0:
+            raise OperationalException(
+                "`value` must be a positive number."
+            )
+        if price is None or price <= 0:
+            raise OperationalException(
+                "`price` must be a positive number."
+            )
+        amount = value / price
+        if precision is not None:
+            amount = RoundingService.round_down(amount, precision)
+        return self.create_limit_order(
+            target_symbol=target_symbol,
+            price=price,
+            order_side=order_side,
+            amount=amount,
+            market=market,
+            metadata=metadata,
+        )
+
+    def order_percent(
+        self,
+        target_symbol,
+        percent,
+        order_side,
+        price,
+        market=None,
+        precision=None,
+        metadata=None,
+    ) -> Order:
+        """
+        Place a LIMIT order for ``percent`` of the portfolio's net size.
+
+        Args:
+            target_symbol: The symbol of the asset to trade.
+            percent: Percentage (0-100) of portfolio net size to allocate.
+            order_side: ``OrderSide.BUY`` or ``OrderSide.SELL``.
+            price: Limit price.
+            market: Optional market identifier.
+            precision: Optional decimal precision to round the
+              computed amount down.
+            metadata: Optional order metadata.
+
+        Returns:
+            Order: The created order.
+        """
+        if percent is None or percent <= 0:
+            raise OperationalException(
+                "`percent` must be a positive number."
+            )
+        portfolio = self.portfolio_service.find({"market": market})
+        net_size = portfolio.get_net_size()
+        value = net_size * (percent / 100.0)
+        return self.order_value(
+            target_symbol=target_symbol,
+            value=value,
+            order_side=order_side,
+            price=price,
+            market=market,
+            precision=precision,
+            metadata=metadata,
+        )
+
+    def order_target(
+        self,
+        target_symbol,
+        target_amount,
+        price,
+        market=None,
+        precision=None,
+        metadata=None,
+    ) -> Order:
+        """
+        Adjust the position in ``target_symbol`` to hold exactly
+        ``target_amount`` units.
+
+        The difference between the current position size and
+        ``target_amount`` is submitted as a BUY (positive diff) or
+        SELL (negative diff) LIMIT order. If the position already
+        matches the target, no order is placed.
+
+        Args:
+            target_symbol: The symbol of the asset to adjust.
+            target_amount: Desired position size in units.
+            price: Limit price.
+            market: Optional market identifier.
+            precision: Optional decimal precision to round the diff down.
+            metadata: Optional order metadata.
+
+        Returns:
+            Order: The created order, or ``None`` if no adjustment
+              was required.
+        """
+        if target_amount is None or target_amount < 0:
+            raise OperationalException(
+                "`target_amount` must be a non-negative number."
+            )
+        if price is None or price <= 0:
+            raise OperationalException(
+                "`price` must be a positive number."
+            )
+        portfolio = self.portfolio_service.find({"market": market})
+        try:
+            position = self.position_service.find(
+                {"symbol": target_symbol, "portfolio": portfolio.id}
+            )
+            current_amount = position.get_amount() \
+                if position is not None else 0
+        except OperationalException:
+            current_amount = 0
+        diff = target_amount - current_amount
+        if precision is not None:
+            sign = 1 if diff >= 0 else -1
+            diff = sign * RoundingService.round_down(abs(diff), precision)
+        if diff == 0:
+            return None
+        order_side = OrderSide.BUY if diff > 0 else OrderSide.SELL
+        return self.create_limit_order(
+            target_symbol=target_symbol,
+            price=price,
+            order_side=order_side,
+            amount=abs(diff),
+            market=market,
+            metadata=metadata,
+        )
+
+    def order_target_value(
+        self,
+        target_symbol,
+        target_value,
+        price,
+        market=None,
+        precision=None,
+        metadata=None,
+    ) -> Order:
+        """
+        Adjust the position in ``target_symbol`` so its market value at
+        ``price`` equals ``target_value``.
+
+        Args:
+            target_symbol: The symbol of the asset to adjust.
+            target_value: Desired position market value in trading currency.
+            price: Limit price.
+            market: Optional market identifier.
+            precision: Optional decimal precision to round the diff down.
+            metadata: Optional order metadata.
+
+        Returns:
+            Order: The created order, or ``None`` if no adjustment
+              was required.
+        """
+        if target_value is None or target_value < 0:
+            raise OperationalException(
+                "`target_value` must be a non-negative number."
+            )
+        if price is None or price <= 0:
+            raise OperationalException(
+                "`price` must be a positive number."
+            )
+        target_amount = target_value / price
+        return self.order_target(
+            target_symbol=target_symbol,
+            target_amount=target_amount,
+            price=price,
+            market=market,
+            precision=precision,
+            metadata=metadata,
+        )
+
+    def order_target_percent(
+        self,
+        target_symbol,
+        target_percent,
+        price,
+        market=None,
+        precision=None,
+        metadata=None,
+    ) -> Order:
+        """
+        Adjust the position in ``target_symbol`` so its market value
+        equals ``target_percent`` of the portfolio's net size.
+
+        Args:
+            target_symbol: The symbol of the asset to adjust.
+            target_percent: Desired position size as a percentage (0-100)
+              of portfolio net size.
+            price: Limit price.
+            market: Optional market identifier.
+            precision: Optional decimal precision to round the diff down.
+            metadata: Optional order metadata.
+
+        Returns:
+            Order: The created order, or ``None`` if no adjustment
+              was required.
+        """
+        if target_percent is None or target_percent < 0:
+            raise OperationalException(
+                "`target_percent` must be a non-negative number."
+            )
+        portfolio = self.portfolio_service.find({"market": market})
+        net_size = portfolio.get_net_size()
+        target_value = net_size * (target_percent / 100.0)
+        return self.order_target_value(
+            target_symbol=target_symbol,
+            target_value=target_value,
+            price=price,
+            market=market,
+            precision=precision,
+            metadata=metadata,
+        )
+
     def get_portfolio(self, market=None) -> Portfolio:
         """
         Function to get the portfolio of the algorithm. This function

--- a/tests/app/algorithm/test_order_convenience_functions.py
+++ b/tests/app/algorithm/test_order_convenience_functions.py
@@ -1,0 +1,273 @@
+from unittest.mock import patch
+
+from investing_algorithm_framework import (
+    MarketCredential,
+    OperationalException,
+    OrderSide,
+    OrderStatus,
+    PortfolioConfiguration,
+)
+from tests.resources import TestBase
+from tests.resources.strategies_for_testing import StrategyOne
+
+
+class TestOrderConvenienceFunctions(TestBase):
+    """Tests for ``Context.order_value``, ``order_percent``,
+    ``order_target``, ``order_target_value`` and ``order_target_percent``
+    (issue #440)."""
+
+    portfolio_configurations = [
+        PortfolioConfiguration(
+            market="BITVAVO",
+            trading_symbol="EUR",
+        )
+    ]
+    market_credentials = [
+        MarketCredential(
+            market="BITVAVO",
+            api_key="api_key",
+            secret_key="secret_key",
+        )
+    ]
+    external_balances = {"EUR": 1000}
+
+    # ---------------------------------------------------------------
+    # order_value
+    # ---------------------------------------------------------------
+    def test_order_value_buy(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        order = self.app.context.order_value(
+            target_symbol="BTC",
+            value=200,
+            order_side=OrderSide.BUY,
+            price=10,
+        )
+        self.assertEqual(OrderStatus.OPEN.value, order.status)
+        self.assertEqual(20, order.get_amount())
+        self.assertEqual(10, order.get_price())
+        self.assertEqual("LIMIT", order.get_order_type())
+
+    def test_order_value_rejects_non_positive_value(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        with self.assertRaises(OperationalException):
+            self.app.context.order_value(
+                target_symbol="BTC",
+                value=0,
+                order_side=OrderSide.BUY,
+                price=10,
+            )
+
+    def test_order_value_rejects_non_positive_price(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        with self.assertRaises(OperationalException):
+            self.app.context.order_value(
+                target_symbol="BTC",
+                value=100,
+                order_side=OrderSide.BUY,
+                price=0,
+            )
+
+    # ---------------------------------------------------------------
+    # order_percent
+    # ---------------------------------------------------------------
+    def test_order_percent_buy(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        # 20% of 1000 EUR = 200 EUR / 10 = 20 BTC
+        order = self.app.context.order_percent(
+            target_symbol="BTC",
+            percent=20,
+            order_side=OrderSide.BUY,
+            price=10,
+        )
+        self.assertEqual(20, order.get_amount())
+        self.assertEqual(10, order.get_price())
+        self.assertEqual(OrderStatus.OPEN.value, order.status)
+
+    def test_order_percent_rejects_zero(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        with self.assertRaises(OperationalException):
+            self.app.context.order_percent(
+                target_symbol="BTC",
+                percent=0,
+                order_side=OrderSide.BUY,
+                price=10,
+            )
+
+    # ---------------------------------------------------------------
+    # order_target
+    # ---------------------------------------------------------------
+    @patch(
+        "investing_algorithm_framework.services.data_providers"
+        ".DataProviderService.get_ticker_data"
+    )
+    def test_order_target_buys_from_zero(self, mock_get_ticker):
+        mock_get_ticker.return_value = {
+            "symbol": "BTCEUR",
+            "bid": 10,
+            "ask": 10,
+            "last": 10,
+        }
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        order = self.app.context.order_target(
+            target_symbol="BTC",
+            target_amount=5,
+            price=10,
+        )
+        self.assertEqual(5, order.get_amount())
+        self.assertEqual("BUY", order.get_order_side())
+
+    @patch(
+        "investing_algorithm_framework.services.data_providers"
+        ".DataProviderService.get_ticker_data"
+    )
+    def test_order_target_sells_excess(self, mock_get_ticker):
+        mock_get_ticker.return_value = {
+            "symbol": "BTCEUR",
+            "bid": 10,
+            "ask": 10,
+            "last": 10,
+        }
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        # Build up a position of 10 BTC
+        self.app.context.create_limit_order(
+            target_symbol="BTC",
+            price=10,
+            order_side=OrderSide.BUY,
+            amount=10,
+        )
+        self.app.container.order_service().check_pending_orders()
+        # Now target down to 4 BTC -> SELL 6
+        order = self.app.context.order_target(
+            target_symbol="BTC",
+            target_amount=4,
+            price=10,
+        )
+        self.assertEqual(6, order.get_amount())
+        self.assertEqual("SELL", order.get_order_side())
+
+    @patch(
+        "investing_algorithm_framework.services.data_providers"
+        ".DataProviderService.get_ticker_data"
+    )
+    def test_order_target_no_op_when_already_at_target(
+        self, mock_get_ticker
+    ):
+        mock_get_ticker.return_value = {
+            "symbol": "BTCEUR",
+            "bid": 10,
+            "ask": 10,
+            "last": 10,
+        }
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        self.app.context.create_limit_order(
+            target_symbol="BTC",
+            price=10,
+            order_side=OrderSide.BUY,
+            amount=5,
+        )
+        self.app.container.order_service().check_pending_orders()
+        result = self.app.context.order_target(
+            target_symbol="BTC",
+            target_amount=5,
+            price=10,
+        )
+        self.assertIsNone(result)
+
+    def test_order_target_rejects_negative_target(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        with self.assertRaises(OperationalException):
+            self.app.context.order_target(
+                target_symbol="BTC",
+                target_amount=-1,
+                price=10,
+            )
+
+    # ---------------------------------------------------------------
+    # order_target_value
+    # ---------------------------------------------------------------
+    def test_order_target_value_buys_from_zero(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        # No position -> need 300 / 10 = 30 BTC
+        order = self.app.context.order_target_value(
+            target_symbol="BTC",
+            target_value=300,
+            price=10,
+        )
+        self.assertEqual(30, order.get_amount())
+        self.assertEqual("BUY", order.get_order_side())
+
+    def test_order_target_value_rejects_negative(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        with self.assertRaises(OperationalException):
+            self.app.context.order_target_value(
+                target_symbol="BTC",
+                target_value=-1,
+                price=10,
+            )
+
+    # ---------------------------------------------------------------
+    # order_target_percent
+    # ---------------------------------------------------------------
+    def test_order_target_percent_buys_from_zero(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        # 30% of 1000 EUR = 300 EUR / 10 = 30 BTC
+        order = self.app.context.order_target_percent(
+            target_symbol="BTC",
+            target_percent=30,
+            price=10,
+        )
+        self.assertEqual(30, order.get_amount())
+        self.assertEqual("BUY", order.get_order_side())
+
+    @patch(
+        "investing_algorithm_framework.services.data_providers"
+        ".DataProviderService.get_ticker_data"
+    )
+    def test_order_target_percent_rebalances_down(self, mock_get_ticker):
+        mock_get_ticker.return_value = {
+            "symbol": "BTCEUR",
+            "bid": 10,
+            "ask": 10,
+            "last": 10,
+        }
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        # Take 60% allocation: 600 / 10 = 60 BTC
+        self.app.context.create_limit_order(
+            target_symbol="BTC",
+            price=10,
+            order_side=OrderSide.BUY,
+            amount=60,
+        )
+        self.app.container.order_service().check_pending_orders()
+        # Rebalance to 10% -> target_value = 100 -> target_amount = 10
+        # -> SELL 50
+        order = self.app.context.order_target_percent(
+            target_symbol="BTC",
+            target_percent=10,
+            price=10,
+        )
+        self.assertEqual(50, order.get_amount())
+        self.assertEqual("SELL", order.get_order_side())
+
+    def test_order_target_percent_rejects_negative(self):
+        self.app.add_strategy(StrategyOne)
+        self.app.run(number_of_iterations=1)
+        with self.assertRaises(OperationalException):
+            self.app.context.order_target_percent(
+                target_symbol="BTC",
+                target_percent=-1,
+                price=10,
+            )


### PR DESCRIPTION
Closes #440.

## Summary

Adds five high-level ordering convenience functions on `Context` that simplify portfolio management and rebalancing. The framework previously required users to manually compute order amounts from target values/percentages — these helpers do it.

## New API

| Method | Behavior |
|---|---|
| `order_value(symbol, value, side, price)` | LIMIT order, `amount = value / price` |
| `order_percent(symbol, percent, side, price)` | LIMIT order for `percent` of portfolio net size |
| `order_target(symbol, target_amount, price)` | Rebalance to exactly `target_amount` units (BUY/SELL diff, no-op if equal) |
| `order_target_value(symbol, target_value, price)` | Rebalance so position value at `price` equals `target_value` |
| `order_target_percent(symbol, target_percent, price)` | Rebalance to `target_percent` of portfolio net size |

All helpers produce **LIMIT** orders (require `price`) and validate inputs (positive `value`/`percent`/`price`, non-negative targets). Internally they delegate to `create_limit_order`; the `target_*` family looks up the current position and submits the BUY/SELL difference, or no order when already on target.

## Example

```python
class MyStrategy(TradingStrategy):
    def run_strategy(self, context, data):
        price = data["btc_ticker"]["price"]

        # Rebalance BTC to 10% of portfolio
        context.order_target_percent(
            target_symbol="BTC", target_percent=10.0, price=price
        )

        # Buy 500 EUR worth of ETH
        context.order_value(
            target_symbol="ETH", value=500.0,
            order_side=OrderSide.BUY, price=price
        )

        # End up with exactly 1.5 BTC
        context.order_target(
            target_symbol="BTC", target_amount=1.5, price=price
        )
```

## Tests

14 new tests in `tests/app/algorithm/test_order_convenience_functions.py` covering buy paths, target-down rebalancing, no-op when already on target, and input validation errors.

```
============= 96 passed, 1 skipped, 2 warnings in 67.99s =============  (full tests/app/algorithm/ suite)
======================== 14 passed in 29.53s ========================= (new file only)
```
