### PR TITLE
docs: get_max_drawdown returns a positive fraction, not a negative percent

### DIFF
--- a/investing_algorithm_framework/services/metrics/drawdown.py
+++ b/investing_algorithm_framework/services/metrics/drawdown.py
@@ -56,18 +56,20 @@ def get_drawdown_series(snapshots: List[PortfolioSnapshot]) -> List[Tuple[float,
 
 def get_max_drawdown(snapshots: List[PortfolioSnapshot]) -> float:
     """
-    Calculate the maximum drawdown of the portfolio as a percentage from the peak.
+    Calculate the maximum drawdown of the portfolio as a fraction of the peak.
 
     Max Drawdown is the maximum observed loss from a peak to a
     trough before a new peak is achieved.
 
-    It is expressed here as a negative percentage.
+    It is expressed here as a positive fraction, matching
+    :func:`get_twr_max_drawdown`.
 
     Args:
         snapshots (List[PortfolioSnapshot]): List of portfolio snapshots
 
     Returns:
-        float: The maximum drawdown as a negative percentage (e.g., -12.5 for a 12.5% drawdown).
+        float: The maximum drawdown as a positive fraction
+            (e.g., ``0.125`` for a 12.5% peak-to-trough decline).
     """
     equity_curve = get_equity_curve(snapshots)
 

--- a/tests/services/metrics/test_drawdowns.py
+++ b/tests/services/metrics/test_drawdowns.py
@@ -387,3 +387,32 @@ class TestDrawdownConsistency(unittest.TestCase):
 
         for (_, ts), expected_ts in zip(drawdown_series, timestamps):
             self.assertEqual(ts, expected_ts)
+
+
+class TestMaxDrawdownReturnConvention(unittest.TestCase):
+    """Pin the documented return convention of ``get_max_drawdown``.
+
+    The docstring's own worked example is the thing that drifted: it promised
+    ``-12.5`` for a 12.5% drawdown while the function returns ``abs()`` of a
+    ``(equity - peak) / peak`` fraction. These assertions fail if either the
+    sign or the scale changes again.
+    """
+
+    def test_returns_a_positive_fraction_not_a_negative_percent(self):
+        snapshots = _make_snapshots(
+            [datetime(2024, 1, 1), datetime(2024, 1, 2)], [100.0, 87.5]
+        )
+        self.assertAlmostEqual(get_max_drawdown(snapshots), 0.125)
+
+    def test_scale_matches_get_twr_max_drawdown(self):
+        # Both are documented as fractions; a 30% decline is 0.3, not 30.0.
+        snapshots = _make_snapshots(
+            [datetime(2024, 1, 1), datetime(2024, 1, 2)], [200.0, 140.0]
+        )
+        self.assertAlmostEqual(get_max_drawdown(snapshots), 0.3)
+
+    def test_no_drawdown_is_zero(self):
+        snapshots = _make_snapshots(
+            [datetime(2024, 1, 1), datetime(2024, 1, 2)], [100.0, 110.0]
+        )
+        self.assertEqual(get_max_drawdown(snapshots), 0.0)


### PR DESCRIPTION
Follow-up to the one I offered at the end of #600. Documentation only — no behaviour change.

### The mismatch

`get_max_drawdown`'s docstring promises a **negative percentage**:

> `float: The maximum drawdown as a negative percentage (e.g., -12.5 for a 12.5% drawdown).`

The function computes `(equity - peak) / peak` and returns `abs()` of it. Running the docstring's own example against `main`:

```python
>>> get_max_drawdown(snaps([100.0, 87.5]))   # peak 100 -> trough 87.5
0.125
```

Positive where the docstring says negative, and a fraction where it says percent — so the worked example is off by a sign and a factor of 100.

### Why it is documentation only

Both callers already depend on the real behaviour, so nothing changes for them:

- `get_calmar_ratio` does `cagr / max_drawdown` — correct only for a positive fraction.
- `app/web/controllers/algorithm.py` passes it through `_finite_or_none` unchanged.

### The convention already exists in this module

`get_twr_max_drawdown`, four functions below, documents it correctly:

> `fraction (e.g. 0.18 for an 18% peak-to-trough decline in alpha)`

This brings the non-TWR twin into line with its own TWR counterpart rather than inventing a convention.

I swept the rest of `drawdown.py` before touching anything: `get_max_daily_drawdown` (`0.05 for a 5%` decline), `get_max_drawdown_absolute` (`positive number (e.g., €10,000)`), `get_drawdown_series` and `get_twr_drawdown_series` (signed fractions) all match what they return. **`get_max_drawdown` is the only one whose example contradicts its code.**

### Tests

Three assertions pin sign, scale, and the no-drawdown case, so the example cannot drift from the code again. I checked they bind by mutating the return site:

| mutant | result |
|---|---|
| `return max_drawdown_pct` (drop `abs()`) | **4 failed**, 17 passed |
| `return abs(max_drawdown_pct) * 100` | **4 failed**, 17 passed |
| unmodified | **21 passed** |

`tests/services/metrics/test_drawdowns.py`: 21 passed on this branch.

### One thing I did not decide for you

If you would rather `get_max_drawdown` actually return a negative percentage to match the table at the top of the module, that is a behaviour change touching `get_calmar_ratio`, and I have not assumed it. This PR makes the documentation true about the current code; say the word and I will send the other version instead.
