### PR TITLE
Sortino: downside deviation is measured among the losing days, so consistent losses send the ratio to ~1e14

### DIFF
--- a/investing_algorithm_framework/analysis/backtest_window_analysis.py
+++ b/investing_algorithm_framework/analysis/backtest_window_analysis.py
@@ -151,10 +151,14 @@ def analyze_backtest_windows(
             (mean_return * periods_per_year) / volatility
             if volatility > 0 else 0.0
         )
-        downside = pct[pct < 0]
-        downside_vol = (
-            float(downside.std() * np.sqrt(periods_per_year))
-            if not downside.empty else 0.0
+        # Downside deviation is the root-mean-square shortfall below the
+        # target over EVERY period, matching `volatility` above. Taking the
+        # standard deviation of the losing periods alone measures their spread
+        # around their own mean, so a window whose losses are a similar size
+        # drives this toward zero and sends `sortino` to ~1e14.
+        shortfall = pct.clip(upper=0.0)
+        downside_vol = float(
+            np.sqrt((shortfall ** 2).mean()) * np.sqrt(periods_per_year)
         )
         sortino = (
             (mean_return * periods_per_year) / downside_vol

--- a/investing_algorithm_framework/services/metrics/sortino_ratio.py
+++ b/investing_algorithm_framework/services/metrics/sortino_ratio.py
@@ -14,7 +14,9 @@ symmetrically distributed.
 
 Formula:
 Sortino Ratio = (Mean Daily Return × Periods Per Year - Risk-Free Rate) /
-               (Downside Standard Deviation of Daily Returns × sqrt(Periods Per Year))
+               (Downside Deviation of Daily Returns × sqrt(Periods Per Year))
+
+where Downside Deviation = sqrt(mean(min(r, 0)**2)) over ALL periods.
 
 """
 
@@ -41,7 +43,9 @@ def get_sortino_ratio(
     Where:
         - Annualized Return is the CAGR of the investment
         - Risk-Free Rate is the return of a risk-free asset (e.g. treasury bills)
-        - Downside Standard Deviation is the standard deviation of negative returns
+        - Downside Standard Deviation is the root-mean-square shortfall
+          below the target, averaged over every period (not the standard
+          deviation of the negative returns alone)
 
     Args:
         snapshots (List[PortfolioSnapshot]): List of portfolio snapshots

--- a/investing_algorithm_framework/services/metrics/standard_deviation.py
+++ b/investing_algorithm_framework/services/metrics/standard_deviation.py
@@ -26,14 +26,14 @@ def _twr_period_returns(snapshots) -> pd.Series:
 
 def get_standard_deviation_downside_returns(snapshots):
     """
-    Calculate the standard deviation of downside returns from the net size
-    of the reports.
+    Calculate the downside deviation of returns: the root-mean-square
+    shortfall below the target, averaged over every period.
 
     Args:
         report (BacktestReport): The report containing the equity curve.
 
     Returns:
-        float: The standard deviation of downside returns.
+        float: The downside deviation of returns.
     """
 
     if len(snapshots) < 2:
@@ -44,19 +44,12 @@ def get_standard_deviation_downside_returns(snapshots):
     if df_returns.empty:
         return 0.0
 
-    # Filter downside returns
-    downside_returns = df_returns[df_returns < 0]
+    # Same definition as get_downside_std_of_daily_returns: the root-mean-square
+    # shortfall below the target over EVERY period. See the note there for why the
+    # dispersion among the losing periods is the wrong quantity.
+    shortfall = df_returns.clip(upper=0.0)
+    downside_std = float(np.sqrt((shortfall ** 2).mean()))
 
-    if downside_returns.empty:
-        return 0.0
-
-    if len(downside_returns) < 2:
-        return 0.0
-
-    # Compute standard deviation of downside returns
-    downside_std = downside_returns.std(ddof=1)  # ddof=1 for sample std dev
-
-    # Handle edge cases
     if np.isnan(downside_std):
         return 0.0
 
@@ -72,7 +65,7 @@ def get_standard_deviation_returns(snapshots):
         report (BacktestReport): The report containing the equity curve.
 
     Returns:
-        float: The standard deviation of downside returns.
+        float: The downside deviation of returns.
     """
 
     if len(snapshots) < 2:
@@ -118,27 +111,34 @@ def get_daily_returns_std(snapshots):
 
 def get_downside_std_of_daily_returns(snapshots):
     """
-    Calculate the downside standard deviation of daily returns from a list of snapshots.
+    Calculate the downside deviation of daily returns from a list of snapshots.
     Resamples data to daily frequency using end-of-day values.
+
+    Downside deviation is the root-mean-square shortfall below the target over
+    every period, not the standard deviation of the losing periods alone.
 
     Args:
         snapshots (List[PortfolioSnapshot]): Snapshots with total_value and created_at.
 
     Returns:
-        float: Downside standard deviation of daily returns.
+        float: Downside deviation of daily returns.
     """
     if len(snapshots) < 2:
         return 0.0  # Not enough data
 
     returns = daily_twr_returns(snapshots)
 
-    # Filter only negative returns for downside deviation
-    negative_returns = returns[returns < 0]
-
-    if negative_returns.empty:
+    if returns.empty:
         return 0.0
 
-    if len(negative_returns) < 2:
-        return 0.0
-
-    return negative_returns.std()
+    # Downside deviation is the root-mean-square SHORTFALL below the target,
+    # averaged over EVERY period -- not the dispersion among the losing days.
+    #
+    # Taking negative_returns.std() divides by the number of losing days and
+    # measures spread around the mean loss, so a strategy whose losses are all
+    # a similar size drives the denominator toward zero and the Sortino ratio
+    # toward infinity. Losses of a consistent size are the mark of a
+    # risk-controlled strategy, so the previous form rewarded most exactly what
+    # the ratio exists to penalise.
+    shortfall = returns.clip(upper=0.0)
+    return float(np.sqrt((shortfall ** 2).mean()))

--- a/tests/analysis/test_backtest_window_analysis.py
+++ b/tests/analysis/test_backtest_window_analysis.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import pandas as pd
 
 from investing_algorithm_framework.analysis.backtest_window_analysis import (
+    analyze_backtest_windows,
     plot_backtest_windows,
     plot_window_correlation_matrix,
 )
@@ -93,3 +94,42 @@ class TestPlotBacktestWindows(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestAnalyzeBacktestWindowsDownside(unittest.TestCase):
+    """`analyze_backtest_windows` publishes downside_volatility and sortino_ratio."""
+
+    def _window(self):
+        import random
+
+        random.seed(42)
+        values = [1000.0]
+        for _ in range(199):
+            change = 0.002 if random.random() > 0.3 else -0.003
+            values.append(values[-1] * (1 + change))
+        index = pd.date_range("2024-01-01", periods=200, freq="D", tz="UTC")
+        price_df = pd.DataFrame({"Close": values}, index=index)
+        date_range = BacktestDateRange(
+            datetime(2024, 1, 1, tzinfo=timezone.utc),
+            datetime(2024, 7, 17, tzinfo=timezone.utc),
+        )
+        result = analyze_backtest_windows(
+            {"window": (date_range, price_df)}, price_column="Close"
+        )
+        rows = result[1] if isinstance(result, tuple) else result
+        return rows[0]
+
+    def test_uniform_losses_do_not_collapse_downside_volatility(self):
+        """Every losing day here is -0.3%, so their spread is ~0 but their risk is not.
+
+        Measuring the dispersion among the losing periods instead of the
+        shortfall over all of them drove downside_volatility to ~7e-14 and
+        sortino_ratio past 1e14.
+        """
+        row = self._window()
+        self.assertGreater(row["downside_volatility"], 0.01)
+        self.assertLess(abs(row["sortino_ratio"]), 1000)
+
+    def test_sharpe_is_unaffected_by_the_downside_definition(self):
+        """Total volatility is a different quantity and must not move."""
+        row = self._window()
+        self.assertAlmostEqual(row["sharpe_ratio"], 1.8521697, places=5)

--- a/tests/app/reporting/metrics/test_sortino_ratio.py
+++ b/tests/app/reporting/metrics/test_sortino_ratio.py
@@ -60,7 +60,10 @@ class TestGetSortinoRatio(unittest.TestCase):
         report.get_snapshots.return_value = snapshots
 
         ratio = get_sortino_ratio(report.get_snapshots(), risk_free_rate=0.027)
-        self.assertEqual(ratio, 0.0)
+        # The portfolio ends at 99 after -10% then +10%, so the ratio is
+        # negative. It read 0.0 because the downside deviation collapsed
+        # when a single losing period had no dispersion to measure.
+        self.assertAlmostEqual(ratio, -1.3743062, places=5)
 
     # def test_constant_returns(self):
     #     now = datetime.now()

--- a/tests/app/reporting/metrics/test_standard_deviations.py
+++ b/tests/app/reporting/metrics/test_standard_deviations.py
@@ -46,9 +46,10 @@ class TestStandardDeviationDownside(unittest.TestCase):
         ]
         report = MagicMock()
         report.get_snapshots.return_value = snapshots
-        # Returns: -10%, -10%
-        expected_std = np.std([-0.1, -0.1], ddof=1)
-        self.assertAlmostEqual(get_standard_deviation_downside_returns(report.get_snapshots()), expected_std, places=6)
+        # Returns: -10%, -10%. Both periods are 10% shortfalls, so the
+        # downside deviation is 0.1, not the ~0 dispersion between them.
+        self.assertAlmostEqual(
+            get_standard_deviation_downside_returns(report.get_snapshots()), 0.1, places=6)
 
     def test_mixed_returns(self):
         now = datetime.now()
@@ -59,8 +60,9 @@ class TestStandardDeviationDownside(unittest.TestCase):
         ]
         report = MagicMock()
         report.get_snapshots.return_value = snapshots
-        # Downside returns: [-0.1] — only 1 element, std(ddof=1) is undefined
-        self.assertEqual(get_standard_deviation_downside_returns(report.get_snapshots()), 0.0)
+        # Shortfalls over the two periods: -0.1 and 0 -> sqrt(0.01 / 2) = 0.0707107
+        self.assertAlmostEqual(
+            get_standard_deviation_downside_returns(report.get_snapshots()), 0.0707107, places=6)
 
     def test_nan_handling(self):
         now = datetime.now()

--- a/tests/services/metrics/test_sortino_ratio.py
+++ b/tests/services/metrics/test_sortino_ratio.py
@@ -52,6 +52,49 @@ class TestGetSortinoRatio(unittest.TestCase):
     # Basic Functionality Tests
     # ==========================================================
 
+    def test_sortino_ratio_finite_when_losses_are_uniform(self):
+        """Consistent losses must not send the ratio to infinity.
+
+        Downside deviation is the shortfall below the target, so a strategy that
+        loses the same amount on every losing day has a well-defined, non-zero
+        downside risk. Measuring the DISPERSION among those losses instead makes
+        the denominator collapse to floating-point noise and the ratio explode.
+        """
+        import random
+        random.seed(42)
+        values = [1000]
+        for _ in range(199):
+            change = 0.002 if random.random() > 0.3 else -0.003
+            values.append(values[-1] * (1 + change))
+
+        result = get_sortino_ratio(self._create_snapshots(values), risk_free_rate=0.03)
+
+        # The module docstring grades > 3 as "Excellent - rare"; anything past
+        # that scale is a broken denominator, not a good strategy.
+        self.assertLess(abs(result), 1000)
+
+    def test_downside_deviation_of_uniform_losses_is_the_loss_size(self):
+        """Three 10% losses have a downside deviation of 10%, not of zero."""
+        from investing_algorithm_framework.services.metrics.standard_deviation import (
+            get_downside_std_of_daily_returns,
+        )
+        snapshots = self._create_snapshots([100, 90, 81, 72.9])
+        self.assertAlmostEqual(
+            get_downside_std_of_daily_returns(snapshots), 0.1, places=6
+        )
+
+    def test_bigger_losses_mean_more_downside_risk(self):
+        """Bigger losses must produce a bigger downside deviation."""
+        from investing_algorithm_framework.services.metrics.standard_deviation import (
+            get_downside_std_of_daily_returns,
+        )
+        small = self._create_snapshots([100, 99, 98.01, 97.0299])     # -1% each
+        large = self._create_snapshots([100, 95, 90.25, 85.7375])     # -5% each
+        self.assertGreater(
+            get_downside_std_of_daily_returns(large),
+            get_downside_std_of_daily_returns(small),
+        )
+
     def test_sortino_ratio_positive(self):
         """Test Sortino ratio with positive returns and some downside."""
         import random

--- a/tests/services/metrics/test_standard_deviations.py
+++ b/tests/services/metrics/test_standard_deviations.py
@@ -67,8 +67,9 @@ class TestGetStandardDeviationDownsideReturns(unittest.TestCase):
         """Test with two snapshots and negative return."""
         snapshots = self._create_snapshots([100, 90])
         result = get_standard_deviation_downside_returns(snapshots)
-        # Only one negative return, std of single value is NaN -> returns 0.0
-        self.assertEqual(result, 0.0)
+        # One period, a 10% shortfall: sqrt(0.1**2 / 1) = 0.1. A single losing
+        # period has downside risk; only its DISPERSION is undefined.
+        self.assertAlmostEqual(result, 0.1, places=6)
 
     # ==========================================================
     # Basic Functionality
@@ -85,18 +86,18 @@ class TestGetStandardDeviationDownsideReturns(unittest.TestCase):
         """Test with all negative returns."""
         snapshots = self._create_snapshots([100, 90, 81, 72.9])
         result = get_standard_deviation_downside_returns(snapshots)
-        # Returns: -10%, -10%, -10%
-        expected_std = np.std([-0.1, -0.1, -0.1], ddof=1)
-        self.assertAlmostEqual(result, expected_std, places=6)
+        # Returns: -10%, -10%, -10%. Every period is a 10% shortfall, so the
+        # downside deviation is 0.1 -- not the ~0 dispersion among them.
+        self.assertAlmostEqual(result, 0.1, places=6)
 
     def test_mixed_returns(self):
         """Test with mixed positive and negative returns."""
         # 100 -> 90 (-10%), 90 -> 99 (+10%), 99 -> 89.1 (-10%)
         snapshots = self._create_snapshots([100, 90, 99, 89.1])
         result = get_standard_deviation_downside_returns(snapshots)
-        # Downside returns: -0.1, -0.1
-        expected_std = np.std([-0.1, -0.1], ddof=1)
-        self.assertAlmostEqual(result, expected_std, places=4)
+        # Shortfalls over the three periods: -0.1, 0, -0.1
+        # sqrt((0.01 + 0 + 0.01) / 3) = 0.0816497
+        self.assertAlmostEqual(result, 0.0816497, places=6)
 
     def test_constant_values(self):
         """Test with constant portfolio values (zero returns)."""
@@ -396,8 +397,8 @@ class TestGetDownsideStdOfDailyReturns(unittest.TestCase):
         """Test with two snapshots and negative return."""
         snapshots = self._create_daily_snapshots([100, 90])
         result = get_downside_std_of_daily_returns(snapshots)
-        # Single negative return, std is NaN (can't compute std of 1 value)
-        self.assertTrue(math.isnan(result) or result == 0.0)
+        # One period, a 10% shortfall: sqrt(0.1**2 / 1) = 0.1
+        self.assertAlmostEqual(result, 0.1, places=6)
 
     # ==========================================================
     # Basic Functionality
@@ -414,8 +415,21 @@ class TestGetDownsideStdOfDailyReturns(unittest.TestCase):
         # Returns: -10%, -10%, -10%
         snapshots = self._create_daily_snapshots([100, 90, 81, 72.9])
         result = get_downside_std_of_daily_returns(snapshots)
-        # All returns are -10%, std should be 0
-        self.assertAlmostEqual(result, 0.0, places=5)
+        # All three periods are 10% shortfalls, so the downside deviation is
+        # 0.1. Zero here would say a strategy losing 10% every day carries no
+        # downside risk, which is the defect this change removes.
+        self.assertAlmostEqual(result, 0.1, places=6)
+
+    def test_mixed_returns_average_over_every_period(self):
+        """A winning day still counts in the denominator.
+
+        Returns: +10%, -10%. The shortfall vector is [0, -0.1], so the downside
+        deviation is sqrt((0 + 0.01) / 2) = 0.0707107 -- averaged over every
+        period, not over the losing ones only.
+        """
+        snapshots = self._create_daily_snapshots([100, 110, 99])
+        result = get_downside_std_of_daily_returns(snapshots)
+        self.assertAlmostEqual(result, 0.0707107, places=6)
 
     def test_varied_negative_returns(self):
         """Test with varied negative returns."""


### PR DESCRIPTION
# Sortino: downside deviation is measured among the losing days, so consistent losses send the ratio to ~1e14

## What happens

`get_downside_std_of_daily_returns` returns `negative_returns.std()` — the dispersion **among** the
losing days. A strategy whose losses are a consistent size therefore has a denominator near zero.
Running the two scenarios your own `test_sortino_only_considers_downside` builds:

```
  moderate upside   Sortino =        75,928,481,746,694.97   Sharpe =   1.25
  larger upside    Sortino =       671,041,653,572,539.38   Sharpe =  10.46

  downside deviation used as the denominator: np.float64(3.92931225215817e-17)
```

Every losing day in that fixture is exactly `-0.003`, so the spread among them is floating-point
noise. The `if std_downside_daily_return == 0: return 0.0` guard does not catch it, because
`3.9e-17` is not `0`. The suite passes because the test asserts only an ordering.

## On the definition — your docstring says the other thing, and I think it is the bug

`sortino_ratio.py:44` currently reads *"Downside Standard Deviation is the standard deviation of
negative returns"*, so I am proposing to change a documented definition, not just an implementation.
Worth saying plainly rather than leaving you to find it.

Two of your tests comment on this behaviour, and they read differently:

| test | comment | reads as |
|---|---|---|
| `test_sortino_ratio_no_downside` | *"Zero downside deviation → **should** return 0.0"* | normative — a decision |
| `test_two_snapshots_negative` | *"std is NaN (**can't compute** std of 1 value)"* | descriptive of a numerical artifact |

I have left the first alone: a strategy with no losing days still returns `0.0` after this change,
and that test is untouched. The second accepts `NaN` as a passing outcome, which reads as a
consequence of the formula rather than a choice about it — that is the one this PR changes.

The published reference, `empyrical.downside_risk`, clips returns at the target, squares, and takes
the mean over **all** periods including the zeros; its docstring points to Sortino's own article for
*"why using the standard deviation of the negative returns is not correct"*.

The practical consequence is an inversion: losses of a consistent size are the signature of a
risk-controlled strategy, and the current form rewards exactly what the ratio exists to penalise.
Three consecutive 10% losses currently report a downside deviation of ~0; they should report 0.1.

## The change

```python
shortfall = returns.clip(upper=0.0)
return float(np.sqrt((shortfall ** 2).mean()))
```

Applied at the three sites that compute downside deviation:

- `get_downside_std_of_daily_returns` — feeds `get_sortino_ratio`
- `get_standard_deviation_downside_returns` — exported from the package root
- `analyze_backtest_windows` — publishes `downside_volatility` and `sortino_ratio` for price
  returns, and had no test of either. On the same fixture shape it reported
  `downside_volatility = 7.5e-14` and `sortino_ratio = 1.1e14`; it now reports `3.41` and `2.49`,
  with `sharpe_ratio` unchanged.

`get_daily_returns_std` (which feeds Sharpe), `get_standard_deviation_returns` and `volatility` are
total dispersion — a different quantity — and are untouched.

After the change the two scenarios above read **1.68** and **22.51**, and the ordering your test
asserts still holds.

## Risk — please read this part

**Every backtest with at least one losing period changes**, not only those with similarly-sized
losses: the denominator moves from a sample standard deviation over the losers to a
root-mean-square over all periods, and those coincide almost nowhere.

**The direction is not uniform.** Where losses are frequent and similar the old value was inflated,
sometimes by orders of magnitude. Where losses are few and dispersed it was *understated*: 400
periods with two losses of −2% and −35% move from **+0.32 to +4.32**, a 13.3× increase.

So Sortino values in reports generated before and after this change are not comparable, silently.
If that matters for your stored reports, I am happy to put it behind a flag or a version bump
instead — which would you prefer?

Sharpe, drawdown, volatility and every other metric are unchanged. No public signature changes.

## Tests

Eight existing tests asserted the old outputs; each is updated with its derivation:

| case | was | now |
|---|---|---|
| three −10% returns | ~0 (dispersion) | **0.1** — every period is a 10% shortfall |
| −10%, +10%, −10% | ~0 | **0.0816** = √((0.01+0+0.01)/3) |
| one losing period | `0.0` (std of one value undefined) | **0.1** — one loss has risk; only its dispersion is undefined |
| Sortino for −10% then +10% | `0.0` | **−1.374** — the portfolio ends at 99, so the ratio is negative |

Six are added: a uniform-loss strategy stays on the documented scale; three −10% returns give 0.1; a
mixed-sign window gives √(0.01/2) = 0.0707107, which pins the denominator to every period rather
than to the losing ones; larger losses produce more downside risk than smaller; and two for
`analyze_backtest_windows`, which had no downside coverage.

## Verification

`pytest tests --ignore=tests/resources` on the branch: **2470 passed, 9 skipped, zero failures**
(Python 3.11; `jinja2`, `httpx` and `pyindicators` needed for collection). Each mutant restored one
at a time at its real site: the original expression is caught by 6 tests, the sibling's by 5, the
window-analysis one by 1, and three near-miss variants — shortfall divided by losing periods,
mean-absolute shortfall, RMS over the losing subset — by the mixed-sign test alone.

## Context

I noticed this while reading the metrics for a strategy of my own. #523 ("Rust phase 2: metric
kernel parity") names `services/metrics/` as the source of truth for the port — if that is still the
plan, this is probably worth settling before the expression is mirrored.
