### PR TITLE
fix: avoid NameError in time-frame error message (file_path -> file_name)

### DIFF
--- a/investing_algorithm_framework/app/reporting/generate.py
+++ b/investing_algorithm_framework/app/reporting/generate.py
@@ -67,7 +67,7 @@ def get_time_frame_from_file_name(file_name: str) -> TimeFrame:
         return TimeFrame.from_string(time_frame_str)
     except ValueError:
         raise ValueError(
-            f"Could not extract time frame from file name: {file_path}. "
+            f"Could not extract time frame from file name: {file_name}. "
             f"Expected format 'OHLCV_<SYMBOL>_<MARKET>_<TIME_FRAME>_<START_DATE>_<END_DATE>.csv', "
             f"got '{time_frame_str}'."
         )


### PR DESCRIPTION
### Problem

In `investing_algorithm_framework/app/reporting/generate.py`, `get_time_frame_from_file_name(file_name)` builds a helpful error message that references an undefined name `file_path`:

```python
def get_time_frame_from_file_name(file_name: str) -> TimeFrame:
    ...
    try:
        return TimeFrame.from_string(time_frame_str)
    except ValueError:
        raise ValueError(
            f"Could not extract time frame from file name: {file_path}. "   # <- file_path is never defined
            ...
        )
```

The function parameter is `file_name`; `file_path` is not defined in this scope (nor imported anywhere), so the `except ValueError` handler itself raises `NameError: name 'file_path' is not defined` **instead of** the intended, informative `ValueError`.

### Impact

`TimeFrame.from_string()` raises `ValueError("Could not convert ... to TimeFrame")` for any unrecognized time-frame token (`investing_algorithm_framework/domain/models/time_frame.py`). `get_time_frame_from_file_name` is called in a loop over data files in `add_ohlcv_data_completeness_charts` (`generate.py:129`). So whenever an OHLCV CSV's file name contains an unrecognized time-frame segment, the report generation crashes with a confusing `NameError` in the error path, masking the real diagnostic the code was trying to surface.

### Fix

Reference the actual parameter name, `file_name`:

```diff
-            f"Could not extract time frame from file name: {file_path}. "
+            f"Could not extract time frame from file name: {file_name}. "
```

One-word change, no behavior change beyond the error message now rendering correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
