### PR TITLE
Add FXMacroData OHLCV provider

### DIFF
--- a/docusaurus/docs/Advanced Concepts/custom-data-providers.md
+++ b/docusaurus/docs/Advanced Concepts/custom-data-providers.md
@@ -47,6 +47,7 @@ The framework ships with these OHLCV data providers:
 | Provider | Market | API Key Required | Supported Assets |
 |----------|--------|-----------------|------------------|
 | `CCXTOHLCVDataProvider` | Any CCXT exchange (e.g. `BINANCE`, `BITVAVO`) | Depends on exchange | Crypto |
+| `FXMacroDataOHLCVDataProvider` | `FXMACRODATA` | Optional | Daily FX reference rates |
 | `YahooOHLCVDataProvider` | `YAHOO` | No | Stocks, ETFs, indices, forex, crypto |
 | `AlphaVantageOHLCVDataProvider` | `ALPHA_VANTAGE` | Yes | Stocks, forex, crypto |
 | `PolygonOHLCVDataProvider` | `POLYGON` | Yes | US stocks, options, forex, crypto |

--- a/docusaurus/docs/Data/market-data-sources.md
+++ b/docusaurus/docs/Data/market-data-sources.md
@@ -105,8 +105,43 @@ The framework ships with built-in data providers for multiple markets. Set the `
 | **Crypto trading** (live) | CCXT exchanges (`BINANCE`, `BITVAVO`, etc.) | Direct exchange connection, supports order execution |
 | **US stocks / ETFs** (research & backtesting) | `YAHOO` | Free, no API key, broad coverage |
 | **US stocks** (production-grade) | `POLYGON` | High reliability, real-time data, official exchange feeds |
+| **Daily FX reference rates** | `FXMACRODATA` | Official-source daily FX spot/reference rates for macro and FX research |
 | **Stocks + forex + crypto** (lightweight) | `ALPHA_VANTAGE` | Simple API, good for prototyping |
 | **Local / offline data** | CSV or Pandas provider | Full control, no network dependency |
+
+---
+
+### FXMacroData — `market="FXMACRODATA"`
+
+**Best for:** Daily FX spot/reference rates in macro and FX research backtests.
+
+FXMacroData serves daily official-source FX reference-rate time series. The
+provider exposes each daily value as close-only OHLCV data: `Open`, `High`,
+`Low`, and `Close` all contain the same daily value, and `Volume` is `0`.
+
+```python
+from investing_algorithm_framework import DataSource, MarketCredential
+
+app.add_market_credential(
+    MarketCredential(market="FXMACRODATA", api_key="your_fxmacrodata_api_key")
+)
+
+DataSource(
+    identifier="eurusd_daily",
+    market="FXMACRODATA",
+    symbol="EURUSD",
+    data_type="OHLCV",
+    time_frame="1d",
+    warmup_window=200,
+)
+```
+
+**Supported timeframes:** `1d`
+
+**Symbol format:** Six-letter FX pairs such as `EURUSD`, `GBPUSD`, or separated
+pairs such as `EUR/USD`.
+
+> API keys can also be configured with `FXMACRODATA_API_KEY` or `FXMD_API_KEY`.
 
 ---
 

--- a/investing_algorithm_framework/__init__.py
+++ b/investing_algorithm_framework/__init__.py
@@ -43,6 +43,7 @@ from .infrastructure import AzureBlobStorageStateHandler, \
     JSONURLDataProvider, ParquetURLDataProvider, \
     CCXTOHLCVDataProvider, CCXTTickerDataProvider, \
     PandasOHLCVDataProvider, OHLCVDataProviderBase, \
+    FXMacroDataOHLCVDataProvider, \
     YahooOHLCVDataProvider, \
     AlphaVantageOHLCVDataProvider, PolygonOHLCVDataProvider, \
     AWSS3StorageStateHandler
@@ -135,6 +136,7 @@ __all__ = [
     'ParquetURLDataProvider',    "CCXTOHLCVDataProvider",
     "CCXTTickerDataProvider",
     "OHLCVDataProviderBase",
+    "FXMacroDataOHLCVDataProvider",
     "YahooOHLCVDataProvider",
     "AlphaVantageOHLCVDataProvider",
     "PolygonOHLCVDataProvider",

--- a/investing_algorithm_framework/infrastructure/__init__.py
+++ b/investing_algorithm_framework/infrastructure/__init__.py
@@ -16,6 +16,7 @@ from .data_providers import CSVOHLCVDataProvider, \
     get_default_ohlcv_data_providers, CCXTOHLCVDataProvider, \
     CCXTTickerDataProvider, PandasOHLCVDataProvider, \
     OHLCVDataProviderBase, \
+    FXMacroDataOHLCVDataProvider, \
     YahooOHLCVDataProvider, AlphaVantageOHLCVDataProvider, \
     PolygonOHLCVDataProvider
 from .order_executors import CCXTOrderExecutor
@@ -59,6 +60,7 @@ __all__ = [
     "CSVURLDataProvider",
     "JSONURLDataProvider",
     "ParquetURLDataProvider",
+    "FXMacroDataOHLCVDataProvider",
     "YahooOHLCVDataProvider",
     "AlphaVantageOHLCVDataProvider",
     "PolygonOHLCVDataProvider",

--- a/investing_algorithm_framework/infrastructure/data_providers/__init__.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/__init__.py
@@ -5,6 +5,7 @@ from .json_url import JSONURLDataProvider
 from .parquet_url import ParquetURLDataProvider
 from .pandas import PandasOHLCVDataProvider
 from .ohlcv_base import OHLCVDataProviderBase
+from .fxmacrodata import FXMacroDataOHLCVDataProvider
 
 
 def _make_optional_provider_placeholder(name, package, extra):
@@ -65,6 +66,7 @@ def get_default_data_providers():
         CSVURLDataProvider(),
         JSONURLDataProvider(),
         ParquetURLDataProvider(),
+        FXMacroDataOHLCVDataProvider(),
     ]
 
     if _yahoo_available:
@@ -88,6 +90,7 @@ def get_default_ohlcv_data_providers():
     """
     providers = [
         CCXTOHLCVDataProvider(),
+        FXMacroDataOHLCVDataProvider(),
     ]
 
     if _yahoo_available:
@@ -114,6 +117,7 @@ __all__ = [
     'get_default_ohlcv_data_providers',
     'OHLCVDataProviderBase',
     'PandasOHLCVDataProvider',
+    'FXMacroDataOHLCVDataProvider',
     'YahooOHLCVDataProvider',
     'AlphaVantageOHLCVDataProvider',
     'PolygonOHLCVDataProvider',

--- a/investing_algorithm_framework/infrastructure/data_providers/fxmacrodata.py
+++ b/investing_algorithm_framework/infrastructure/data_providers/fxmacrodata.py
@@ -1,0 +1,190 @@
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pandas as pd
+import polars as pl
+
+from investing_algorithm_framework.domain import OperationalException
+from .ohlcv_base import OHLCVDataProviderBase
+
+logger = logging.getLogger("investing_algorithm_framework")
+
+FXMACRODATA_API_BASE_URL = "https://fxmacrodata.com/api/v1"
+TIMEFRAME_TO_FXMACRODATA = {
+    "1d": "daily",
+}
+
+
+def _empty_ohlcv_frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        schema={
+            "Datetime": pl.Datetime("us", "UTC"),
+            "Open": pl.Float64,
+            "High": pl.Float64,
+            "Low": pl.Float64,
+            "Close": pl.Float64,
+            "Volume": pl.Float64,
+        }
+    )
+
+
+def _format_date(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.date().isoformat()
+
+
+def _split_fx_pair(symbol: str) -> tuple[str, str]:
+    normalized = "".join(char for char in symbol.upper() if char.isalpha())
+    if len(normalized) != 6:
+        raise OperationalException(
+            "FXMacroData symbols must look like 'EURUSD' or 'EUR/USD'"
+        )
+    return normalized[:3], normalized[3:]
+
+
+def _read_http_error(error: HTTPError) -> str:
+    try:
+        body = error.read().decode("utf-8").strip()
+    except Exception:
+        body = ""
+    message = f"FXMacroData API error {error.code}"
+    if body:
+        message = f"{message}: {body}"
+    return message
+
+
+class FXMacroDataOHLCVDataProvider(OHLCVDataProviderBase):
+    """
+    Daily FX reference-rate provider backed by the FXMacroData REST API.
+
+    FXMacroData returns one daily spot/reference value per currency pair.
+    The provider exposes that value as close-only OHLCV data by setting
+    Open, High, Low, and Close to the same value and Volume to 0.
+
+    Optional API keys can be configured with MarketCredential using
+    market="FXMACRODATA", or with the FXMACRODATA_API_KEY / FXMD_API_KEY
+    environment variables.
+
+    Usage:
+        DataSource(
+            identifier="eurusd_daily",
+            market="FXMACRODATA",
+            symbol="EURUSD",
+            data_type="OHLCV",
+            time_frame="1d",
+        )
+    """
+
+    market_name = "FXMACRODATA"
+    timeframe_map = TIMEFRAME_TO_FXMACRODATA
+    data_provider_identifier = "fxmacrodata_ohlcv_data_provider"
+
+    def __init__(
+        self,
+        *args,
+        base_url: str = FXMACRODATA_API_BASE_URL,
+        timeout: float = 30,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.base_url = base_url
+        self.timeout = timeout
+
+    def _validate_symbol(self, data_source) -> bool:
+        try:
+            _split_fx_pair(data_source.symbol)
+            return True
+        except Exception:
+            return False
+
+    def _download_ohlcv(
+        self,
+        symbol: str,
+        time_frame,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> pl.DataFrame:
+        self._get_provider_interval()
+        base_currency, quote_currency = _split_fx_pair(symbol)
+
+        params = {
+            "start_date": _format_date(start_date),
+            "end_date": _format_date(end_date),
+        }
+        api_key = self._get_optional_api_key()
+        if api_key:
+            params["api_key"] = api_key
+
+        url = (
+            f"{self.base_url.rstrip('/')}/forex/"
+            f"{base_currency.lower()}/{quote_currency.lower()}"
+        )
+        query = urlencode(params)
+        if query:
+            url = f"{url}?{query}"
+
+        request = Request(url, headers={"Accept": "application/json"})
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            raise OperationalException(_read_http_error(error)) from error
+        except Exception as error:
+            logger.error(f"Error downloading FXMacroData data: {error}")
+            return _empty_ohlcv_frame()
+
+        rows = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            raise OperationalException(
+                "FXMacroData response did not include a data list"
+            )
+
+        records = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            value = row.get("val")
+            date_value = row.get("date")
+            if value is None or date_value is None:
+                continue
+            try:
+                dt = datetime.fromisoformat(str(date_value)).replace(
+                    tzinfo=timezone.utc
+                )
+                price = float(value)
+            except (TypeError, ValueError):
+                continue
+            records.append(
+                {
+                    "Datetime": dt,
+                    "Open": price,
+                    "High": price,
+                    "Low": price,
+                    "Close": price,
+                    "Volume": 0.0,
+                }
+            )
+
+        if not records:
+            return _empty_ohlcv_frame()
+
+        df = pd.DataFrame(records)
+        df = df.sort_values("Datetime").reset_index(drop=True)
+        return pl.from_pandas(
+            df[["Datetime", "Open", "High", "Low", "Close", "Volume"]]
+        )
+
+    def _get_optional_api_key(self) -> str:
+        credential = self.get_credential(self.market_name)
+        if credential is not None and credential.api_key:
+            return credential.api_key
+        return os.getenv("FXMACRODATA_API_KEY") or os.getenv("FXMD_API_KEY")
+
+    def _storage_file_suffix(self) -> str:
+        return "fxmacrodata"

--- a/tests/infrastructure/data_providers/test_fxmacrodata_ohlcv_data_provider.py
+++ b/tests/infrastructure/data_providers/test_fxmacrodata_ohlcv_data_provider.py
@@ -1,0 +1,217 @@
+import json
+from datetime import datetime, timezone
+from unittest import TestCase
+from unittest.mock import patch
+
+import pandas as pd
+import polars as pl
+
+from investing_algorithm_framework.domain import DataSource
+from investing_algorithm_framework.infrastructure import (
+    FXMacroDataOHLCVDataProvider,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self.payload.encode("utf-8")
+
+
+class TestFXMacroDataHasData(TestCase):
+    def test_returns_false_for_non_fxmacrodata_market(self):
+        provider = FXMacroDataOHLCVDataProvider()
+        data_source = DataSource(
+            identifier="eurusd_daily",
+            market="YAHOO",
+            symbol="EURUSD",
+            data_type="OHLCV",
+            time_frame="1d",
+        )
+        self.assertFalse(provider.has_data(data_source))
+
+    def test_returns_false_for_non_ohlcv_type(self):
+        provider = FXMacroDataOHLCVDataProvider()
+        data_source = DataSource(
+            identifier="eurusd_ticker",
+            market="FXMACRODATA",
+            symbol="EURUSD",
+            data_type="TICKER",
+            time_frame="1d",
+        )
+        self.assertFalse(provider.has_data(data_source))
+
+    def test_returns_true_for_valid_pair(self):
+        provider = FXMacroDataOHLCVDataProvider()
+        data_source = DataSource(
+            identifier="eurusd_daily",
+            market="FXMACRODATA",
+            symbol="EUR/USD",
+            data_type="OHLCV",
+            time_frame="1d",
+        )
+        self.assertTrue(provider.has_data(data_source))
+
+    def test_returns_false_for_invalid_pair(self):
+        provider = FXMacroDataOHLCVDataProvider()
+        data_source = DataSource(
+            identifier="eur_daily",
+            market="FXMACRODATA",
+            symbol="EUR",
+            data_type="OHLCV",
+            time_frame="1d",
+        )
+        self.assertFalse(provider.has_data(data_source))
+
+    def test_returns_false_for_unsupported_timeframe(self):
+        provider = FXMacroDataOHLCVDataProvider()
+        data_source = DataSource(
+            identifier="eurusd_hourly",
+            market="FXMACRODATA",
+            symbol="EURUSD",
+            data_type="OHLCV",
+            time_frame="1h",
+        )
+        self.assertFalse(provider.has_data(data_source))
+
+
+class TestFXMacroDataGetData(TestCase):
+    @patch(
+        "investing_algorithm_framework.infrastructure"
+        ".data_providers.fxmacrodata.urlopen"
+    )
+    def test_get_data_returns_close_only_polars_dataframe(self, mock_urlopen):
+        payload = {
+            "data": [
+                {"date": "2024-01-03", "val": 1.092},
+                {"date": "2024-01-01", "val": "1.1038"},
+            ]
+        }
+        captured = {}
+
+        def fake_urlopen(request, timeout):
+            captured["url"] = request.full_url
+            captured["accept"] = request.headers["Accept"]
+            captured["timeout"] = timeout
+            return FakeResponse(json.dumps(payload))
+
+        mock_urlopen.side_effect = fake_urlopen
+
+        provider = FXMacroDataOHLCVDataProvider(
+            symbol="EURUSD",
+            market="FXMACRODATA",
+            time_frame="1d",
+            timeout=12,
+        )
+        data = provider.get_data(
+            start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end_date=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        )
+
+        self.assertIsInstance(data, pl.DataFrame)
+        self.assertEqual(
+            data.columns,
+            ["Datetime", "Open", "High", "Low", "Close", "Volume"],
+        )
+        self.assertEqual(data["Close"].to_list(), [1.1038, 1.092])
+        self.assertEqual(data["Open"].to_list(), [1.1038, 1.092])
+        self.assertEqual(data["Volume"].to_list(), [0.0, 0.0])
+        self.assertEqual(
+            captured["url"],
+            "https://fxmacrodata.com/api/v1/forex/eur/usd"
+            "?start_date=2024-01-01&end_date=2024-01-31",
+        )
+        self.assertEqual(captured["accept"], "application/json")
+        self.assertEqual(captured["timeout"], 12)
+
+    @patch.dict("os.environ", {"FXMACRODATA_API_KEY": "test-key"})
+    @patch(
+        "investing_algorithm_framework.infrastructure"
+        ".data_providers.fxmacrodata.urlopen"
+    )
+    def test_includes_environment_api_key(self, mock_urlopen):
+        mock_urlopen.return_value = FakeResponse(
+            json.dumps({"data": [{"date": "2024-01-01", "val": 1.1038}]})
+        )
+        provider = FXMacroDataOHLCVDataProvider(
+            symbol="EUR/USD",
+            market="FXMACRODATA",
+            time_frame="1d",
+        )
+        provider.get_data(
+            start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end_date=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        )
+
+        request = mock_urlopen.call_args[0][0]
+        self.assertIn("api_key=test-key", request.full_url)
+
+    @patch(
+        "investing_algorithm_framework.infrastructure"
+        ".data_providers.fxmacrodata.urlopen"
+    )
+    def test_get_data_returns_pandas_when_configured(self, mock_urlopen):
+        mock_urlopen.return_value = FakeResponse(
+            json.dumps({"data": [{"date": "2024-01-01", "val": 1.1038}]})
+        )
+        provider = FXMacroDataOHLCVDataProvider(
+            symbol="EURUSD",
+            market="FXMACRODATA",
+            time_frame="1d",
+            pandas=True,
+        )
+        data = provider.get_data(
+            start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end_date=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        )
+
+        self.assertIsInstance(data, pd.DataFrame)
+
+
+class TestFXMacroDataCopy(TestCase):
+    def test_copy_creates_new_instance(self):
+        provider = FXMacroDataOHLCVDataProvider()
+        data_source = DataSource(
+            identifier="eurusd_daily",
+            market="FXMACRODATA",
+            symbol="EURUSD",
+            data_type="OHLCV",
+            time_frame="1d",
+        )
+        copied = provider.copy(data_source)
+        self.assertIsInstance(copied, FXMacroDataOHLCVDataProvider)
+        self.assertEqual(copied.symbol, "EURUSD")
+        self.assertEqual(copied.market, "FXMACRODATA")
+        self.assertIsNot(provider, copied)
+
+
+class TestFXMacroDataRegistration(TestCase):
+    def test_in_default_data_providers(self):
+        from investing_algorithm_framework.infrastructure.data_providers \
+            import get_default_data_providers
+
+        providers = get_default_data_providers()
+        matching = [
+            p for p in providers
+            if isinstance(p, FXMacroDataOHLCVDataProvider)
+        ]
+        self.assertEqual(len(matching), 1)
+
+    def test_in_default_ohlcv_data_providers(self):
+        from investing_algorithm_framework.infrastructure.data_providers \
+            import get_default_ohlcv_data_providers
+
+        providers = get_default_ohlcv_data_providers()
+        matching = [
+            p for p in providers
+            if isinstance(p, FXMacroDataOHLCVDataProvider)
+        ]
+        self.assertEqual(len(matching), 1)


### PR DESCRIPTION
## Summary

Adds a native `FXMacroDataOHLCVDataProvider` for daily FX reference-rate series from the FXMacroData REST API.

The provider:

- supports `market="FXMACRODATA"` with daily `1d` data sources
- accepts symbols such as `EURUSD` and `EUR/USD`
- maps FXMacroData close-only daily reference values into the framework OHLCV schema by setting Open/High/Low/Close to the same value and Volume to 0
- supports API keys via `MarketCredential(market="FXMACRODATA", api_key="...")`, `FXMACRODATA_API_KEY`, or `FXMD_API_KEY`
- is registered with the default data-provider lists and documented with the existing market-data-source docs

## Validation

- `python -m pytest tests\infrastructure\data_providers\test_fxmacrodata_ohlcv_data_provider.py -q`
- `python -m compileall -q investing_algorithm_framework\infrastructure\data_providers\fxmacrodata.py`
- `git diff --check`