### PR TITLE
fix(notebook): restore the %%backtest cell magic (shadowed by the same-named line magic)

### DIFF
--- a/investing_algorithm_framework/notebook/magic.py
+++ b/investing_algorithm_framework/notebook/magic.py
@@ -42,8 +42,7 @@ try:
     from IPython.core.magic import (
         Magics,
         magics_class,
-        cell_magic,
-        line_magic,
+        line_cell_magic,
     )
 except ImportError:
     # IPython is an optional dependency (install with
@@ -58,10 +57,7 @@ except ImportError:
     def magics_class(cls):
         return cls
 
-    def cell_magic(func):
-        return func
-
-    def line_magic(func):
+    def line_cell_magic(func):
         return func
 
 
@@ -311,8 +307,20 @@ def _run_backtest(args, strategies):
 class BacktestMagics(Magics):
     """IPython magic commands for the investing-algorithm-framework."""
 
-    @cell_magic
-    def backtest(self, line, cell):
+    @line_cell_magic
+    def backtest(self, line, cell=None):
+        """
+        Run a backtest, either from an inline cell or from a strategy file.
+
+        ``%%backtest`` (cell magic) defines the strategy inline;
+        ``%backtest`` (line magic) loads it from an existing file.
+        See :meth:`_backtest_cell` and :meth:`_backtest_line`.
+        """
+        if cell is None:
+            return self._backtest_line(line)
+        return self._backtest_cell(line, cell)
+
+    def _backtest_cell(self, line, cell):
         """
         %%backtest — define a strategy inline and run a backtest.
 
@@ -364,8 +372,7 @@ class BacktestMagics(Magics):
         else:
             return backtest
 
-    @line_magic
-    def backtest(self, line):  # noqa: F811
+    def _backtest_line(self, line):
         """
         %backtest — run a backtest from an existing strategy file.
 


### PR DESCRIPTION
### The bug

`BacktestMagics` (`investing_algorithm_framework/notebook/magic.py`) defines `backtest` twice in the same class body:

```python
@cell_magic
def backtest(self, line, cell):   # %%backtest -- inline strategy
    ...

@line_magic
def backtest(self, line):  # noqa: F811   # %backtest -- strategy file
    ...
```

Both IPython decorators call `record_magic(magics, kind, magic_name, method_name)` with the **same method name**, so the class-level table ends up as

```
{'line': {'backtest': 'backtest'}, 'cell': {'backtest': 'backtest'}}
```

and the class dict keeps only the *last* definition. `Magics.__init__` then resolves both entries with `getattr(self, 'backtest')` — i.e. the **line-magic** body, whose signature is `(self, line)`.

`run_cell_magic` calls the registered function as `fn(line, cell)`, so the documented `%%backtest` cell magic (module docstring, README-style example in its own docstring) cannot run at all:

```
TypeError: BacktestMagics.backtest() takes 2 positional arguments but 3 were given
```

The `# noqa: F811` silenced the one linter that would have flagged it; `flake8` stays quiet, so this has been invisible.

### Verification

I executed the real `BacktestMagics` class body (extracted with `ast` from `main` and from this branch) against real IPython 9.17.1 `Magics`/`magics_class`, instantiated it, and called through the actual magic registry — helpers (`_build_parser`, `_run_backtest`, …) stubbed so no market data is needed:

```
== BEFORE (main) ==
  registry: {'line': ['backtest'], 'cell': ['backtest']}
  line magic -> 'BACKTEST_OBJ'
  cell magic -> TypeError: BacktestMagics.backtest() takes 2 positional arguments but 3 were given
== AFTER  (patched) ==
  registry: {'line': ['backtest'], 'cell': ['backtest']}
  line magic -> 'BACKTEST_OBJ'
  cell magic -> 'BACKTEST_OBJ'
```

### The fix

Collapse the pair into a single `@line_cell_magic` dispatcher — the supported way for one magic class to serve both `%name` and `%%name` — that forwards to the two original bodies, kept verbatim as `_backtest_cell` / `_backtest_line`:

```python
@line_cell_magic
def backtest(self, line, cell=None):
    if cell is None:
        return self._backtest_line(line)
    return self._backtest_cell(line, cell)
```

`%backtest strategies/my_strategy.py --start ...` behaves exactly as before; `%%backtest` now reaches its own implementation. The `noqa: F811` is no longer needed. The no-IPython fallback stub block is updated to match the new import.

`flake8 --isolated --max-line-length 79 --select=E,W,F` reports the same two pre-existing `W503` lines before and after — nothing introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
